### PR TITLE
Add Testing Framework and Basic Tests

### DIFF
--- a/.github/workflows/Run-Unit-Tests.yml
+++ b/.github/workflows/Run-Unit-Tests.yml
@@ -3,11 +3,10 @@ name: CI
 on: 
   pull_request:
   workflow_dispatch:
-  push:
 
 jobs:
   test:
-    name: Run Unit Tests
+    name: Validation Tests
     runs-on: windows-latest
     permissions:
       contents: read
@@ -31,6 +30,24 @@ jobs:
           Remove-Item -Path "$cwd\autohotkey.zip" -Force -ErrorAction SilentlyContinue
 
           Write-Output ("$cwd\autohotkey;" + "$cwd\autohotkey\Compiler") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Validate Changed .ahk Files
+        shell: pwsh
+        run: |
+          git fetch origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+
+          $changed = @(git diff --name-only origin/${{ github.base_ref }} ${{ github.sha }} | Where-Object { $_ -like "*.ahk" })
+
+          if ($changed) {
+            Write-Output "Found changed AHK files:"
+            $changed | ForEach-Object { Write-Output " - $_" }
+
+            ./Tests/ValidateAhkFiles.ps1 -AhkExePath "$PWD/autohotkey/AutoHotkey64.exe" -Files $changed
+          }
+          else {
+            Write-Output "No changed AHK files to validate."
+            exit 0
+          }
 
       - name: Run Unit Tests
         working-directory: Tests

--- a/.github/workflows/Run-Unit-Tests.yml
+++ b/.github/workflows/Run-Unit-Tests.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on: 
+  pull_request:
+  workflow_dispatch:
+  push:
+
+jobs:
+  test:
+    name: Run Unit Tests
+    runs-on: windows-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install AutoHotkey V2
+        shell: powershell
+        env:
+            url: https://github.com/AutoHotkey/AutoHotkey/releases/download/v2.0.19/AutoHotkey_2.0.19.zip
+        run: |
+          $cwd = (Get-Item .).FullName
+          Invoke-WebRequest "$env:url" -OutFile "$cwd\autohotkey.zip"
+          Expand-Archive -Path "$cwd\autohotkey.zip" -DestinationPath "$cwd\autohotkey" -Force
+          Remove-Item -Path "$cwd\autohotkey.zip" -Force -ErrorAction SilentlyContinue
+
+          Write-Output ("$cwd\autohotkey;" + "$cwd\autohotkey\Compiler") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Run Unit Tests
+        working-directory: Tests
+        shell: powershell
+        run: AutoHotkey64.exe /ErrorStdOut RunTests.ahk
+
+      - name: Publish Test Results
+        if: always()
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: Tests/junit.xml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.junit.xml
+junit.xml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "Tests/Yunit"]
+	path = Tests/Yunit
+	url = git@github.com:Uberi/Yunit.git
+	branch = v2

--- a/Tests/CStyleArrayTests.ahk
+++ b/Tests/CStyleArrayTests.ahk
@@ -1,0 +1,118 @@
+#Requires AutoHotkey v2.0
+
+#Include ../CStyleArray.ahk
+#Include ./Yunit/Yunit.ahk
+#Include ./YunitExtensions/Assert.ahk
+#Include ../Windows/Win32/Foundation/RECT.ahk
+
+class CStyleArrayListTests {
+
+    Constructor_WithStruct_Works(){
+        list := CStyleArrayList(RECT, 1)
+
+        Yunit.Assert(list.length == 1)
+        Yunit.Assert(list.Get(1) is RECT)
+    }
+
+    Constructor_WithPrimitive_Works(){
+        list := CStyleArrayList(Primitive, "Int", 1)
+
+        Yunit.Assert(list.length == 1)
+        Yunit.Assert(IsInteger(list.Get(1)))
+    }
+
+    Constructor_WithInvalidPrimitiveType_ThrowsTypeError(){
+        Assert.Throws((*) => CStyleArrayList(Primitive, "NotAValidType"), TypeError)
+        Assert.Throws((*) => CStyleArrayList(Primitive, 1), TypeError)
+    }
+
+    Constructor_WithInvalidStructType_ThrowsTypeError(){
+        Assert.Throws((*) => CStyleArrayList({}, 3), TypeError)
+        Assert.Throws((*) => CStyleArrayList("string", 3), TypeError)
+    }
+
+    EnumeratorOne_WithPrimitive_EnumeratesEverything(){
+        list := CStyleArrayList(Primitive, "Int64", 5)
+        list[1] := 1
+        list[2] := 2
+        list[3] := 3
+        list[4] := 4
+        list[5] := 5
+
+        for(val in list){
+            Yunit.Assert(val == A_Index, Format("Expected {1}, but got {2}", A_Index, val))
+        }
+    }
+
+    EnumeratorTwo_WithPrimitive_EnumeratesEverything(){
+        list := CStyleArrayList(Primitive, "Int64", 5)
+        list[1] := 1
+        list[2] := 2
+        list[3] := 3
+        list[4] := 4
+        list[5] := 5
+
+        for(index, val in list){
+            Yunit.Assert(index == A_Index, Format("2-Parameter enumerator returned {1} for index {2}", index, A_Index))
+            Yunit.Assert(val == index, Format("Expected {1}, but got {2}", index, val))
+        }
+    }
+
+    EnumeratorOne_WithStruct_EnumeratesEverything(){
+        list := CStyleArrayList(RECT, 5)
+        list[1] := RECT.FromObject({top: 1})
+        list[2] := RECT.FromObject({top: 2})
+        list[3] := RECT.FromObject({top: 3})
+        list[4] := RECT.FromObject({top: 4})
+        list[5] := RECT.FromObject({top: 5})
+
+        for(val in list){
+            Yunit.Assert(val is RECT, "Expected a RECT but got a(n) " . Type(val))
+            Yunit.Assert(val.top == A_Index, Format("Expected {1}, but got {2}", A_Index, val.top))
+        }
+    }
+
+    EnumeratorTwo_WithStruct_EnumeratesEverything(){
+        list := CStyleArrayList(RECT, 5)
+        list[1] := RECT.FromObject({top: 1})
+        list[2] := RECT.FromObject({top: 2})
+        list[3] := RECT.FromObject({top: 3})
+        list[4] := RECT.FromObject({top: 4})
+        list[5] := RECT.FromObject({top: 5})
+
+        for(index, val in list){
+            Yunit.Assert(index == A_Index, Format("2-Parameter enumerator returned {1} for index {2}", index, A_Index))
+            Yunit.Assert(val is RECT, "Expected a RECT but got a(n) " . Type(val))
+            Yunit.Assert(val.top == index, Format("Expected {1}, but got {2}", index, val.top))
+        }
+    }
+
+    InsertAt_WithOneParam_ShiftsValuesRight(){
+        list := CStyleArrayList(RECT, 5)
+        list[1] := RECT.FromObject({top: 1})
+        list[2] := RECT.FromObject({top: 2})
+        list[3] := RECT.FromObject({top: 3})
+        list[4] := RECT.FromObject({top: 4})
+        list[5] := RECT.FromObject({top: 5})
+
+        list.InsertAt(2, RECT.FromObject({top: 100, bottom: 100}))
+
+        Yunit.Assert(list[2].MemoryEquals(RECT.FromObject({top: 100, bottom: 100})), list[2].HexDump())
+        Yunit.Assert(list[3].top == 2)
+        Yunit.Assert(list[4].top == 3)
+        Yunit.Assert(list[5].top == 4)
+        Yunit.Assert(list[6].top == 5)
+    }
+
+    ToString_WithPrimitives_ReturnsUsefulString(){
+        list := CStyleArrayList(Primitive, "Int64", 5)
+        list[1] := 1
+        list[2] := 2
+        list[3] := 3
+        list[4] := 4
+        list[5] := 5
+
+        expected := "[1, 2, 3, 4, 5]"
+        Yunit.Assert(String(list) == expected, Format("Got '{1}' but expected '{2}'", String(list), expected))
+    }
+}

--- a/Tests/GeneratedApiSmokeTests.ahk
+++ b/Tests/GeneratedApiSmokeTests.ahk
@@ -1,0 +1,135 @@
+#Requires AutoHotkey v2.0
+
+#Include ./Yunit/Yunit.ahk
+#Include ./YunitExtensions/Assert.ahk
+
+#Include ../Windows/Win32/Foundation/Apis.ahk
+#Include ../Windows/Win32/Foundation/SYSTEMTIME.ahk
+#Include ../Windows/Win32/System/SystemInformation/Apis.ahk
+#Include ../Windows/Win32/UI/WindowsAndMessaging/Apis.ahk
+#include ../Windows/Win32/System/Memory/Apis.ahk
+#Include ../Windows/Win32/Networking/WinSock/Apis.ahk
+#Include ../Windows/Win32/System/Com/Urlmon/Apis.ahk
+
+class GeneratedApiSmokeTests {
+
+    /**
+     * Tests for string parameters and return values. In general, we should be abstracting
+     * away string encoding and memory management as much as possible while still allowing
+     * users to use e.g. pointers to strings on the heap for performance reasons.
+     * 
+     * So parameters MUST accept:
+     *  - Buffers and buffer-like objects
+     *  - Raw pointers (that is, pure Integers)
+     *  - Variables containing strings
+     *  - String literals
+     */
+    class String{
+
+        Params_Always_AcceptStringLiterals() {
+            msgNum := WindowsAndMessaging.RegisterWindowMessageW("test window message") ; Shouldn't throw
+            Yunit.Assert(msgNum != 0, "RegisterWindowMessageW with string literal failed")
+        }
+
+        Params_Always_AcceptStringPointers(){
+            ptr := StrPtr("test window message ooglyboogly")
+            msgNum := WindowsAndMessaging.RegisterWindowMessageW(ptr)   ; Shouldn't throw
+            Yunit.Assert(msgNum != 0, "RegisterWindowMessageW with string pointer failed")
+        }
+
+        Params_Always_AcceptBuffers(){
+            buf := Buffer(32)
+            StrPut("16-Character Str", buf, 16, "UTF-16")
+
+            ; This should not throw
+            charsProcessed := WindowsAndMessaging.CharUpperBuffW(buf, 16)
+
+            upper := StrGet(buf, 16, "UTF-16")
+            
+            Yunit.Assert(upper == "16-CHARACTER STR", Format("Expected '16-CHARACTER STR' but got '{1}'", upper))
+            Yunit.Assert(charsProcessed == 16, Format("Expected 16 but got '{1}'", charsProcessed))
+        }
+
+        Params_Always_AcceptBufferLikeObjects(){
+            bfLikeObj := BufferLike(32)
+
+            StrPut("16-Character Str", bfLikeObj, 16, "UTF-16")
+
+            ; This is the real test - this should not throw
+            charsProcessed := WindowsAndMessaging.CharUpperBuffW(bfLikeObj, 16)
+
+            upper := StrGet(bfLikeObj, 16, "UTF-16")
+
+            Yunit.Assert(upper == "16-CHARACTER STR", Format("Expected '16-CHARACTER STR' but got '{1}'", upper))
+            Yunit.Assert(charsProcessed == 16, Format("Expected 16 but got '{1}'", charsProcessed)) 
+        }
+    }
+
+    /**
+     * We should be parsing metadata and throwing errors WHEN possible
+     */
+    class ErrorChecking {
+
+        /**
+         * Check that a method which returns an HRESULT but doesn't set LastError 
+         * throws appropriately
+         * These are more common in COM interface implementations than native code
+         */
+        HRESULTReturningMethods_OnError_ThrowOSErrors(){
+            Assert.Throws((*) => Urlmon.UrlMkSetSessionOption(1, 0, -1), OSError)
+        }
+
+        /**
+         * Methods which set LastError should check it after executing the DllCall and
+         * throw if it's anything but S_OK (0), unless either the `[CanReturnMultipleSuccessValues]`
+         * or `[CanReturnErrorsAsSuccess]` attribute is present
+         */
+        LastErrorSettingMethods_OnError_ThrowOSError(){
+            SystemInformation.GetSystemTime(now := SYSTEMTIME())
+
+            ; We don't have permission to set the system time
+            Assert.Throws((*) => SystemInformation.SetSystemTime(now), OSError)
+        }
+
+        ; //TODO test for [CanReturnMultipleSuccessValues] (these are mostly (all)? COM methods)
+
+        ; //TODO test for [CanReturnErrorsAsSuccess] (these are mostly (all)? COM methods)
+
+        /**
+         * Methods not decorated with either [PreserveSig] or [SetLastError] should never throw
+         * errors, even if they fail
+         */
+        NoPreserveSig_NoSetLastError_Never_ThrowsError(){
+            res := WinSock.WSCUnInstallNameSpace(0)     ; Will fail but should not throw
+            Yunit.Assert(res != 0)
+        }
+    }
+
+    /**
+     * Methods which take pointers to primitives (like int* or uint*, etc) should accept
+     * a VarRef pass it in such a way that DllCall updates it automatically.
+     */
+    PrimitivePointerParams_WhenPassedVarRef_UpdateVarRef(){
+        SystemInformation.GetPhysicallyInstalledSystemMemory(&memSize := 0)
+
+        ; AHK has no native support for unsigned 64-bit ints so this might not actually be positive
+        Yunit.Assert(memSize != 0)  
+    }
+}
+
+/**
+ * Test buffer-like object class - mostly exists to free iteslf automatically
+ */
+class BufferLike {
+
+    static hProcHeap := Memory.GetProcessHeap()
+
+    __New(size){
+        this.ptr := Memory.HeapAlloc(BufferLike.hProcHeap, 0, size)
+        this.size := size
+    }
+
+    __Delete(){
+        Memory.HeapFree(BufferLike.hProcHeap, 0, this.ptr)
+    }
+}

--- a/Tests/GeneratedApiSmokeTests.ahk
+++ b/Tests/GeneratedApiSmokeTests.ahk
@@ -85,10 +85,7 @@ class GeneratedApiSmokeTests {
          * or `[CanReturnErrorsAsSuccess]` attribute is present
          */
         LastErrorSettingMethods_OnError_ThrowOSError(){
-            SystemInformation.GetSystemTime(now := SYSTEMTIME())
-
-            ; We don't have permission to set the system time
-            Assert.Throws((*) => SystemInformation.SetSystemTime(now), OSError)
+            Assert.Throws((*) => WindowsAndMessaging.LoadMenuW(0, 0), OSError)
         }
 
         ; //TODO test for [CanReturnMultipleSuccessValues] (these are mostly (all)? COM methods)

--- a/Tests/GeneratedStructSmokeTests.ahk
+++ b/Tests/GeneratedStructSmokeTests.ahk
@@ -1,0 +1,89 @@
+#Requires AutoHotkey v2.0
+
+#Include .\Yunit\Yunit.ahk
+#Include .\YunitExtensions\Assert.ahk
+
+#Include ../Windows/Win32/Networking/HttpServer/HTTP_REQUEST_HEADERS.ahk
+#Include ../Windows/Win32/UI/Controls/NMCHAR.ahk
+#Include ../Windows/Win32/Graphics/Gdi/LOGFONTA.ahk
+#Include ../Windows/Win32/Graphics/Gdi/LOGFONTW.ahk
+#Include ../Windows/Win32/UI/WindowsAndMessaging/ICONINFOEXW.ahk
+
+/**
+ * Tests of generated source code
+ */
+class GeneratedStructSmokeTests {
+    
+    class GettersAndAccessors {
+        Get_EmbeddedStruct_CachesProxyObject(){
+            test := NMCHAR()
+
+            ref1 := test.hdr
+            ref2 := test.hdr
+
+            Yunit.Assert(ref1 == ref2)
+        }
+
+        Set_EmbeddedStruct_ThrowsPropertyError(){
+            test := NMCHAR()
+            Assert.Throws((*) => test.hdr := "something", Error)
+        }
+
+        Get_FixedArray_CachesProxyObject(){
+            test := HTTP_REQUEST_HEADERS()
+
+            ref1 := test.KnownHeaders
+            ref2 := test.KnownHeaders
+
+            Yunit.Assert(ref1 == ref2)
+        }
+
+        Set_FixedArray_ThrowsPropertyError(){
+            test := HTTP_REQUEST_HEADERS()
+            Assert.Throws((*) => test.KnownHeaders := "test", Error)
+        }
+
+        Set_LiteralUnicodeString_ConvertsCorrectly(){
+            test := LOGFONTW()
+            test.lfFaceName := "ooglyboogly"
+            Yunit.Assert((str := StrGet(test.ptr + 28, 31, "UTF-16")) == "ooglyboogly", 
+                Format("Expected '{1}' but got '{2}'", "ooglyboogly", str))
+        }
+
+        Get_UnicodeString_ReturnsStringObject(){
+            test := LOGFONTW()
+            StrPut("This is a test string", test.ptr + 28, 31, "UTF-16")
+
+            str := test.lfFaceName
+
+            Yunit.Assert(str is String)
+            Yunit.Assert(str == "This is a test string", Format("Expected '{1}' but got '{2}'", "This is a test string", str))
+        }
+
+        Set_LiteralAnsiString_ConvertsCorrectly(){
+            test := LOGFONTA()
+            test.lfFaceName := "ooglyboogly"
+            Yunit.Assert((str := StrGet(test.ptr + 28, 31, "CP0")) == "ooglyboogly", 
+                Format("Expected '{1}' but got '{2}'", "ooglyboogly", str))
+        }
+
+        Get_AnsiString_ReturnsStringObject(){
+            test := LOGFONTA()
+            StrPut("This is a test string", test.ptr + 28, 31, "CP0")
+
+            str := test.lfFaceName
+
+            Yunit.Assert(str is String)
+            Yunit.Assert(str == "This is a test string", Format("Expected '{1}' but got '{2}'", "This is a test string", str))
+        }
+    }
+
+    class Constructors {
+
+        New_WithStructSizeProperty_SetsIt() {
+            test := ICONINFOEXW()
+            Yunit.Assert(test.cbSize == ICONINFOEXW.sizeof, 
+                Format("Expected cbSize to match ICONINFOEXW.sizeof ({1}), but it was {2}", ICONINFOEXW.sizeof, test.cbSize))
+        }
+    }
+}

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -1,0 +1,19 @@
+# Unit Tests
+
+This project uses [`Yunit`](https://github.com/Uberi/Yunit/tree/v2) for unit tests. See that repo for usage details.
+
+## Testing Standards
+- Unit tests must follow the [[UnitOfWork_StateUnderTest_ExpectedBehavior]](https://osherove.com/blog/2005/4/3/naming-standards-for-unit-tests.html) naming convention. UnitOfWork should refer to the method under test. Ex:
+  - `Constructor_PtrIsZero_CreatesNewBuffer`
+- Avoid [mocking](https://en.wikipedia.org/wiki/Mock_object) at all costs. There's 20,000 options for test cases here. Pick one.
+  > [Grug on testing](https://grugbrain.dev/#grug-on-testing)
+  > 
+  > also, grug dislike mocking in test, prefer only when absolute necessary to (rare/never) and coarse grain mocking (cut points/systems) only at that
+- Group unit tests logically but not excessively. Use good judgement.
+- One test suite per tested class
+- Inspecting private properties is allowed for unit tests ***and unit tests only***.
+  
+## Here or the Generator?
+There's some nuance to the decision about whether to test in this repo or the generator. Changes to hand-written .ahk scripts that only exist in this repo (e.g. `AhkWin32Struct`, `CSyleArray`) should go here. Smoke tests of the generated classes can also go here. But comprehensive tests, tests of the generator itself, and tests that check the output of the generator (e.g. that it is in fact valid AHK code) should go in the generator.
+
+Use good judgement.

--- a/Tests/RunTests.ahk
+++ b/Tests/RunTests.ahk
@@ -9,8 +9,9 @@
 #Include ./Win32Struct.test.ahk
 #Include ./GeneratedStructSmokeTests.ahk
 #Include ./GeneratedApiSmokeTests.ahk
+#Include ./CStyleArrayTests.ahk
 
 tester := Yunit.Use(YunitStdOut, YunitJUnit, YunitResultCounter)
-tester.Test(Win32StructTest, GeneratedStructSmokeTests, GeneratedApiSmokeTests)
+tester.Test(Win32StructTest, GeneratedStructSmokeTests, GeneratedApiSmokeTests, CStyleArrayListTests)
 
 ExitApp(YunitResultCounter.failures == 0? 0 : 1)

--- a/Tests/RunTests.ahk
+++ b/Tests/RunTests.ahk
@@ -1,0 +1,14 @@
+#Requires AutoHotkey v2.0
+
+#Include ./Yunit/Yunit.ahk
+#Include ./Yunit/Junit.ahk
+#Include ./Yunit/Stdout.ahk
+#Include ./YunitExtensions/Assert.ahk
+#Include ./YunitExtensions/ResultCounter.ahk
+
+#Include ./Win32Struct.test.ahk
+
+tester := Yunit.Use(YunitStdOut, YunitJUnit, YunitResultCounter)
+tester.Test(Win32StructTest)
+
+ExitApp(YunitResultCounter.failures == 0? 0 : 1)

--- a/Tests/RunTests.ahk
+++ b/Tests/RunTests.ahk
@@ -7,8 +7,9 @@
 #Include ./YunitExtensions/ResultCounter.ahk
 
 #Include ./Win32Struct.test.ahk
+#Include ./GeneratedStructSmokeTests.ahk
 
 tester := Yunit.Use(YunitStdOut, YunitJUnit, YunitResultCounter)
-tester.Test(Win32StructTest)
+tester.Test(Win32StructTest, GeneratedStructSmokeTests)
 
 ExitApp(YunitResultCounter.failures == 0? 0 : 1)

--- a/Tests/RunTests.ahk
+++ b/Tests/RunTests.ahk
@@ -8,8 +8,9 @@
 
 #Include ./Win32Struct.test.ahk
 #Include ./GeneratedStructSmokeTests.ahk
+#Include ./GeneratedApiSmokeTests.ahk
 
 tester := Yunit.Use(YunitStdOut, YunitJUnit, YunitResultCounter)
-tester.Test(Win32StructTest, GeneratedStructSmokeTests)
+tester.Test(Win32StructTest, GeneratedStructSmokeTests, GeneratedApiSmokeTests)
 
 ExitApp(YunitResultCounter.failures == 0? 0 : 1)

--- a/Tests/ValidateAhkFiles.ps1
+++ b/Tests/ValidateAhkFiles.ps1
@@ -1,0 +1,87 @@
+# This is a version of the ValidateAhk.ps1 script found in the generator meant for use
+# In CI/CD pipelines. As such, it takes a list of filepaths instead of searching for
+# files to validate itself.
+#
+# USAGE (run at repo root):
+#   $changed = git fetch origin main --depth=1
+#   $changed = git diff --name-only origin/main...HEAD | Where-Object { $_ -like "*.ahk" }
+#
+#   ./Tests/ValidateAhkFiles.ps1 -AhkExePath "path/to/AutoHotkey64.exe" -Files $changed
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$AhkExePath,
+
+    [string[]]$Files
+)
+
+function Get-AutoHotkeyProcStartInfo {
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $AhkExePath
+    $psi.Arguments = "/ErrorStdOut /Validate *"
+    $psi.RedirectStandardInput = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.UseShellExecute = $false
+    return $psi
+}
+
+if (-not $Files -or $Files.Count -eq 0) {
+    Write-Output "No .ahk files to validate."
+    exit 0
+}
+
+Write-Output "Validating $($Files.Count) changed files..."
+$fail = $false
+
+foreach ($file in $Files) {
+    if (-not (Test-Path $file)) { continue }
+
+    $lines = @(
+        "#Warn VarUnset, StdOut"
+        "#Warn Unreachable, StdOut"
+        "#Include $file"
+    )
+
+    $psi = Get-AutoHotkeyProcStartInfo
+
+    $proc = [System.Diagnostics.Process]::Start($psi)
+
+    # Wrap the StandardInput BaseStream in an ASCII StreamWriter to
+    # suppress the BOM - weird things are happening on the GitHub 
+    # runners
+    $sw = New-Object System.IO.StreamWriter(
+        $proc.StandardInput.BaseStream,
+        [System.Text.Encoding]::ASCII,
+        4096,
+        $false
+    )
+    $sw.NewLine = "`n"  # Probably not necessary but I'm being paranoid
+
+    # Send lines as lines
+    foreach ($line in $lines) {
+        $sw.WriteLine($line)
+    }
+    $sw.Flush()
+    $sw.Dispose()   # Let the StreamWriter deal with the underlying input stream
+
+    $stdout = $proc.StandardOutput.ReadToEnd()
+    $stderr = $proc.StandardError.ReadToEnd()
+    $proc.WaitForExit()
+
+    if (-not [string]::IsNullOrWhiteSpace($stdout)) {
+        Write-Output $stdout
+        $fail = $true
+    }
+    if (-not [string]::IsNullOrWhiteSpace($stderr)) {
+        $Host.UI.WriteErrorLine($stderr)
+        $fail = $true
+    }
+}
+
+if($fail){
+    exit 1
+}
+else{
+    exit 0
+}

--- a/Tests/Win32Struct.test.ahk
+++ b/Tests/Win32Struct.test.ahk
@@ -1,0 +1,254 @@
+#Requires AutoHotkey v2.0
+
+#Include ./Yunit/Yunit.ahk
+#Include ./YunitExtensions/Assert.ahk
+
+#Include ../Win32Struct.ahk
+#Include ../Windows/Win32/Foundation/RECT.ahk
+#Include ../Windows/Win32/Networking/HttpServer/HTTP_REQUEST_HEADERS.ahk
+#Include ../Windows/Win32/UI/Controls/NMCHAR.ahk
+
+class Win32StructTest {
+
+    PtrIsZero_CreatesNewBuffer(){
+        test := RECT(0)
+        Yunit.Assert(test.__buf is Buffer, "Expected a buffer but got a(n) " . Type(test.__buf))
+    }
+
+    PtrUnset_CreatesNewBuffer(){
+        test := RECT()
+        Yunit.Assert(test.__buf is Buffer, "Expected a buffer but got a(n) " . Type(test.__buf))
+    }
+
+    PtrNotZero_DoesNotCreateBuffer(){
+        test := RECT(1)
+        Yunit.Assert(!(test.__buf is Buffer), "Expected a plain Object but got a(n) " . Type(test.__buf))
+    }
+
+    Always_TakesSizeFromClass(){
+        test := RECT()
+        Yunit.Assert(test.size == 16, "Expected size of 16 but got " . test.size)
+
+        test := RECT(9999)
+        Yunit.Assert(test.size == 16, "Expected size of 16 but got " . test.size)
+    }
+
+    Clone_Always_CreatesCopy(){
+        test := RECT()
+        test.top := 5
+        test.bottom := -9999
+        test.left := 42
+        test.right := -1
+
+        clone := test.Clone()
+
+        Yunit.Assert(clone.ptr != test.ptr, "Clone's pointer equals source's pointer")
+
+        Yunit.Assert(clone.top == 5, "Clone and source values are not equal")
+        Yunit.Assert(clone.bottom == -9999, "Clone and source values are not equal")
+        Yunit.Assert(clone.left == 42, "Clone and source are values not equal")
+        Yunit.Assert(clone.right == -1, "Clone and source are values not equal")
+    }
+
+    CopyTo_WithStruct_CopiesData(){
+        test := RECT()
+        test.top := 1
+        test.bottom := 2
+        test.left := 3
+        test.right := 4
+
+        copy := RECT()
+
+        test.CopyTo(copy)
+
+        Yunit.Assert(copy.ptr != test.ptr, "CopyTo changed a pointer!")
+        Yunit.Assert(copy.top == 1, "Copy's values are not equal")
+        Yunit.Assert(copy.bottom == 2, "Copy's values are not equal")
+        Yunit.Assert(copy.left == 3, "Copy's values are not equal")
+        Yunit.Assert(copy.right == 4, "Copy's values are not equal")
+    }
+
+    CopyTo_WithBuffer_CopiesData(){
+        test := RECT()
+        test.left := 1
+        test.top := 2
+        test.right := 3
+        test.bottom := 4
+
+        copy := Buffer(16, 0)
+
+        test.CopyTo(copy)
+
+        Yunit.Assert((val := NumGet(copy, 0, "int")) == 1, val . " != " . 1)
+        Yunit.Assert((val := NumGet(copy, 4, "int")) == 2, val . " != " . 2)
+        Yunit.Assert((val := NumGet(copy, 8, "int")) == 3, val . " != " . 3)
+        Yunit.Assert((val := NumGet(copy, 12, "int")) == 4, val . " != " . 4)
+    }
+
+    CopyTo_WithPureInteger_CopiesData(){
+        test := RECT()
+        test.left := 1
+        test.top := 2
+        test.right := 3
+        test.bottom := 4
+
+        copy := Buffer(16, 0)
+
+        test.CopyTo(copy.ptr)
+
+        Yunit.Assert((val := NumGet(copy, 0, "int")) == 1, val . " != " . 1)
+        Yunit.Assert((val := NumGet(copy, 4, "int")) == 2, val . " != " . 2)
+        Yunit.Assert((val := NumGet(copy, 8, "int")) == 3, val . " != " . 3)
+        Yunit.Assert((val := NumGet(copy, 12, "int")) == 4, val . " != " . 4)
+    }
+
+    CopyTo_WithUndersizeBuffer_CopiesData(){
+        test := RECT()
+        test.left := 1
+        test.top := 2
+        test.right := 3
+        test.bottom := 4
+
+        copy := Buffer(8, 0)
+
+        test.CopyTo(copy)
+
+        Yunit.Assert((val := NumGet(copy, 0, "int")) == 1, val . " != " . 1)
+        Yunit.Assert((val := NumGet(copy, 4, "int")) == 2, val . " != " . 2)
+    }
+
+    CopyTo_WithInvalidTarget_ThrowsError(){
+        test := RECT()
+
+        Assert.Throws((*) => test.CopyTo("invalid"), TypeError)
+        Assert.Throws((*) => test.CopyTo({obj: "not buffer-like"}), TypeError)
+    }
+
+    MemoryEquals_WithEqualStucts_ReturnsTrue(){
+        left := RECT(), right := RECT()
+        left.left := 1, right.left := 1
+        left.top := 2, right.top := 2
+        left.right := 3, right.right := 3
+        left.bottom := 4, right.bottom := 4
+
+        Yunit.Assert(left.MemoryEquals(right), "Structs are equal but MemoryEquals() returned false")
+    }
+
+    MemoryEquals_WithEqualBuffer_ReturnsTrue(){
+        left := RECT(), right := RECT()
+        left.left := 1, right.left := 1
+        left.top := 2, right.top := 2
+        left.right := 3, right.right := 3
+        left.bottom := 4, right.bottom := 4
+
+        Yunit.Assert(left.MemoryEquals(right.__buf), "Structs are equal but MemoryEquals() returned false")
+    }
+
+    MemoryEquals_WithRawPtrToEqualBuffer_ReturnsTrue(){
+        left := RECT(), right := RECT()
+        left.left := 1, right.left := 1
+        left.top := 2, right.top := 2
+        left.right := 3, right.right := 3
+        left.bottom := 4, right.bottom := 4
+
+        Yunit.Assert(left.MemoryEquals(right.__buf.ptr), "Structs are equal but MemoryEquals() returned false")
+    }
+
+    MemoryEquals_WithDifferingStucts_ReturnsFalse(){
+        left := RECT(), right := RECT()
+        left.left := 1, right.left := 1
+        left.top := 2, right.top := 2
+        left.right := 3, right.right := 5
+        left.bottom := 4, right.bottom := 6
+
+        Yunit.Assert(!left.MemoryEquals(right, &diffOffset), "Structs are equal but MemoryEquals() returned false")
+        Yunit.Assert(diffOffset == 8, "MemoryEquals returned an incorrect diff offset. Expected 8, got " . diffOffset)
+    }
+
+    MemoryEquals_WithStructsOfDifferingSize_ReturnsFalse(){
+        test := RECT()
+        diff := HTTP_REQUEST_HEADERS()
+
+        Yunit.Assert(!test.MemoryEquals(diff), "MemoryEquals() should return false for structs of differing length")
+    }
+
+    Fill_Always_FillsAllBytes(){
+        test := RECT()
+        test.Fill(0x42)
+        loop(test.size){
+            Yunit.Assert((val := NumGet(test, A_Index - 1, "char") & 0xFF) == 0x42, 
+                Format("Byte at offset {1} is {2}, expected 0xFF`n{3}`n", A_Index, val, test.HexDump()))
+        }
+    }
+
+    HexDump_Always_ReturnsCorrectDump(){
+        test := RECT()
+        test.left := Ord("@")
+        test.top := 0xFFFFFFFF
+        test.right := 0
+        test.bottom := 0x1A2B3C4D
+
+        expected := "40 00 00 00 FF FF FF FF  00 00 00 00 4D 3C 2B 1A  |@...........M<+.|`n"
+        actual := test.HexDump()
+        Yunit.Assert(actual == expected, "HexDump is incorect. Expected `n'" . expected . "'but got `n'" . actual . "'")
+    }
+
+    FromObject_WithNoEmbeddedElements_PopulatesValues(){
+        test := RECT.FromObject({ top: 0, bottom: 100, left: 0, right: 100 })
+
+        Yunit.Assert(test.top == 0)
+        Yunit.Assert(test.bottom == 100)
+        Yunit.Assert(test.left == 0)
+        Yunit.Assert(test.right == 100)
+    }
+
+    FromObject_WithEmbeddedStruct_PopulatesValues(){
+        test := NMCHAR.FromObject({
+            hdr: {
+                hwndFrom: 0xFF00FFAA,
+                idFrom: 0x1A2B3C4D,
+                code: 0xABCD
+            },
+            ch: Ord("A"),
+            dwItemPrev: 42,
+            dwItemNext: 43
+        })
+
+        dump := "`n" . test.HexDump()
+
+        Yunit.Assert(test.hdr.hwndFrom == 0xFF00FFAA, dump)
+        Yunit.Assert(test.hdr.idFrom == 0x1A2B3C4D, dump)
+        Yunit.Assert(test.hdr.code == 0xABCD, dump)
+        Yunit.Assert(test.ch = Ord("A"), dump)
+        Yunit.Assert(test.dwItemPrev == 42, dump)
+        Yunit.Assert(test.dwItemNext == 43, dump)
+    }
+
+    FromObject_WithArray_PopulatesValues(){
+        Hdr1 := "Content-Type: application/json"
+        Hdr2 := "Accept: application/json"
+        headers := HTTP_REQUEST_HEADERS.FromObject({
+            KnownHeaders: [
+                { RawValueLength: StrLen(Hdr1), pRawValue: StrPtr(Hdr1) },
+                { RawValueLength: StrLen(Hdr2), pRawValue: StrPtr(Hdr2) }
+            ]
+        })
+
+        Yunit.Assert(headers.KnownHeaders[1].RawValueLength == StrLen(Hdr1))
+        Yunit.Assert(headers.KnownHeaders[1].pRawValue == StrPtr(Hdr1))
+        Yunit.Assert(headers.KnownHeaders[2].RawValueLength == StrLen(Hdr2))
+        Yunit.Assert(headers.KnownHeaders[2].pRawValue == StrPtr(Hdr2))
+    }
+
+    FromObject_WithUnknownValue_ThrowsPropertyError(){
+        Assert.Throws((*) => RECT.FromObject({badproperty: "test"}), PropertyError)
+    }
+
+    FromObject_WithClass_ThrowsPropertyError(){
+        Assert.Throws((*) => RECT.FromObject({__Class: "test"}), PropertyError)
+    }
+
+    FromObject_OnWin32Struct_ThrowsTypeError(){
+        Assert.Throws((*) => Win32Struct.FromObject({}), TypeError)
+    }
+}

--- a/Tests/YunitExtensions/Assert.ahk
+++ b/Tests/YunitExtensions/Assert.ahk
@@ -23,7 +23,7 @@ class Assert {
                 return
             }
 
-            throw TypeError(Format("Expected a(n) {1} but got a(n) {2}", callable.Prototype.__Class, Type(thrown)))
+            throw TypeError(Format("Expected a(n) {1} but got a(n) {2}", errType.Prototype.__Class, Type(thrown)))
         }
 
         throw Error(Format("Expeted {1} to throw a(n) {2}, but nothing was thrown", 

--- a/Tests/YunitExtensions/Assert.ahk
+++ b/Tests/YunitExtensions/Assert.ahk
@@ -1,0 +1,35 @@
+#Requires AutoHotkey v2.0
+
+/**
+ * Custom assertions for Yunit
+ */
+class Assert {
+
+    /**
+     * Assert that `callable` throws an object of type `errType`. This does not have to be an
+     * Error, but it probably should
+     * 
+     * @param {Func () => Any} callable callable object that you expect to throw an error 
+     * @param {Class} errType the type of the object you expect to be thrown. Probably something
+     *          extending error 
+     */
+    static Throws(callable, errType){
+        try{
+            callable.Call()
+
+        }
+        catch Any as thrown{
+            if(thrown is errType){
+                return
+            }
+
+            throw TypeError(Format("Expected a(n) {1} but got a(n) {2}", callable.Prototype.__Class, Type(thrown)))
+        }
+
+        throw Error(Format("Expeted {1} to throw a(n) {2}, but nothing was thrown", 
+            (callable.HasProp("Name") && callable.Name != "") ? callable.Name : "Anonymous " . Type(callable),
+            errType.Prototype.__Class
+        ))
+    }
+
+}

--- a/Tests/YunitExtensions/ResultCounter.ahk
+++ b/Tests/YunitExtensions/ResultCounter.ahk
@@ -1,0 +1,25 @@
+#Requires AutoHotkey v2.0
+
+/**
+ * Literally just counts failures in the test and attaches them to a property on
+ * the Yunit instance
+ */
+class YunitResultCounter {
+
+    static passes := 0
+    static failures := 0
+
+    __New(instance) { 
+
+    }
+
+    Update(Category, Test, Result)
+    {
+        if(result is Error){
+            YunitResultCounter.failures++
+        }
+        else{
+            YunitResultCounter.passes++
+        }
+    }
+}


### PR DESCRIPTION
Integrate Yunit for AHK unit testing and port the PowerShell script for AHK syntax validation over to work on individual filepaths. Add both to an action.

Adds basic (not comprehensive) unit tests for `Win32Struct` and `CStyleArrayList`, as well as some smoke tests for generated structs and methods. More tests to come as changes are added.