### PR TITLE
Feature/bitfields

### DIFF
--- a/Tests/GeneratedStructSmokeTests.ahk
+++ b/Tests/GeneratedStructSmokeTests.ahk
@@ -8,6 +8,7 @@
 #Include ../Windows/Win32/Graphics/Gdi/LOGFONTA.ahk
 #Include ../Windows/Win32/Graphics/Gdi/LOGFONTW.ahk
 #Include ../Windows/Win32/UI/WindowsAndMessaging/ICONINFOEXW.ahk
+#Include ../Windows/Win32/UI/WindowsAndMessaging/MENUBARINFO.ahk
 
 /**
  * Tests of generated source code
@@ -84,6 +85,51 @@ class GeneratedStructSmokeTests {
             test := ICONINFOEXW()
             Yunit.Assert(test.cbSize == ICONINFOEXW.sizeof, 
                 Format("Expected cbSize to match ICONINFOEXW.sizeof ({1}), but it was {2}", ICONINFOEXW.sizeof, test.cbSize))
+        }
+    }
+
+    /**
+     * Tests for bitfield members
+     */
+    class Bitfields {
+
+        ; One bit field
+        SimpleBitfield_GetAndSet_GetsAndSetsBits() {
+            mbi := MENUBARINFO()
+
+            mbi.fFocused := 1
+            Yunit.Assert(mbi._bitfield == 0x2, Format("Expected _bitfield to be 0x2 but got 0x{1:0X}", mbi._bitfield))
+            Yunit.Assert(mbi.fFocused == 1)
+        }
+
+        SimpleBitfield_Set_Always_MasksInput(){
+            mbi := MENUBARINFO()
+            
+            mbi.fFocused := 0xFFFFFFFF
+            Yunit.Assert(mbi._bitfield == 0x2, Format("Expected _bitfield to be 0x2 but got 0x{1:0X}", mbi._bitfield))
+            Yunit.Assert(mbi.fFocused == 1)
+        }
+
+        LongBitfield_Set_SetsBits(){
+            mbi := MENUBARINFO()
+
+            mbi.fUnused := -1
+            Yunit.Assert(mbi._bitfield == 0xFFFFFFFFFFFFFFFC, Format("Expected _bitfield to be 0xFFFFFFFFFFFFFFFC but got 0x{1:0X}", mbi._bitfield))
+        }
+
+        LongBitfield_Get_GetsBits(){
+            mbi := MENUBARINFO()
+
+            mbi.fUnused := 42
+            Yunit.Assert(mbi.fUnused == 42)
+        }
+
+        BitfieldProperties_Get_UseBackingField(){
+            mbi := MENUBARINFO()
+            mbi._bitfield := -1     ;Set all bits to 1
+
+            Yunit.Assert(mbi.fFocused == 1)
+            Yunit.Assert(mbi.fBarFocused == 1)
         }
     }
 }

--- a/Windows/Win32/Devices/Cdrom/CDROM_PERFORMANCE_HEADER.ahk
+++ b/Windows/Win32/Devices/Cdrom/CDROM_PERFORMANCE_HEADER.ahk
@@ -23,11 +23,39 @@ class CDROM_PERFORMANCE_HEADER extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - Except
+     * - Write
+     * - Reserved1
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 4, "char")
         set => NumPut("char", value, this, 4)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Except {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Write {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 2) & 0x3F
+        set => this._bitfield := ((value & 0x3F) << 2) | (this._bitfield & ~(0x3F << 2))
     }
 
     /**

--- a/Windows/Win32/Devices/Cdrom/CDROM_READ_TOC_EX.ahk
+++ b/Windows/Win32/Devices/Cdrom/CDROM_READ_TOC_EX.ahk
@@ -12,11 +12,39 @@ class CDROM_READ_TOC_EX extends Win32Struct
     static packingSize => 1
 
     /**
+     * This bitfield backs the following members:
+     * - Format
+     * - Reserved1
+     * - Msf
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "char")
         set => NumPut("char", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Format {
+        get => (this._bitfield >> 0) & 0xF
+        set => this._bitfield := ((value & 0xF) << 0) | (this._bitfield & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 4) & 0x7
+        set => this._bitfield := ((value & 0x7) << 4) | (this._bitfield & ~(0x7 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Msf {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/Devices/Cdrom/CDROM_TOC_ATIP_DATA_BLOCK.ahk
+++ b/Windows/Win32/Devices/Cdrom/CDROM_TOC_ATIP_DATA_BLOCK.ahk
@@ -12,6 +12,11 @@ class CDROM_TOC_ATIP_DATA_BLOCK extends Win32Struct
     static packingSize => 1
 
     /**
+     * This bitfield backs the following members:
+     * - CdrwReferenceSpeed
+     * - Reserved3
+     * - WritePower
+     * - True1
      * @type {Integer}
      */
     _bitfield1 {
@@ -22,6 +27,42 @@ class CDROM_TOC_ATIP_DATA_BLOCK extends Win32Struct
     /**
      * @type {Integer}
      */
+    CdrwReferenceSpeed {
+        get => (this._bitfield1 >> 0) & 0x7
+        set => this._bitfield1 := ((value & 0x7) << 0) | (this._bitfield1 & ~(0x7 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved3 {
+        get => (this._bitfield1 >> 3) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 3) | (this._bitfield1 & ~(0x1 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    WritePower {
+        get => (this._bitfield1 >> 4) & 0x7
+        set => this._bitfield1 := ((value & 0x7) << 4) | (this._bitfield1 & ~(0x7 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    True1 {
+        get => (this._bitfield1 >> 7) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 7) | (this._bitfield1 & ~(0x1 << 7))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - Reserved4
+     * - UnrestrictedUse
+     * - Reserved5
+     * @type {Integer}
+     */
     _bitfield2 {
         get => NumGet(this, 1, "char")
         set => NumPut("char", value, this, 1)
@@ -30,9 +71,88 @@ class CDROM_TOC_ATIP_DATA_BLOCK extends Win32Struct
     /**
      * @type {Integer}
      */
+    Reserved4 {
+        get => (this._bitfield2 >> 0) & 0x3F
+        set => this._bitfield2 := ((value & 0x3F) << 0) | (this._bitfield2 & ~(0x3F << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    UnrestrictedUse {
+        get => (this._bitfield2 >> 6) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 6) | (this._bitfield2 & ~(0x1 << 6))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved5 {
+        get => (this._bitfield2 >> 7) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 7) | (this._bitfield2 & ~(0x1 << 7))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - A3Valid
+     * - A2Valid
+     * - A1Valid
+     * - DiscSubType
+     * - IsCdrw
+     * - True2
+     * @type {Integer}
+     */
     _bitfield3 {
         get => NumGet(this, 2, "char")
         set => NumPut("char", value, this, 2)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    A3Valid {
+        get => (this._bitfield3 >> 0) & 0x1
+        set => this._bitfield3 := ((value & 0x1) << 0) | (this._bitfield3 & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    A2Valid {
+        get => (this._bitfield3 >> 1) & 0x1
+        set => this._bitfield3 := ((value & 0x1) << 1) | (this._bitfield3 & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    A1Valid {
+        get => (this._bitfield3 >> 2) & 0x1
+        set => this._bitfield3 := ((value & 0x1) << 2) | (this._bitfield3 & ~(0x1 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    DiscSubType {
+        get => (this._bitfield3 >> 3) & 0x7
+        set => this._bitfield3 := ((value & 0x7) << 3) | (this._bitfield3 & ~(0x7 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    IsCdrw {
+        get => (this._bitfield3 >> 6) & 0x1
+        set => this._bitfield3 := ((value & 0x1) << 6) | (this._bitfield3 & ~(0x1 << 6))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    True2 {
+        get => (this._bitfield3 >> 7) & 0x1
+        set => this._bitfield3 := ((value & 0x1) << 7) | (this._bitfield3 & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/Devices/Cdrom/CDROM_TOC_CD_TEXT_DATA_BLOCK.ahk
+++ b/Windows/Win32/Devices/Cdrom/CDROM_TOC_CD_TEXT_DATA_BLOCK.ahk
@@ -20,11 +20,30 @@ class CDROM_TOC_CD_TEXT_DATA_BLOCK extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - TrackNumber
+     * - ExtensionFlag
      * @type {Integer}
      */
     _bitfield1 {
         get => NumGet(this, 1, "char")
         set => NumPut("char", value, this, 1)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    TrackNumber {
+        get => (this._bitfield1 >> 0) & 0x7F
+        set => this._bitfield1 := ((value & 0x7F) << 0) | (this._bitfield1 & ~(0x7F << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ExtensionFlag {
+        get => (this._bitfield1 >> 7) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 7) | (this._bitfield1 & ~(0x1 << 7))
     }
 
     /**
@@ -36,11 +55,39 @@ class CDROM_TOC_CD_TEXT_DATA_BLOCK extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - CharacterPosition
+     * - BlockNumber
+     * - Unicode
      * @type {Integer}
      */
     _bitfield2 {
         get => NumGet(this, 3, "char")
         set => NumPut("char", value, this, 3)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    CharacterPosition {
+        get => (this._bitfield2 >> 0) & 0xF
+        set => this._bitfield2 := ((value & 0xF) << 0) | (this._bitfield2 & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    BlockNumber {
+        get => (this._bitfield2 >> 4) & 0x7
+        set => this._bitfield2 := ((value & 0x7) << 4) | (this._bitfield2 & ~(0x7 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Unicode {
+        get => (this._bitfield2 >> 7) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 7) | (this._bitfield2 & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/Devices/Cdrom/CDROM_TOC_FULL_TOC_DATA_BLOCK.ahk
+++ b/Windows/Win32/Devices/Cdrom/CDROM_TOC_FULL_TOC_DATA_BLOCK.ahk
@@ -20,11 +20,30 @@ class CDROM_TOC_FULL_TOC_DATA_BLOCK extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - Control
+     * - Adr
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 1, "char")
         set => NumPut("char", value, this, 1)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Control {
+        get => (this._bitfield >> 0) & 0xF
+        set => this._bitfield := ((value & 0xF) << 0) | (this._bitfield & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Adr {
+        get => (this._bitfield >> 4) & 0xF
+        set => this._bitfield := ((value & 0xF) << 4) | (this._bitfield & ~(0xF << 4))
     }
 
     /**

--- a/Windows/Win32/Devices/Cdrom/CDROM_WRITE_SPEED_DESCRIPTOR.ahk
+++ b/Windows/Win32/Devices/Cdrom/CDROM_WRITE_SPEED_DESCRIPTOR.ahk
@@ -12,11 +12,57 @@ class CDROM_WRITE_SPEED_DESCRIPTOR extends Win32Struct
     static packingSize => 1
 
     /**
+     * This bitfield backs the following members:
+     * - MixedReadWrite
+     * - Exact
+     * - Reserved1
+     * - WriteRotationControl
+     * - Reserved2
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "char")
         set => NumPut("char", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    MixedReadWrite {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Exact {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    WriteRotationControl {
+        get => (this._bitfield >> 3) & 0x3
+        set => this._bitfield := ((value & 0x3) << 3) | (this._bitfield & ~(0x3 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved2 {
+        get => (this._bitfield >> 5) & 0x7
+        set => this._bitfield := ((value & 0x7) << 5) | (this._bitfield & ~(0x7 << 5))
     }
 
     /**

--- a/Windows/Win32/Devices/Cdrom/SUB_Q_CURRENT_POSITION.ahk
+++ b/Windows/Win32/Devices/Cdrom/SUB_Q_CURRENT_POSITION.ahk
@@ -32,11 +32,30 @@ class SUB_Q_CURRENT_POSITION extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - Control
+     * - ADR
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 5, "char")
         set => NumPut("char", value, this, 5)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Control {
+        get => (this._bitfield >> 0) & 0xF
+        set => this._bitfield := ((value & 0xF) << 0) | (this._bitfield & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ADR {
+        get => (this._bitfield >> 4) & 0xF
+        set => this._bitfield := ((value & 0xF) << 4) | (this._bitfield & ~(0xF << 4))
     }
 
     /**

--- a/Windows/Win32/Devices/Cdrom/SUB_Q_MEDIA_CATALOG_NUMBER.ahk
+++ b/Windows/Win32/Devices/Cdrom/SUB_Q_MEDIA_CATALOG_NUMBER.ahk
@@ -43,11 +43,30 @@ class SUB_Q_MEDIA_CATALOG_NUMBER extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - Reserved1
+     * - Mcval
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 8, "char")
         set => NumPut("char", value, this, 8)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 0) & 0x7F
+        set => this._bitfield := ((value & 0x7F) << 0) | (this._bitfield & ~(0x7F << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Mcval {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/Devices/Cdrom/SUB_Q_TRACK_ISRC.ahk
+++ b/Windows/Win32/Devices/Cdrom/SUB_Q_TRACK_ISRC.ahk
@@ -56,11 +56,30 @@ class SUB_Q_TRACK_ISRC extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - Reserved2
+     * - Tcval
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 8, "char")
         set => NumPut("char", value, this, 8)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved2 {
+        get => (this._bitfield >> 0) & 0x7F
+        set => this._bitfield := ((value & 0x7F) << 0) | (this._bitfield & ~(0x7F << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Tcval {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/Devices/Cdrom/TRACK_DATA.ahk
+++ b/Windows/Win32/Devices/Cdrom/TRACK_DATA.ahk
@@ -20,11 +20,30 @@ class TRACK_DATA extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - Control
+     * - Adr
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 1, "char")
         set => NumPut("char", value, this, 1)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Control {
+        get => (this._bitfield >> 0) & 0xF
+        set => this._bitfield := ((value & 0xF) << 0) | (this._bitfield & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Adr {
+        get => (this._bitfield >> 4) & 0xF
+        set => this._bitfield := ((value & 0xF) << 4) | (this._bitfield & ~(0xF << 4))
     }
 
     /**

--- a/Windows/Win32/Devices/Communication/COMSTAT.ahk
+++ b/Windows/Win32/Devices/Communication/COMSTAT.ahk
@@ -14,11 +14,93 @@ class COMSTAT extends Win32Struct
     static packingSize => 4
 
     /**
+     * This bitfield backs the following members:
+     * - fCtsHold
+     * - fDsrHold
+     * - fRlsdHold
+     * - fXoffHold
+     * - fXoffSent
+     * - fEof
+     * - fTxim
+     * - fReserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, transmission is waiting for the CTS (clear-to-send) signal to be sent.
+     * @type {Integer}
+     */
+    fCtsHold {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, transmission is waiting for the DSR (data-set-ready) signal to be sent.
+     * @type {Integer}
+     */
+    fDsrHold {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, transmission is waiting for the RLSD (receive-line-signal-detect) signal to be sent.
+     * @type {Integer}
+     */
+    fRlsdHold {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, transmission is waiting because the XOFF character was received.
+     * @type {Integer}
+     */
+    fXoffHold {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, transmission is waiting because the XOFF character was transmitted. (Transmission halts when the XOFF character is transmitted to a system that takes the next character as XON, regardless of the actual character.)
+     * @type {Integer}
+     */
+    fXoffSent {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, the end-of-file (EOF) character has been received.
+     * @type {Integer}
+     */
+    fEof {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, there is a character queued for transmission that has come to the communications device by way of the 
+     * <a href="https://docs.microsoft.com/windows/desktop/api/winbase/nf-winbase-transmitcommchar">TransmitCommChar</a> function. The communications device transmits such a character ahead of other characters in the device's output buffer.
+     * @type {Integer}
+     */
+    fTxim {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * Reserved; do not use.
+     * @type {Integer}
+     */
+    fReserved {
+        get => (this._bitfield >> 7) & 0x1FFFFFF
+        set => this._bitfield := ((value & 0x1FFFFFF) << 7) | (this._bitfield & ~(0x1FFFFFF << 7))
     }
 
     /**

--- a/Windows/Win32/Devices/Communication/DCB.ahk
+++ b/Windows/Win32/Devices/Communication/DCB.ahk
@@ -205,11 +205,175 @@ class DCB extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - fBinary
+     * - fParity
+     * - fOutxCtsFlow
+     * - fOutxDsrFlow
+     * - fDtrControl
+     * - fDsrSensitivity
+     * - fTXContinueOnXoff
+     * - fOutX
+     * - fInX
+     * - fErrorChar
+     * - fNull
+     * - fRtsControl
+     * - fAbortOnError
+     * - fDummy2
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 8, "uint")
         set => NumPut("uint", value, this, 8)
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, binary mode is enabled. Windows does not support 
+     *       nonbinary mode transfers, so this member must be <b>TRUE</b>.
+     * @type {Integer}
+     */
+    fBinary {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, parity checking is performed and errors are 
+     *       reported.
+     * @type {Integer}
+     */
+    fParity {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, the CTS (clear-to-send) signal is monitored for output 
+     *       flow control. If this member is <b>TRUE</b> and CTS is turned off, output is suspended until 
+     *       CTS is sent again.
+     * @type {Integer}
+     */
+    fOutxCtsFlow {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, the DSR (data-set-ready) signal is monitored for output 
+     *       flow control. If this member is <b>TRUE</b> and DSR is turned off, output is suspended until 
+     *       DSR is sent again.
+     * @type {Integer}
+     */
+    fOutxDsrFlow {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fDtrControl {
+        get => (this._bitfield >> 4) & 0x3
+        set => this._bitfield := ((value & 0x3) << 4) | (this._bitfield & ~(0x3 << 4))
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, the communications driver is sensitive to the state of 
+     *       the DSR signal. The driver ignores any bytes received, unless the DSR modem input line is high.
+     * @type {Integer}
+     */
+    fDsrSensitivity {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, transmission continues after the input buffer has come 
+     *       within <b>XoffLim</b> bytes of being full and the driver has transmitted the 
+     *       <b>XoffChar</b> character to stop receiving bytes. If this member is 
+     *       <b>FALSE</b>, transmission does not continue until the input buffer is within 
+     *       <b>XonLim</b> bytes of being empty and the driver has transmitted 
+     *       the <b>XonChar</b> character to resume reception.
+     * @type {Integer}
+     */
+    fTXContinueOnXoff {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
+    }
+
+    /**
+     * Indicates whether XON/XOFF flow control is used during transmission. If this member is 
+     *       <b>TRUE</b>, transmission stops when the <b>XoffChar</b> character is 
+     *       received and starts again when the <b>XonChar</b> character is received.
+     * @type {Integer}
+     */
+    fOutX {
+        get => (this._bitfield >> 8) & 0x1
+        set => this._bitfield := ((value & 0x1) << 8) | (this._bitfield & ~(0x1 << 8))
+    }
+
+    /**
+     * Indicates whether XON/XOFF flow control is used during reception. If this member is 
+     *       <b>TRUE</b>, the <b>XoffChar</b> character is sent when the input buffer 
+     *       comes within <b>XoffLim</b> bytes of being full, and the <b>XonChar</b> 
+     *       character is sent when the input buffer comes within <b>XonLim</b> bytes of being 
+     *       empty.
+     * @type {Integer}
+     */
+    fInX {
+        get => (this._bitfield >> 9) & 0x1
+        set => this._bitfield := ((value & 0x1) << 9) | (this._bitfield & ~(0x1 << 9))
+    }
+
+    /**
+     * Indicates whether bytes received with parity errors are replaced with the character specified by the 
+     *       <b>ErrorChar</b> member. If this member is <b>TRUE</b> and the 
+     *       <b>fParity</b> member is <b>TRUE</b>, replacement occurs.
+     * @type {Integer}
+     */
+    fErrorChar {
+        get => (this._bitfield >> 10) & 0x1
+        set => this._bitfield := ((value & 0x1) << 10) | (this._bitfield & ~(0x1 << 10))
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, null bytes are discarded when received.
+     * @type {Integer}
+     */
+    fNull {
+        get => (this._bitfield >> 11) & 0x1
+        set => this._bitfield := ((value & 0x1) << 11) | (this._bitfield & ~(0x1 << 11))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fRtsControl {
+        get => (this._bitfield >> 12) & 0x3
+        set => this._bitfield := ((value & 0x3) << 12) | (this._bitfield & ~(0x3 << 12))
+    }
+
+    /**
+     * If this member is <b>TRUE</b>, the driver terminates all read and write operations with 
+     *       an error status if an error occurs. The driver will not accept any further communications operations until the 
+     *       application has acknowledged the error by calling the 
+     *       <a href="https://docs.microsoft.com/windows/desktop/api/winbase/nf-winbase-clearcommerror">ClearCommError</a> function.
+     * @type {Integer}
+     */
+    fAbortOnError {
+        get => (this._bitfield >> 14) & 0x1
+        set => this._bitfield := ((value & 0x1) << 14) | (this._bitfield & ~(0x1 << 14))
+    }
+
+    /**
+     * Reserved; do not use.
+     * @type {Integer}
+     */
+    fDummy2 {
+        get => (this._bitfield >> 15) & 0x1FFFF
+        set => this._bitfield := ((value & 0x1FFFF) << 15) | (this._bitfield & ~(0x1FFFF << 15))
     }
 
     /**

--- a/Windows/Win32/Devices/Dvd/DVD_ASF.ahk
+++ b/Windows/Win32/Devices/Dvd/DVD_ASF.ahk
@@ -23,10 +23,29 @@ class DVD_ASF extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - SuccessFlag
+     * - Reserved1
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 3, "char")
         set => NumPut("char", value, this, 3)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    SuccessFlag {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 1) & 0x7F
+        set => this._bitfield := ((value & 0x7F) << 1) | (this._bitfield & ~(0x7F << 1))
     }
 }

--- a/Windows/Win32/Devices/Dvd/DVD_DISC_CONTROL_BLOCK_HEADER.ahk
+++ b/Windows/Win32/Devices/Dvd/DVD_DISC_CONTROL_BLOCK_HEADER.ahk
@@ -34,11 +34,57 @@ class DVD_DISC_CONTROL_BLOCK_HEADER extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - RecordingWithinTheUserDataArea
+     * - ReadingDiscControlBlocks
+     * - FormattingTheMedium
+     * - ModificationOfThisDiscControlBlock
+     * - ReservedDoNotUse_UseAsByteInstead_1
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 7, "char")
         set => NumPut("char", value, this, 7)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    RecordingWithinTheUserDataArea {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ReadingDiscControlBlocks {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    FormattingTheMedium {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ModificationOfThisDiscControlBlock {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ReservedDoNotUse_UseAsByteInstead_1 {
+        get => (this._bitfield >> 4) & 0xF
+        set => this._bitfield := ((value & 0xF) << 4) | (this._bitfield & ~(0xF << 4))
     }
 
     /**

--- a/Windows/Win32/Devices/Dvd/DVD_DISC_CONTROL_BLOCK_WRITE_INHIBIT.ahk
+++ b/Windows/Win32/Devices/Dvd/DVD_DISC_CONTROL_BLOCK_WRITE_INHIBIT.ahk
@@ -46,11 +46,39 @@ class DVD_DISC_CONTROL_BLOCK_WRITE_INHIBIT extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - WriteProtectStatus
+     * - ReservedDoNotUse_UseAsByteInstead_1
+     * - UpdateRequiresPassword
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 47, "char")
         set => NumPut("char", value, this, 47)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    WriteProtectStatus {
+        get => (this._bitfield >> 0) & 0x3
+        set => this._bitfield := ((value & 0x3) << 0) | (this._bitfield & ~(0x3 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ReservedDoNotUse_UseAsByteInstead_1 {
+        get => (this._bitfield >> 2) & 0x1F
+        set => this._bitfield := ((value & 0x1F) << 2) | (this._bitfield & ~(0x1F << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    UpdateRequiresPassword {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/Devices/Dvd/DVD_DUAL_LAYER_MIDDLE_ZONE_START_ADDRESS.ahk
+++ b/Windows/Win32/Devices/Dvd/DVD_DUAL_LAYER_MIDDLE_ZONE_START_ADDRESS.ahk
@@ -12,11 +12,30 @@ class DVD_DUAL_LAYER_MIDDLE_ZONE_START_ADDRESS extends Win32Struct
     static packingSize => 1
 
     /**
+     * This bitfield backs the following members:
+     * - Reserved0
+     * - InitStatus
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "char")
         set => NumPut("char", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 0) & 0x7F
+        set => this._bitfield := ((value & 0x7F) << 0) | (this._bitfield & ~(0x7F << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    InitStatus {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/Devices/Dvd/DVD_DUAL_LAYER_RECORDING_INFORMATION.ahk
+++ b/Windows/Win32/Devices/Dvd/DVD_DUAL_LAYER_RECORDING_INFORMATION.ahk
@@ -12,11 +12,30 @@ class DVD_DUAL_LAYER_RECORDING_INFORMATION extends Win32Struct
     static packingSize => 1
 
     /**
+     * This bitfield backs the following members:
+     * - Reserved0
+     * - Layer0SectorsImmutable
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "char")
         set => NumPut("char", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 0) & 0x7F
+        set => this._bitfield := ((value & 0x7F) << 0) | (this._bitfield & ~(0x7F << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Layer0SectorsImmutable {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/Devices/Dvd/DVD_LAYER_DESCRIPTOR.ahk
+++ b/Windows/Win32/Devices/Dvd/DVD_LAYER_DESCRIPTOR.ahk
@@ -12,6 +12,9 @@ class DVD_LAYER_DESCRIPTOR extends Win32Struct
     static packingSize => 4
 
     /**
+     * This bitfield backs the following members:
+     * - BookVersion
+     * - BookType
      * @type {Integer}
      */
     _bitfield1 {
@@ -22,12 +25,52 @@ class DVD_LAYER_DESCRIPTOR extends Win32Struct
     /**
      * @type {Integer}
      */
+    BookVersion {
+        get => (this._bitfield1 >> 0) & 0xF
+        set => this._bitfield1 := ((value & 0xF) << 0) | (this._bitfield1 & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    BookType {
+        get => (this._bitfield1 >> 4) & 0xF
+        set => this._bitfield1 := ((value & 0xF) << 4) | (this._bitfield1 & ~(0xF << 4))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - MinimumRate
+     * - DiskSize
+     * @type {Integer}
+     */
     _bitfield2 {
         get => NumGet(this, 1, "char")
         set => NumPut("char", value, this, 1)
     }
 
     /**
+     * @type {Integer}
+     */
+    MinimumRate {
+        get => (this._bitfield2 >> 0) & 0xF
+        set => this._bitfield2 := ((value & 0xF) << 0) | (this._bitfield2 & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    DiskSize {
+        get => (this._bitfield2 >> 4) & 0xF
+        set => this._bitfield2 := ((value & 0xF) << 4) | (this._bitfield2 & ~(0xF << 4))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - LayerType
+     * - TrackPath
+     * - NumberOfLayers
+     * - Reserved1
      * @type {Integer}
      */
     _bitfield3 {
@@ -38,9 +81,60 @@ class DVD_LAYER_DESCRIPTOR extends Win32Struct
     /**
      * @type {Integer}
      */
+    LayerType {
+        get => (this._bitfield3 >> 0) & 0xF
+        set => this._bitfield3 := ((value & 0xF) << 0) | (this._bitfield3 & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    TrackPath {
+        get => (this._bitfield3 >> 4) & 0x1
+        set => this._bitfield3 := ((value & 0x1) << 4) | (this._bitfield3 & ~(0x1 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    NumberOfLayers {
+        get => (this._bitfield3 >> 5) & 0x3
+        set => this._bitfield3 := ((value & 0x3) << 5) | (this._bitfield3 & ~(0x3 << 5))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield3 >> 7) & 0x1
+        set => this._bitfield3 := ((value & 0x1) << 7) | (this._bitfield3 & ~(0x1 << 7))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - TrackDensity
+     * - LinearDensity
+     * @type {Integer}
+     */
     _bitfield4 {
         get => NumGet(this, 3, "char")
         set => NumPut("char", value, this, 3)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    TrackDensity {
+        get => (this._bitfield4 >> 0) & 0xF
+        set => this._bitfield4 := ((value & 0xF) << 0) | (this._bitfield4 & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    LinearDensity {
+        get => (this._bitfield4 >> 4) & 0xF
+        set => this._bitfield4 := ((value & 0xF) << 4) | (this._bitfield4 & ~(0xF << 4))
     }
 
     /**
@@ -68,10 +162,29 @@ class DVD_LAYER_DESCRIPTOR extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - Reserved5
+     * - BCAFlag
      * @type {Integer}
      */
     _bitfield5 {
         get => NumGet(this, 16, "char")
         set => NumPut("char", value, this, 16)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved5 {
+        get => (this._bitfield5 >> 0) & 0x7F
+        set => this._bitfield5 := ((value & 0x7F) << 0) | (this._bitfield5 & ~(0x7F << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    BCAFlag {
+        get => (this._bitfield5 >> 7) & 0x1
+        set => this._bitfield5 := ((value & 0x1) << 7) | (this._bitfield5 & ~(0x1 << 7))
     }
 }

--- a/Windows/Win32/Devices/Dvd/DVD_LIST_OF_RECOGNIZED_FORMAT_LAYERS_TYPE_CODE.ahk
+++ b/Windows/Win32/Devices/Dvd/DVD_LIST_OF_RECOGNIZED_FORMAT_LAYERS_TYPE_CODE.ahk
@@ -20,10 +20,47 @@ class DVD_LIST_OF_RECOGNIZED_FORMAT_LAYERS_TYPE_CODE extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - OnlineFormatlayer
+     * - Reserved1
+     * - DefaultFormatLayer
+     * - Reserved2
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 1, "char")
         set => NumPut("char", value, this, 1)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    OnlineFormatlayer {
+        get => (this._bitfield >> 0) & 0x3
+        set => this._bitfield := ((value & 0x3) << 0) | (this._bitfield & ~(0x3 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 2) & 0x3
+        set => this._bitfield := ((value & 0x3) << 2) | (this._bitfield & ~(0x3 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    DefaultFormatLayer {
+        get => (this._bitfield >> 4) & 0x3
+        set => this._bitfield := ((value & 0x3) << 4) | (this._bitfield & ~(0x3 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved2 {
+        get => (this._bitfield >> 6) & 0x3
+        set => this._bitfield := ((value & 0x3) << 6) | (this._bitfield & ~(0x3 << 6))
     }
 }

--- a/Windows/Win32/Devices/Dvd/DVD_PRERECORDED_INFORMATION.ahk
+++ b/Windows/Win32/Devices/Dvd/DVD_PRERECORDED_INFORMATION.ahk
@@ -47,11 +47,30 @@ class DVD_PRERECORDED_INFORMATION extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - ExtensionCode
+     * - PartVers1on
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 6, "char")
         set => NumPut("char", value, this, 6)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ExtensionCode {
+        get => (this._bitfield >> 0) & 0xF
+        set => this._bitfield := ((value & 0xF) << 0) | (this._bitfield & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    PartVers1on {
+        get => (this._bitfield >> 4) & 0xF
+        set => this._bitfield := ((value & 0xF) << 4) | (this._bitfield & ~(0xF << 4))
     }
 
     /**

--- a/Windows/Win32/Devices/Dvd/DVD_RAM_MEDIUM_STATUS.ahk
+++ b/Windows/Win32/Devices/Dvd/DVD_RAM_MEDIUM_STATUS.ahk
@@ -12,11 +12,75 @@ class DVD_RAM_MEDIUM_STATUS extends Win32Struct
     static packingSize => 1
 
     /**
+     * This bitfield backs the following members:
+     * - Reserved0
+     * - PersistentWriteProtect
+     * - CartridgeWriteProtect
+     * - MediaSpecificWriteInhibit
+     * - Reserved1
+     * - CartridgeNotSealed
+     * - MediaInCartridge
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "char")
         set => NumPut("char", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    PersistentWriteProtect {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    CartridgeWriteProtect {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    MediaSpecificWriteInhibit {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 4) & 0x3
+        set => this._bitfield := ((value & 0x3) << 4) | (this._bitfield & ~(0x3 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    CartridgeNotSealed {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    MediaInCartridge {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/Devices/Dvd/DVD_RAM_RECORDING_TYPE.ahk
+++ b/Windows/Win32/Devices/Dvd/DVD_RAM_RECORDING_TYPE.ahk
@@ -12,11 +12,39 @@ class DVD_RAM_RECORDING_TYPE extends Win32Struct
     static packingSize => 1
 
     /**
+     * This bitfield backs the following members:
+     * - Reserved0
+     * - RealTimeData
+     * - Reserved1
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "char")
         set => NumPut("char", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 0) & 0xF
+        set => this._bitfield := ((value & 0xF) << 0) | (this._bitfield & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    RealTimeData {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 5) & 0x7
+        set => this._bitfield := ((value & 0x7) << 5) | (this._bitfield & ~(0x7 << 5))
     }
 
     /**

--- a/Windows/Win32/Devices/Dvd/DVD_RPC_KEY.ahk
+++ b/Windows/Win32/Devices/Dvd/DVD_RPC_KEY.ahk
@@ -12,11 +12,39 @@ class DVD_RPC_KEY extends Win32Struct
     static packingSize => 1
 
     /**
+     * This bitfield backs the following members:
+     * - UserResetsAvailable
+     * - ManufacturerResetsAvailable
+     * - TypeCode
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "char")
         set => NumPut("char", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    UserResetsAvailable {
+        get => (this._bitfield >> 0) & 0x7
+        set => this._bitfield := ((value & 0x7) << 0) | (this._bitfield & ~(0x7 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ManufacturerResetsAvailable {
+        get => (this._bitfield >> 3) & 0x7
+        set => this._bitfield := ((value & 0x7) << 3) | (this._bitfield & ~(0x7 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    TypeCode {
+        get => (this._bitfield >> 6) & 0x3
+        set => this._bitfield := ((value & 0x3) << 6) | (this._bitfield & ~(0x3 << 6))
     }
 
     /**

--- a/Windows/Win32/Devices/Dvd/DVD_STRUCTURE_LIST_ENTRY.ahk
+++ b/Windows/Win32/Devices/Dvd/DVD_STRUCTURE_LIST_ENTRY.ahk
@@ -20,11 +20,39 @@ class DVD_STRUCTURE_LIST_ENTRY extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - Reserved0
+     * - Readable
+     * - Sendable
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 1, "char")
         set => NumPut("char", value, this, 1)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 0) & 0x3F
+        set => this._bitfield := ((value & 0x3F) << 0) | (this._bitfield & ~(0x3F << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Readable {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Sendable {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/Devices/Dvd/DVD_WRITE_PROTECTION_STATUS.ahk
+++ b/Windows/Win32/Devices/Dvd/DVD_WRITE_PROTECTION_STATUS.ahk
@@ -12,11 +12,57 @@ class DVD_WRITE_PROTECTION_STATUS extends Win32Struct
     static packingSize => 1
 
     /**
+     * This bitfield backs the following members:
+     * - SoftwareWriteProtectUntilPowerdown
+     * - MediaPersistentWriteProtect
+     * - CartridgeWriteProtect
+     * - MediaSpecificWriteProtect
+     * - Reserved0
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "char")
         set => NumPut("char", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    SoftwareWriteProtectUntilPowerdown {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    MediaPersistentWriteProtect {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    CartridgeWriteProtect {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    MediaSpecificWriteProtect {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 4) & 0xF
+        set => this._bitfield := ((value & 0xF) << 4) | (this._bitfield & ~(0xF << 4))
     }
 
     /**

--- a/Windows/Win32/Devices/Dvd/HD_DVD_R_MEDIUM_STATUS.ahk
+++ b/Windows/Win32/Devices/Dvd/HD_DVD_R_MEDIUM_STATUS.ahk
@@ -12,11 +12,30 @@ class HD_DVD_R_MEDIUM_STATUS extends Win32Struct
     static packingSize => 1
 
     /**
+     * This bitfield backs the following members:
+     * - ExtendedTestZone
+     * - Reserved1
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "char")
         set => NumPut("char", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ExtendedTestZone {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 1) & 0x7F
+        set => this._bitfield := ((value & 0x7F) << 1) | (this._bitfield & ~(0x7F << 1))
     }
 
     /**

--- a/Windows/Win32/Devices/HumanInterfaceDevice/HIDP_LINK_COLLECTION_NODE.ahk
+++ b/Windows/Win32/Devices/HumanInterfaceDevice/HIDP_LINK_COLLECTION_NODE.ahk
@@ -60,11 +60,39 @@ class HIDP_LINK_COLLECTION_NODE extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - CollectionType
+     * - IsAlias
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 12, "uint")
         set => NumPut("uint", value, this, 12)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    CollectionType {
+        get => (this._bitfield >> 0) & 0xFF
+        set => this._bitfield := ((value & 0xFF) << 0) | (this._bitfield & ~(0xFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    IsAlias {
+        get => (this._bitfield >> 8) & 0x1
+        set => this._bitfield := ((value & 0x1) << 8) | (this._bitfield & ~(0x1 << 8))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 9) & 0x7FFFFF
+        set => this._bitfield := ((value & 0x7FFFFF) << 9) | (this._bitfield & ~(0x7FFFFF << 9))
     }
 
     /**

--- a/Windows/Win32/Devices/Usb/USBD_ENDPOINT_OFFLOAD_INFORMATION.ahk
+++ b/Windows/Win32/Devices/Usb/USBD_ENDPOINT_OFFLOAD_INFORMATION.ahk
@@ -44,6 +44,10 @@ class USBD_ENDPOINT_OFFLOAD_INFORMATION extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - RootHubPortNumber
+     * - RouteString
+     * - Speed
      * @type {Integer}
      */
     _bitfield1 {
@@ -54,9 +58,79 @@ class USBD_ENDPOINT_OFFLOAD_INFORMATION extends Win32Struct
     /**
      * @type {Integer}
      */
+    RootHubPortNumber {
+        get => (this._bitfield1 >> 0) & 0xFF
+        set => this._bitfield1 := ((value & 0xFF) << 0) | (this._bitfield1 & ~(0xFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    RouteString {
+        get => (this._bitfield1 >> 8) & 0xFFFFF
+        set => this._bitfield1 := ((value & 0xFFFFF) << 8) | (this._bitfield1 & ~(0xFFFFF << 8))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Speed {
+        get => (this._bitfield1 >> 28) & 0xF
+        set => this._bitfield1 := ((value & 0xF) << 28) | (this._bitfield1 & ~(0xF << 28))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - UsbDeviceAddress
+     * - SlotId
+     * - MultiTT
+     * - LSOrFSDeviceConnectedToTTHub
+     * - Reserved0
+     * @type {Integer}
+     */
     _bitfield2 {
         get => NumGet(this, 20, "uint")
         set => NumPut("uint", value, this, 20)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    UsbDeviceAddress {
+        get => (this._bitfield2 >> 0) & 0xFF
+        set => this._bitfield2 := ((value & 0xFF) << 0) | (this._bitfield2 & ~(0xFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    SlotId {
+        get => (this._bitfield2 >> 8) & 0xFF
+        set => this._bitfield2 := ((value & 0xFF) << 8) | (this._bitfield2 & ~(0xFF << 8))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    MultiTT {
+        get => (this._bitfield2 >> 16) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 16) | (this._bitfield2 & ~(0x1 << 16))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    LSOrFSDeviceConnectedToTTHub {
+        get => (this._bitfield2 >> 17) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 17) | (this._bitfield2 & ~(0x1 << 17))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield2 >> 18) & 0x3FFF
+        set => this._bitfield2 := ((value & 0x3FFF) << 18) | (this._bitfield2 & ~(0x3FFF << 18))
     }
 
     /**

--- a/Windows/Win32/Devices/Usb/_URB_OS_FEATURE_DESCRIPTOR_REQUEST.ahk
+++ b/Windows/Win32/Devices/Usb/_URB_OS_FEATURE_DESCRIPTOR_REQUEST.ahk
@@ -84,11 +84,30 @@ class _URB_OS_FEATURE_DESCRIPTOR_REQUEST extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - Recipient
+     * - Reserved1
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 128, "char")
         set => NumPut("char", value, this, 128)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Recipient {
+        get => (this._bitfield >> 0) & 0x1F
+        set => this._bitfield := ((value & 0x1F) << 0) | (this._bitfield & ~(0x1F << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 5) & 0x7
+        set => this._bitfield := ((value & 0x7) << 5) | (this._bitfield & ~(0x7 << 5))
     }
 
     /**

--- a/Windows/Win32/Globalization/MAPPING_ENUM_OPTIONS.ahk
+++ b/Windows/Win32/Globalization/MAPPING_ENUM_OPTIONS.ahk
@@ -100,10 +100,31 @@ class MAPPING_ENUM_OPTIONS extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - OnlineService
+     * - ServiceType
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 72, "uint")
         set => NumPut("uint", value, this, 72)
+    }
+
+    /**
+     * Reserved for future use. Must be set to 0.
+     * @type {Integer}
+     */
+    OnlineService {
+        get => (this._bitfield >> 0) & 0x3
+        set => this._bitfield := ((value & 0x3) << 0) | (this._bitfield & ~(0x3 << 0))
+    }
+
+    /**
+     * Reserved for future use. Must be set to 0.
+     * @type {Integer}
+     */
+    ServiceType {
+        get => (this._bitfield >> 2) & 0x3
+        set => this._bitfield := ((value & 0x3) << 2) | (this._bitfield & ~(0x3 << 2))
     }
 }

--- a/Windows/Win32/Globalization/MAPPING_OPTIONS.ahk
+++ b/Windows/Win32/Globalization/MAPPING_OPTIONS.ahk
@@ -168,10 +168,21 @@ class MAPPING_OPTIONS extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - GetActionDisplayName
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 112, "uint")
         set => NumPut("uint", value, this, 112)
+    }
+
+    /**
+     * Reserved.
+     * @type {Integer}
+     */
+    GetActionDisplayName {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
     }
 }

--- a/Windows/Win32/Globalization/MAPPING_SERVICE_INFO.ahk
+++ b/Windows/Win32/Globalization/MAPPING_SERVICE_INFO.ahk
@@ -235,10 +235,106 @@ class MAPPING_SERVICE_INFO extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - IsOneToOneLanguageMapping
+     * - HasSubservices
+     * - OnlineOnly
+     * - ServiceType
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 168, "uint")
         set => NumPut("uint", value, this, 168)
+    }
+
+    /**
+     * Flag indicating the language mapping between input language and output language that is supported by the service. Possible values are shown in the following table.
+     * 			 
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="0"></a><dl>
+     * <dt><b>0</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The input and output languages are not paired and the service can receive data in any of the input languages and render data in any of the output languages.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="1"></a><dl>
+     * <dt><b>1</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The arrays of the input and output languages for the service are paired. In other words, given a particular input language, the service retrieves results in the paired language defined in the output language array. Use of the language pairing can be useful, for example, in bilingual dictionary scenarios. 
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    IsOneToOneLanguageMapping {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * Flag indicating if the service has subservices, that is, other services that plug into the service. This flag is used in service enumeration to determine if the parent service must be called to get a list of subservices. Possible values are shown in the following table.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="0"></a><dl>
+     * <dt><b>0</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The service is a regular service that stands alone and has no subservices. 
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="1"></a><dl>
+     * <dt><b>1</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The service acts as a parent for subservices.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    HasSubservices {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * Reserved for future use.
+     * @type {Integer}
+     */
+    OnlineOnly {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * Reserved for future use.
+     * @type {Integer}
+     */
+    ServiceType {
+        get => (this._bitfield >> 3) & 0x3
+        set => this._bitfield := ((value & 0x3) << 3) | (this._bitfield & ~(0x3 << 3))
     }
 }

--- a/Windows/Win32/Globalization/SCRIPT_ANALYSIS.ahk
+++ b/Windows/Win32/Globalization/SCRIPT_ANALYSIS.ahk
@@ -18,11 +18,248 @@ class SCRIPT_ANALYSIS extends Win32Struct
     static packingSize => 2
 
     /**
+     * This bitfield backs the following members:
+     * - eScript
+     * - fRTL
+     * - fLayoutRTL
+     * - fLinkBefore
+     * - fLinkAfter
+     * - fLogicalOrder
+     * - fNoGlyphIndex
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "ushort")
         set => NumPut("ushort", value, this, 0)
+    }
+
+    /**
+     * Opaque value identifying the engine that Uniscribe uses when calling the <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptshape">ScriptShape</a>, <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptplace">ScriptPlace</a>, and <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scripttextout">ScriptTextOut</a> functions for the item. The value for this member is undefined and applications should not rely on its value being the same from one release to the next. An application can obtain the attributes of <b>eScript</b> by calling <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptgetproperties">ScriptGetProperties</a>.
+     * 
+     * To disable shaping, the application should set this member to SCRIPT_UNDEFINED.
+     * @type {Integer}
+     */
+    eScript {
+        get => (this._bitfield >> 0) & 0x3FF
+        set => this._bitfield := ((value & 0x3FF) << 0) | (this._bitfield & ~(0x3FF << 0))
+    }
+
+    /**
+     * Value indicating rendering direction. Possible values are defined in the following table. This member is set to <b>TRUE</b> for a number in a left-to-right run, because digits are always displayed left to right, or <b>FALSE</b> for a number in a right-to-left run. The value of this member is normally identical to the parity of the Unicode embedding level, but it might differ if overridden by <a href="https://docs.microsoft.com/windows/desktop/api/wingdi/nf-wingdi-getcharacterplacementa">GetCharacterPlacement</a> legacy support.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b><b>TRUE</b></b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Use a right-to-left rendering direction.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b><b>FALSE</b></b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Use a left-to-right rendering direction.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fRTL {
+        get => (this._bitfield >> 10) & 0x1
+        set => this._bitfield := ((value & 0x1) << 10) | (this._bitfield & ~(0x1 << 10))
+    }
+
+    /**
+     * Value indicating layout direction for a number. Possible values are defined in the following table. This member is usually the same as the value assigned to <b>fRTL</b> for a number in a right-to-left run.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b><b>TRUE</b></b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Lay out the number in a right-to-left run, because it is read as part of the right-to-left sequence.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b><b>FALSE</b></b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Lay out the number in a left-to-right run, because it is read as part of the left-to-right sequence.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fLayoutRTL {
+        get => (this._bitfield >> 11) & 0x1
+        set => this._bitfield := ((value & 0x1) << 11) | (this._bitfield & ~(0x1 << 11))
+    }
+
+    /**
+     * Value indicating if the shaping engine shapes the first character of the item as if it joins with a previous character. Possible values are defined in the following table. This member is set by <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptitemize">ScriptItemize</a>. The application can override the value before calling <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptshape">ScriptShape</a>.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b><b>TRUE</b></b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Shape the first character by linking with a previous character.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b><b>FALSE</b></b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Do not shape the first character by linking with a previous character.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fLinkBefore {
+        get => (this._bitfield >> 12) & 0x1
+        set => this._bitfield := ((value & 0x1) << 12) | (this._bitfield & ~(0x1 << 12))
+    }
+
+    /**
+     * Value indicating if the shaping engine shapes the last character of the item as if it joins with a subsequent character. Possible values are defined in the following table. This member is set by <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptitemize">ScriptItemize</a>. The application can override the value before calling <b>ScriptItemize</b>.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b><b>TRUE</b></b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Shape the last character by linking with a subsequent character.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b><b>FALSE</b></b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Do not shape the last character by linking with a subsequent character.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fLinkAfter {
+        get => (this._bitfield >> 13) & 0x1
+        set => this._bitfield := ((value & 0x1) << 13) | (this._bitfield & ~(0x1 << 13))
+    }
+
+    /**
+     * Value indicating if the shaping engine generates all glyph-related arrays in logical order. Possible values are defined in the following table. This member is set to <b>FALSE</b> by <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptitemize">ScriptItemize</a>. The application can override the value before calling <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptshape">ScriptShape</a>.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b><b>TRUE</b></b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Generate all glyph-related arrays in logical order.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b><b>FALSE</b></b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Generate all glyph-related arrays in visual order, with the first array entry corresponding to the leftmost glyph. This value is the default.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fLogicalOrder {
+        get => (this._bitfield >> 14) & 0x1
+        set => this._bitfield := ((value & 0x1) << 14) | (this._bitfield & ~(0x1 << 14))
+    }
+
+    /**
+     * Value indicating the use of glyphs for the item. Possible values are defined in the following table. The application can set this member to <b>TRUE</b> on input to <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptshape">ScriptShape</a> to disable the use of glyphs for the item. Additionally, <b>ScriptShape</b> sets it to <b>TRUE</b> for a hardware context containing symbolic, unrecognized, and device fonts.
+     * 
+     * Disabling the use of glyphs also disables complex script shaping. Setting this member to <b>TRUE</b> implements shaping and placing directly by calls to <a href="https://docs.microsoft.com/windows/desktop/api/wingdi/nf-wingdi-gettextextentexpointa">GetTextExtentExPoint</a> and <a href="https://docs.microsoft.com/windows/desktop/api/wingdi/nf-wingdi-exttextouta">ExtTextOut</a>.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b><b>TRUE</b></b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Disable the use of glyphs for the item. This value is used for bitmap, vector, and device fonts.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b><b>FALSE</b></b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Enable the use of glyphs for the item. This value is the default.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fNoGlyphIndex {
+        get => (this._bitfield >> 15) & 0x1
+        set => this._bitfield := ((value & 0x1) << 15) | (this._bitfield & ~(0x1 << 15))
     }
 
     /**

--- a/Windows/Win32/Globalization/SCRIPT_DIGITSUBSTITUTE.ahk
+++ b/Windows/Win32/Globalization/SCRIPT_DIGITSUBSTITUTE.ahk
@@ -14,6 +14,9 @@ class SCRIPT_DIGITSUBSTITUTE extends Win32Struct
     static packingSize => 4
 
     /**
+     * This bitfield backs the following members:
+     * - NationalDigitLanguage
+     * - TraditionalDigitLanguage
      * @type {Integer}
      */
     _bitfield1 {
@@ -22,11 +25,87 @@ class SCRIPT_DIGITSUBSTITUTE extends Win32Struct
     }
 
     /**
+     * Language for native substitution.
+     * @type {Integer}
+     */
+    NationalDigitLanguage {
+        get => (this._bitfield1 >> 0) & 0xFFFF
+        set => this._bitfield1 := ((value & 0xFFFF) << 0) | (this._bitfield1 & ~(0xFFFF << 0))
+    }
+
+    /**
+     * Language for traditional substitution.
+     * @type {Integer}
+     */
+    TraditionalDigitLanguage {
+        get => (this._bitfield1 >> 16) & 0xFFFF
+        set => this._bitfield1 := ((value & 0xFFFF) << 16) | (this._bitfield1 & ~(0xFFFF << 16))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - DigitSubstitute
      * @type {Integer}
      */
     _bitfield2 {
         get => NumGet(this, 4, "uint")
         set => NumPut("uint", value, this, 4)
+    }
+
+    /**
+     * Substitution type. This member is normally set by <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptrecorddigitsubstitution">ScriptRecordDigitSubstitution</a>. However, it can also have any of the values defined in the following table.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="SCRIPT_DIGITSUBSTITUTE_CONTEXT_"></a><a id="script_digitsubstitute_context_"></a><dl>
+     * <dt><b>SCRIPT_DIGITSUBSTITUTE_CONTEXT </b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Substitute digits U+0030 to U+0039 using the language of the prior letters. If there are no prior letters, substitute digits using the <b>TraditionalDigitLanguage</b> member. This member is normally set to the primary language of the locale passed to <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptrecorddigitsubstitution">ScriptRecordDigitSubstitution</a>.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="SCRIPT_DIGITSUBSTITUTE_NATIONAL"></a><a id="script_digitsubstitute_national"></a><dl>
+     * <dt><b>SCRIPT_DIGITSUBSTITUTE_NATIONAL</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Substitute digits U+0030 to U+0039 using the <b>NationalDigitLanguage</b> member. This member is normally set to the national digits retrieved for the constant <a href="https://docs.microsoft.com/windows/desktop/Intl/locale-snative-constants">LOCALE_SNATIVEDIGITS</a> by <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptrecorddigitsubstitution">ScriptRecordDigitSubstitution</a>.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="SCRIPT_DIGITSUBSTITUTE_NONE"></a><a id="script_digitsubstitute_none"></a><dl>
+     * <dt><b>SCRIPT_DIGITSUBSTITUTE_NONE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Do not substitute digits. Display Unicode values U+0030 to U+0039 with European numerals.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="SCRIPT_DIGITSUBSTITUTE_TRADITIONAL"></a><a id="script_digitsubstitute_traditional"></a><dl>
+     * <dt><b>SCRIPT_DIGITSUBSTITUTE_TRADITIONAL</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Substitute digits U+0030 to U+0039 using the <b>TraditionalDigitLanguage</b> member. This member is normally set to the primary language of the locale passed to <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptrecorddigitsubstitution">ScriptRecordDigitSubstitution</a>.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    DigitSubstitute {
+        get => (this._bitfield2 >> 0) & 0xFF
+        set => this._bitfield2 := ((value & 0xFF) << 0) | (this._bitfield2 & ~(0xFF << 0))
     }
 
     /**

--- a/Windows/Win32/Globalization/SCRIPT_PROPERTIES.ahk
+++ b/Windows/Win32/Globalization/SCRIPT_PROPERTIES.ahk
@@ -45,6 +45,17 @@ class SCRIPT_PROPERTIES extends Win32Struct
     static packingSize => 4
 
     /**
+     * This bitfield backs the following members:
+     * - langid
+     * - fNumeric
+     * - fComplex
+     * - fNeedsWordBreaking
+     * - fNeedsCaretInfo
+     * - bCharSet
+     * - fControl
+     * - fPrivateUseArea
+     * - fNeedsCharacterJustify
+     * - fInvalidGlyph
      * @type {Integer}
      */
     _bitfield1 {
@@ -53,10 +64,506 @@ class SCRIPT_PROPERTIES extends Win32Struct
     }
 
     /**
+     * <a href="https://docs.microsoft.com/windows/desktop/Intl/language-identifiers">Language identifier</a> for the language associated with the script. When a script is used for many languages, this member represents a default language. For example, Western script is represented by LANG_ENGLISH although it is also used for French, German, and other European languages.
+     * @type {Integer}
+     */
+    langid {
+        get => (this._bitfield1 >> 0) & 0xFFFF
+        set => this._bitfield1 := ((value & 0xFFFF) << 0) | (this._bitfield1 & ~(0xFFFF << 0))
+    }
+
+    /**
+     * Value indicating if a script contains only digits and the other characters used in writing numbers by the rules of the Unicode bidirectional algorithm. For example, currency symbols, the thousands separator, and the decimal point are classified as numeric when adjacent to or between digits. Possible values for this member are defined in the following table.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b>TRUE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The script contains only digits and the other characters used in writing numbers by the rules of the Unicode bidirectional algorithm.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b>FALSE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The script does not contain only digits and the other characters used in writing numbers by the rules of the Unicode bidirectional algorithm.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fNumeric {
+        get => (this._bitfield1 >> 16) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 16) | (this._bitfield1 & ~(0x1 << 16))
+    }
+
+    /**
+     * Value indicating a complex script for a language that requires special shaping or layout. Possible values are defined in the following table. 
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b>TRUE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The script requires special shaping or layout.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b>FALSE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The script contains no combining characters and requires no contextual shaping or reordering.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fComplex {
+        get => (this._bitfield1 >> 17) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 17) | (this._bitfield1 & ~(0x1 << 17))
+    }
+
+    /**
+     * Value indicating the type of word break placement for a language. Possible values are defined in the following table. 
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b>TRUE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The language has word break placement that requires the application to call <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptbreak">ScriptBreak</a> and that includes character positions marked by the <b>fWordStop</b> member in <a href="https://docs.microsoft.com/windows/win32/api/usp10/ns-usp10-script_logattr">SCRIPT_LOGATTR</a>.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b>FALSE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Word break placement is identified by scanning for characters marked by the <b>fWhiteSpace</b> member in <a href="https://docs.microsoft.com/windows/win32/api/usp10/ns-usp10-script_logattr">SCRIPT_LOGATTR</a>, or for glyphs marked by the value SCRIPT_JUSTIFY_BLANK or SCRIPT_JUSTIFY_ARABIC_BLANK for the <b>uJustification</b> member of <a href="https://docs.microsoft.com/windows/win32/api/usp10/ns-usp10-script_visattr">SCRIPT_VISATTR</a>.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fNeedsWordBreaking {
+        get => (this._bitfield1 >> 18) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 18) | (this._bitfield1 & ~(0x1 << 18))
+    }
+
+    /**
+     * Value indicating if a language, for example, Thai or Indian, restricts caret placement to cluster boundaries. Possible values are defined in the following table. To determine valid caret positions, the application inspects the <b>fCharStop</b> value in the logical attributes retrieved by <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptbreak">ScriptBreak</a>, or compares adjacent values in the <i>pwLogClust</i> array retrieved by <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptshape">ScriptShape</a>.
+     * 
+     * <div class="alert"><b>Note</b>  <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptxtocp">ScriptXtoCP</a> and <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptcptox">ScriptCPtoX</a> automatically apply caret placement restrictions.</div>
+     * <div> </div>
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b>TRUE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The language restricts caret placement to cluster boundaries.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b>FALSE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The language does not restrict caret placement to cluster boundaries.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fNeedsCaretInfo {
+        get => (this._bitfield1 >> 19) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 19) | (this._bitfield1 & ~(0x1 << 19))
+    }
+
+    /**
+     * Nominal character set associated with the script. During creation of a font suitable for displaying the script, this character set can be used as the value of the <b>lfCharSet</b> member of <a href="https://docs.microsoft.com/windows/desktop/api/wingdi/ns-wingdi-logfonta">LOGFONT</a>.
+     * 
+     * For a new script having no character set defined, the application should typically set <b>bCharSet</b> to DEFAULT_CHARSET. See the description of member <b>fAmbiguousCharSet</b>.
+     * @type {Integer}
+     */
+    bCharSet {
+        get => (this._bitfield1 >> 20) & 0xFF
+        set => this._bitfield1 := ((value & 0xFF) << 20) | (this._bitfield1 & ~(0xFF << 20))
+    }
+
+    /**
+     * Value indicating if only control characters are used in the script. Possible values are defined in the following table. Note that every control character does not end up in a <a href="https://docs.microsoft.com/windows/win32/api/usp10/ns-usp10-script_control">SCRIPT_CONTROL</a> structure.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b>TRUE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Set only control characters in the script.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b>FALSE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Do not set only control characters in the script.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fControl {
+        get => (this._bitfield1 >> 28) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 28) | (this._bitfield1 & ~(0x1 << 28))
+    }
+
+    /**
+     * Value indicating the use of a private use area, a special set of characters that is privately defined for the Unicode range U+E000 through U+F8FF. Possible values are defined in the following table. 
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b>TRUE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Use a private use area.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b>FALSE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Do not use a private use area.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fPrivateUseArea {
+        get => (this._bitfield1 >> 29) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 29) | (this._bitfield1 & ~(0x1 << 29))
+    }
+
+    /**
+     * Value indicating the handling of justification for the script by increasing all the spaces between letters, not just the spaces between words. Possible values are defined in the following table. When performing inter-character justification, Uniscribe inserts extra space only after glyphs marked with the SCRIPT_JUSTIFY_CHARACTER value for the <b>uJustification</b> member of <a href="https://docs.microsoft.com/windows/win32/api/usp10/ns-usp10-script_visattr">SCRIPT_VISATTR</a>.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b>TRUE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Use character justification.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b>FALSE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Do not use character justification.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fNeedsCharacterJustify {
+        get => (this._bitfield1 >> 30) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 30) | (this._bitfield1 & ~(0x1 << 30))
+    }
+
+    /**
+     * Value indicating if <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptshape">ScriptShape</a> generates an invalid glyph for a script to represent invalid sequences. Possible values are defined in the following table. The application can obtain the glyph index of the invalid glyph for a particular font by calling <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptgetfontproperties">ScriptGetFontProperties</a>.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b>TRUE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Generate an invalid glyph to represent invalid sequences.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b>FALSE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Do not generate an invalid glyph to represent invalid sequences.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fInvalidGlyph {
+        get => (this._bitfield1 >> 31) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 31) | (this._bitfield1 & ~(0x1 << 31))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - fInvalidLogAttr
+     * - fCDM
+     * - fAmbiguousCharSet
+     * - fClusterSizeVaries
+     * - fRejectInvalid
      * @type {Integer}
      */
     _bitfield2 {
         get => NumGet(this, 4, "uint")
         set => NumPut("uint", value, this, 4)
+    }
+
+    /**
+     * Value indicating if <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptbreak">ScriptBreak</a> marks invalid combinations for a script by setting <b>fInvalid</b> in the logical attributes buffer. Possible values are defined in the following table. 
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b>TRUE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Mark invalid combinations for the script.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b>FALSE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Do not mark invalid combinations for the script.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fInvalidLogAttr {
+        get => (this._bitfield2 >> 0) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 0) | (this._bitfield2 & ~(0x1 << 0))
+    }
+
+    /**
+     * Value indicating if a script contains an item that has been analyzed by <a href="https://docs.microsoft.com/windows/desktop/api/usp10/nf-usp10-scriptitemize">ScriptItemize</a> as including Combining Diacritical Marks (U+0300 through U+36F). Possible values are defined in the following table. 
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b>TRUE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The script contains an item that includes combining diacritical marks.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b>FALSE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The script does not contain an item that includes combining diacritical marks.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fCDM {
+        get => (this._bitfield2 >> 1) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 1) | (this._bitfield2 & ~(0x1 << 1))
+    }
+
+    /**
+     * Value indicating if a script contains characters that are supported by more than one character set. Possible values are defined in the following table. 
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b>TRUE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The script contains characters that are supported by more than one character set. In this case, the <b>bCharSet</b> member of this structure should be ignored, and the <b>lfCharSet</b> member of <a href="https://docs.microsoft.com/windows/desktop/api/wingdi/ns-wingdi-logfonta">LOGFONT</a> should be set to DEFAULT_CHARSET. See the Remarks section for more information.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b>FALSE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The script does not contain characters that are supported by more than one character set.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fAmbiguousCharSet {
+        get => (this._bitfield2 >> 2) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 2) | (this._bitfield2 & ~(0x1 << 2))
+    }
+
+    /**
+     * Value indicating if a script, such as Arabic, might use contextual shaping that causes a string to increase in size during removal of characters. Possible values are defined in the following table. 
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b>TRUE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Use a variable cluster size for contextual shaping.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b>FALSE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Do not use a variable cluster size for contextual shaping.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fClusterSizeVaries {
+        get => (this._bitfield2 >> 3) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 3) | (this._bitfield2 & ~(0x1 << 3))
+    }
+
+    /**
+     * Value indicating if a script, for example, Thai, should reject invalid sequences that conventionally cause an editor program, such as Notepad, to beep and ignore keystrokes. Possible values are defined in the following table. 
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="TRUE"></a><a id="true"></a><dl>
+     * <dt><b>TRUE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Reject invalid sequences.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FALSE"></a><a id="false"></a><dl>
+     * <dt><b>FALSE</b></dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Do not reject invalid sequences.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    fRejectInvalid {
+        get => (this._bitfield2 >> 4) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 4) | (this._bitfield2 & ~(0x1 << 4))
     }
 }

--- a/Windows/Win32/Graphics/Direct3D12/D3D12_RAYTRACING_INSTANCE_DESC.ahk
+++ b/Windows/Win32/Graphics/Direct3D12/D3D12_RAYTRACING_INSTANCE_DESC.ahk
@@ -33,6 +33,9 @@ class D3D12_RAYTRACING_INSTANCE_DESC extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - InstanceID
+     * - InstanceMask
      * @type {Integer}
      */
     _bitfield1 {
@@ -41,11 +44,58 @@ class D3D12_RAYTRACING_INSTANCE_DESC extends Win32Struct
     }
 
     /**
+     * Type: **[UINT](/windows/win32/winprog/windows-data-types) : 24**
+     * 
+     * An arbitrary 24-bit value that can be accessed using the `InstanceID` intrinsic function in supported shader types.
+     * @type {Integer}
+     */
+    InstanceID {
+        get => (this._bitfield1 >> 0) & 0xFFFFFF
+        set => this._bitfield1 := ((value & 0xFFFFFF) << 0) | (this._bitfield1 & ~(0xFFFFFF << 0))
+    }
+
+    /**
+     * Type: **[UINT](/windows/win32/winprog/windows-data-types) : 8**
+     * 
+     * An 8-bit mask assigned to the instance, which can be used to include/reject groups of instances on a per-ray basis. If the value is zero, then the instance will never be included, so typically this should be set to some non-zero value. For more information see, the `InstanceInclusionMask` parameter to the [TraceRay](/windows/win32/direct3d12/traceray-function) function.
+     * @type {Integer}
+     */
+    InstanceMask {
+        get => (this._bitfield1 >> 24) & 0xFF
+        set => this._bitfield1 := ((value & 0xFF) << 24) | (this._bitfield1 & ~(0xFF << 24))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - InstanceContributionToHitGroupIndex
+     * - Flags
      * @type {Integer}
      */
     _bitfield2 {
         get => NumGet(this, 52, "uint")
         set => NumPut("uint", value, this, 52)
+    }
+
+    /**
+     * Type: **[UINT](/windows/win32/winprog/windows-data-types) : 24**
+     * 
+     * An arbitrary 24-bit value representing per-instance contribution to add into shader table indexing to select the hit group to use.
+     * @type {Integer}
+     */
+    InstanceContributionToHitGroupIndex {
+        get => (this._bitfield2 >> 0) & 0xFFFFFF
+        set => this._bitfield2 := ((value & 0xFFFFFF) << 0) | (this._bitfield2 & ~(0xFFFFFF << 0))
+    }
+
+    /**
+     * Type: **[UINT](/windows/win32/winprog/windows-data-types) : 8**
+     * 
+     * An 8-bit mask representing flags from [D3D12_RAYTRACING_INSTANCE_FLAGS](./ne-d3d12-d3d12_raytracing_instance_flags.md) to apply to the instance.
+     * @type {Integer}
+     */
+    Flags {
+        get => (this._bitfield2 >> 24) & 0xFF
+        set => this._bitfield2 := ((value & 0xFF) << 24) | (this._bitfield2 & ~(0xFF << 24))
     }
 
     /**

--- a/Windows/Win32/Graphics/DirectWrite/DWRITE_CLUSTER_METRICS.ahk
+++ b/Windows/Win32/Graphics/DirectWrite/DWRITE_CLUSTER_METRICS.ahk
@@ -36,10 +36,83 @@ class DWRITE_CLUSTER_METRICS extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - canWrapLineAfter
+     * - isWhitespace
+     * - isNewline
+     * - isSoftHyphen
+     * - isRightToLeft
+     * - padding
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 6, "ushort")
         set => NumPut("ushort", value, this, 6)
+    }
+
+    /**
+     * Type: <b>UINT16</b>
+     * 
+     * Indicates whether a line can be broken right after the cluster.
+     * @type {Integer}
+     */
+    canWrapLineAfter {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * Type: <b>UINT16</b>
+     * 
+     * Indicates whether the cluster corresponds to a whitespace character.
+     * @type {Integer}
+     */
+    isWhitespace {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * Type: <b>UINT16</b>
+     * 
+     * Indicates whether the cluster corresponds to a newline character.
+     * @type {Integer}
+     */
+    isNewline {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * Type: <b>UINT16</b>
+     * 
+     * Indicates whether the cluster corresponds to a soft hyphen character.
+     * @type {Integer}
+     */
+    isSoftHyphen {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * Type: <b>UINT16</b>
+     * 
+     * Indicates whether the cluster is read from right to left.
+     * @type {Integer}
+     */
+    isRightToLeft {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * Type: <b>UINT16</b>
+     * 
+     * Reserved for future use.
+     * @type {Integer}
+     */
+    padding {
+        get => (this._bitfield >> 5) & 0x7FF
+        set => this._bitfield := ((value & 0x7FF) << 5) | (this._bitfield & ~(0x7FF << 5))
     }
 }

--- a/Windows/Win32/Graphics/DirectWrite/DWRITE_JUSTIFICATION_OPPORTUNITY.ahk
+++ b/Windows/Win32/Graphics/DirectWrite/DWRITE_JUSTIFICATION_OPPORTUNITY.ahk
@@ -41,10 +41,81 @@ class DWRITE_JUSTIFICATION_OPPORTUNITY extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - expansionPriority
+     * - compressionPriority
+     * - allowResidualExpansion
+     * - allowResidualCompression
+     * - applyToLeadingEdge
+     * - applyToTrailingEdge
+     * - reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 12, "uint")
         set => NumPut("uint", value, this, 12)
+    }
+
+    /**
+     * Priority of this expansion point. Larger priorities are applied later, while priority zero does nothing.
+     * @type {Integer}
+     */
+    expansionPriority {
+        get => (this._bitfield >> 0) & 0xFF
+        set => this._bitfield := ((value & 0xFF) << 0) | (this._bitfield & ~(0xFF << 0))
+    }
+
+    /**
+     * Priority of this compression point. Larger priorities are applied later, while priority zero does nothing.
+     * @type {Integer}
+     */
+    compressionPriority {
+        get => (this._bitfield >> 8) & 0xFF
+        set => this._bitfield := ((value & 0xFF) << 8) | (this._bitfield & ~(0xFF << 8))
+    }
+
+    /**
+     * Allow this expansion point to use up any remaining slack space even after all expansion priorities have been used up.
+     * @type {Integer}
+     */
+    allowResidualExpansion {
+        get => (this._bitfield >> 16) & 0x1
+        set => this._bitfield := ((value & 0x1) << 16) | (this._bitfield & ~(0x1 << 16))
+    }
+
+    /**
+     * Allow this compression point to use up any remaining space even after all compression priorities have been used up.
+     * @type {Integer}
+     */
+    allowResidualCompression {
+        get => (this._bitfield >> 17) & 0x1
+        set => this._bitfield := ((value & 0x1) << 17) | (this._bitfield & ~(0x1 << 17))
+    }
+
+    /**
+     * Apply expansion and compression to the leading edge of the glyph. This bit is <b>FALSE</b> (0) for connected scripts, fixed-size characters, and diacritics. It is generally <b>FALSE</b> within a multi-glyph cluster, unless the script allows expansion of glyphs within a cluster, like Thai.
+     * @type {Integer}
+     */
+    applyToLeadingEdge {
+        get => (this._bitfield >> 18) & 0x1
+        set => this._bitfield := ((value & 0x1) << 18) | (this._bitfield & ~(0x1 << 18))
+    }
+
+    /**
+     * Apply expansion and compression to the trailing edge of the glyph. This bit is <b>FALSE</b> (0) for connected scripts, fixed-size characters, and diacritics. It is generally <b>FALSE</b> within a multi-glyph cluster, unless the script allows expansion of glyphs within a cluster, like Thai.
+     * @type {Integer}
+     */
+    applyToTrailingEdge {
+        get => (this._bitfield >> 19) & 0x1
+        set => this._bitfield := ((value & 0x1) << 19) | (this._bitfield & ~(0x1 << 19))
+    }
+
+    /**
+     * Reserved
+     * @type {Integer}
+     */
+    reserved {
+        get => (this._bitfield >> 20) & 0xFFF
+        set => this._bitfield := ((value & 0xFFF) << 20) | (this._bitfield & ~(0xFFF << 20))
     }
 }

--- a/Windows/Win32/Graphics/DirectWrite/DWRITE_SCRIPT_PROPERTIES.ahk
+++ b/Windows/Win32/Graphics/DirectWrite/DWRITE_SCRIPT_PROPERTIES.ahk
@@ -61,10 +61,99 @@ class DWRITE_SCRIPT_PROPERTIES extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - restrictCaretToClusters
+     * - usesWordDividers
+     * - isDiscreteWriting
+     * - isBlockWriting
+     * - isDistributedWithinCluster
+     * - isConnectedWriting
+     * - isCursiveWriting
+     * - reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 16, "uint")
         set => NumPut("uint", value, this, 16)
+    }
+
+    /**
+     * Restrict the caret to whole clusters, like Thai and Devanagari. Scripts such as Arabic by default allow navigation between clusters. Others like Thai always navigate across whole clusters.
+     * @type {Integer}
+     */
+    restrictCaretToClusters {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * The language uses dividers between words, such as spaces between Latin or the Ethiopic wordspace. Examples include Latin, Greek, Devanagari, and Ethiopic. Chinese, Korean, and Thai are excluded.
+     * @type {Integer}
+     */
+    usesWordDividers {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * The characters are discrete units from each other. This includes both block scripts and clustered scripts. Examples include Latin, Greek, Cyrillic, Hebrew, Chinese, and Thai.
+     * @type {Integer}
+     */
+    isDiscreteWriting {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * The language is a block script, expanding between characters. Examples include Chinese, Japanese, Korean, and Bopomofo.
+     * @type {Integer}
+     */
+    isBlockWriting {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * The language is justified within glyph clusters, not just between glyph clusters, such as the character sequence of Thai Lu and Sara Am (U+E026, U+E033), which form a single cluster but still expand between them. Examples include Thai, Lao, and Khmer.
+     * @type {Integer}
+     */
+    isDistributedWithinCluster {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * The script's clusters are connected to each other (such as the baseline-linked Devanagari), and no separation is added between characters.
+     * 
+     * <div class="alert"><b>Note</b>  Cursively linked scripts like Arabic are also connected (but not all connected scripts are cursive). </div>
+     * <div> </div>
+     * Examples include Devanagari, Arabic, Syriac, Bengala, Gurmukhi, and Ogham. Latin, Chinese, and Thaana are excluded.
+     * @type {Integer}
+     */
+    isConnectedWriting {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * The script is naturally cursive (Arabic and Syriac), meaning it uses other justification methods like kashida extension rather than inter-character spacing.
+     * 
+     * <div class="alert"><b>Note</b>   Although other scripts like Latin and Japanese might actually support handwritten cursive forms, they are not considered cursive scripts.</div>
+     * <div> </div>
+     * Examples include Arabic, Syriac, and Mongolian. Thaana, Devanagari, Latin, and Chinese are excluded.
+     * @type {Integer}
+     */
+    isCursiveWriting {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * Reserved
+     * @type {Integer}
+     */
+    reserved {
+        get => (this._bitfield >> 7) & 0x1FFFFFF
+        set => this._bitfield := ((value & 0x1FFFFFF) << 7) | (this._bitfield & ~(0x1FFFFFF << 7))
     }
 }

--- a/Windows/Win32/Media/DirectShow/AM_COLCON.ahk
+++ b/Windows/Win32/Media/DirectShow/AM_COLCON.ahk
@@ -16,6 +16,9 @@ class AM_COLCON extends Win32Struct
     static packingSize => 1
 
     /**
+     * This bitfield backs the following members:
+     * - emph1col
+     * - emph2col
      * @type {Integer}
      */
     _bitfield1 {
@@ -24,6 +27,27 @@ class AM_COLCON extends Win32Struct
     }
 
     /**
+     * Emphasis color 1.
+     * @type {Integer}
+     */
+    emph1col {
+        get => (this._bitfield1 >> 0) & 0xF
+        set => this._bitfield1 := ((value & 0xF) << 0) | (this._bitfield1 & ~(0xF << 0))
+    }
+
+    /**
+     * Emphasis color 2.
+     * @type {Integer}
+     */
+    emph2col {
+        get => (this._bitfield1 >> 4) & 0xF
+        set => this._bitfield1 := ((value & 0xF) << 4) | (this._bitfield1 & ~(0xF << 4))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - backcol
+     * - patcol
      * @type {Integer}
      */
     _bitfield2 {
@@ -32,6 +56,27 @@ class AM_COLCON extends Win32Struct
     }
 
     /**
+     * Background color.
+     * @type {Integer}
+     */
+    backcol {
+        get => (this._bitfield2 >> 0) & 0xF
+        set => this._bitfield2 := ((value & 0xF) << 0) | (this._bitfield2 & ~(0xF << 0))
+    }
+
+    /**
+     * Pattern color.
+     * @type {Integer}
+     */
+    patcol {
+        get => (this._bitfield2 >> 4) & 0xF
+        set => this._bitfield2 := ((value & 0xF) << 4) | (this._bitfield2 & ~(0xF << 4))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - emph1con
+     * - emph2con
      * @type {Integer}
      */
     _bitfield3 {
@@ -40,10 +85,49 @@ class AM_COLCON extends Win32Struct
     }
 
     /**
+     * Emphasis contrast 1.
+     * @type {Integer}
+     */
+    emph1con {
+        get => (this._bitfield3 >> 0) & 0xF
+        set => this._bitfield3 := ((value & 0xF) << 0) | (this._bitfield3 & ~(0xF << 0))
+    }
+
+    /**
+     * Emphasis contrast 2.
+     * @type {Integer}
+     */
+    emph2con {
+        get => (this._bitfield3 >> 4) & 0xF
+        set => this._bitfield3 := ((value & 0xF) << 4) | (this._bitfield3 & ~(0xF << 4))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - backcon
+     * - patcon
      * @type {Integer}
      */
     _bitfield4 {
         get => NumGet(this, 3, "char")
         set => NumPut("char", value, this, 3)
+    }
+
+    /**
+     * Background contrast.
+     * @type {Integer}
+     */
+    backcon {
+        get => (this._bitfield4 >> 0) & 0xF
+        set => this._bitfield4 := ((value & 0xF) << 0) | (this._bitfield4 & ~(0xF << 0))
+    }
+
+    /**
+     * Pattern contrast.
+     * @type {Integer}
+     */
+    patcon {
+        get => (this._bitfield4 >> 4) & 0xF
+        set => this._bitfield4 := ((value & 0xF) << 4) | (this._bitfield4 & ~(0xF << 4))
     }
 }

--- a/Windows/Win32/Media/DirectShow/Tv/RATING_SYSTEM.ahk
+++ b/Windows/Win32/Media/DirectShow/Tv/RATING_SYSTEM.ahk
@@ -20,11 +20,30 @@ class RATING_SYSTEM extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - rating_system_is_age_type
+     * - reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 8, "char")
         set => NumPut("char", value, this, 8)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    rating_system_is_age_type {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    reserved {
+        get => (this._bitfield >> 1) & 0x7F
+        set => this._bitfield := ((value & 0x7F) << 1) | (this._bitfield & ~(0x7F << 1))
     }
 
     /**

--- a/Windows/Win32/Media/KernelStreaming/KS_COLCON.ahk
+++ b/Windows/Win32/Media/KernelStreaming/KS_COLCON.ahk
@@ -12,6 +12,9 @@ class KS_COLCON extends Win32Struct
     static packingSize => 1
 
     /**
+     * This bitfield backs the following members:
+     * - emph1col
+     * - emph2col
      * @type {Integer}
      */
     _bitfield1 {
@@ -22,12 +25,50 @@ class KS_COLCON extends Win32Struct
     /**
      * @type {Integer}
      */
+    emph1col {
+        get => (this._bitfield1 >> 0) & 0xF
+        set => this._bitfield1 := ((value & 0xF) << 0) | (this._bitfield1 & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    emph2col {
+        get => (this._bitfield1 >> 4) & 0xF
+        set => this._bitfield1 := ((value & 0xF) << 4) | (this._bitfield1 & ~(0xF << 4))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - backcol
+     * - patcol
+     * @type {Integer}
+     */
     _bitfield2 {
         get => NumGet(this, 1, "char")
         set => NumPut("char", value, this, 1)
     }
 
     /**
+     * @type {Integer}
+     */
+    backcol {
+        get => (this._bitfield2 >> 0) & 0xF
+        set => this._bitfield2 := ((value & 0xF) << 0) | (this._bitfield2 & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    patcol {
+        get => (this._bitfield2 >> 4) & 0xF
+        set => this._bitfield2 := ((value & 0xF) << 4) | (this._bitfield2 & ~(0xF << 4))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - emph1con
+     * - emph2con
      * @type {Integer}
      */
     _bitfield3 {
@@ -38,8 +79,43 @@ class KS_COLCON extends Win32Struct
     /**
      * @type {Integer}
      */
+    emph1con {
+        get => (this._bitfield3 >> 0) & 0xF
+        set => this._bitfield3 := ((value & 0xF) << 0) | (this._bitfield3 & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    emph2con {
+        get => (this._bitfield3 >> 4) & 0xF
+        set => this._bitfield3 := ((value & 0xF) << 4) | (this._bitfield3 & ~(0xF << 4))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - backcon
+     * - patcon
+     * @type {Integer}
+     */
     _bitfield4 {
         get => NumGet(this, 3, "char")
         set => NumPut("char", value, this, 3)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    backcon {
+        get => (this._bitfield4 >> 0) & 0xF
+        set => this._bitfield4 := ((value & 0xF) << 0) | (this._bitfield4 & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    patcon {
+        get => (this._bitfield4 >> 4) & 0xF
+        set => this._bitfield4 := ((value & 0xF) << 4) | (this._bitfield4 & ~(0xF << 4))
     }
 }

--- a/Windows/Win32/Media/Speech/SPEVENT.ahk
+++ b/Windows/Win32/Media/Speech/SPEVENT.ahk
@@ -12,11 +12,30 @@ class SPEVENT extends Win32Struct
     static packingSize => 8
 
     /**
+     * This bitfield backs the following members:
+     * - eEventId
+     * - elParamType
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "int")
         set => NumPut("int", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    eEventId {
+        get => (this._bitfield >> 0) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 0) | (this._bitfield & ~(0xFFFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    elParamType {
+        get => (this._bitfield >> 16) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 16) | (this._bitfield & ~(0xFFFF << 16))
     }
 
     /**

--- a/Windows/Win32/Media/Speech/SPEVENTEX.ahk
+++ b/Windows/Win32/Media/Speech/SPEVENTEX.ahk
@@ -12,11 +12,30 @@ class SPEVENTEX extends Win32Struct
     static packingSize => 8
 
     /**
+     * This bitfield backs the following members:
+     * - eEventId
+     * - elParamType
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "int")
         set => NumPut("int", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    eEventId {
+        get => (this._bitfield >> 0) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 0) | (this._bitfield & ~(0xFFFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    elParamType {
+        get => (this._bitfield >> 16) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 16) | (this._bitfield & ~(0xFFFF << 16))
     }
 
     /**

--- a/Windows/Win32/Media/Speech/SPSERIALIZEDEVENT.ahk
+++ b/Windows/Win32/Media/Speech/SPSERIALIZEDEVENT.ahk
@@ -12,11 +12,30 @@ class SPSERIALIZEDEVENT extends Win32Struct
     static packingSize => 8
 
     /**
+     * This bitfield backs the following members:
+     * - eEventId
+     * - elParamType
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "int")
         set => NumPut("int", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    eEventId {
+        get => (this._bitfield >> 0) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 0) | (this._bitfield & ~(0xFFFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    elParamType {
+        get => (this._bitfield >> 16) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 16) | (this._bitfield & ~(0xFFFF << 16))
     }
 
     /**

--- a/Windows/Win32/Media/Speech/SPSERIALIZEDEVENT64.ahk
+++ b/Windows/Win32/Media/Speech/SPSERIALIZEDEVENT64.ahk
@@ -12,11 +12,30 @@ class SPSERIALIZEDEVENT64 extends Win32Struct
     static packingSize => 8
 
     /**
+     * This bitfield backs the following members:
+     * - eEventId
+     * - elParamType
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "int")
         set => NumPut("int", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    eEventId {
+        get => (this._bitfield >> 0) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 0) | (this._bitfield & ~(0xFFFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    elParamType {
+        get => (this._bitfield >> 16) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 16) | (this._bitfield & ~(0xFFFF << 16))
     }
 
     /**

--- a/Windows/Win32/NetworkManagement/Dns/DNS_HEADER.ahk
+++ b/Windows/Win32/NetworkManagement/Dns/DNS_HEADER.ahk
@@ -23,6 +23,12 @@ class DNS_HEADER extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - RecursionDesired
+     * - Truncation
+     * - Authoritative
+     * - Opcode
+     * - IsResponse
      * @type {Integer}
      */
     _bitfield1 {
@@ -31,11 +37,310 @@ class DNS_HEADER extends Win32Struct
     }
 
     /**
+     * A value that specifies whether recursive name query should be used  by the DNS name server.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x00</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Do not use recursive name query.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x01</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Use recursive name query.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    RecursionDesired {
+        get => (this._bitfield1 >> 0) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 0) | (this._bitfield1 & ~(0x1 << 0))
+    }
+
+    /**
+     * A value that specifies whether the DNS message has been truncated.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x00</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The message is not truncated.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x01</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The message is truncated.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    Truncation {
+        get => (this._bitfield1 >> 1) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 1) | (this._bitfield1 & ~(0x1 << 1))
+    }
+
+    /**
+     * A value that  specifies whether the DNS server from which the DNS message is being sent is authoritative for the domain name's zone.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x00</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The DNS server is not authoritative in the zone.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x01</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The DNS server is authoritative in the zone.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    Authoritative {
+        get => (this._bitfield1 >> 2) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 2) | (this._bitfield1 & ~(0x1 << 2))
+    }
+
+    /**
+     * A value that specifies the operation code to be taken on the DNS message as defined in section 4.1.1 of <a href="https://www.ietf.org/rfc/rfc1035.txt">RFC 1035</a> as the <b>OPCODE</b> field.
+     * @type {Integer}
+     */
+    Opcode {
+        get => (this._bitfield1 >> 3) & 0xF
+        set => this._bitfield1 := ((value & 0xF) << 3) | (this._bitfield1 & ~(0xF << 3))
+    }
+
+    /**
+     * A value that specifies whether the DNS message is a query or a response message.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x00</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The DNS message is a query.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x01</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The DNS message is a response.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    IsResponse {
+        get => (this._bitfield1 >> 7) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 7) | (this._bitfield1 & ~(0x1 << 7))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - ResponseCode
+     * - CheckingDisabled
+     * - AuthenticatedData
+     * - Reserved
+     * - RecursionAvailable
      * @type {Integer}
      */
     _bitfield2 {
         get => NumGet(this, 3, "char")
         set => NumPut("char", value, this, 3)
+    }
+
+    /**
+     * The <a href="https://docs.microsoft.com/windows/desktop/DNS/dns-constants">DNS Response Code</a> of the message.
+     * @type {Integer}
+     */
+    ResponseCode {
+        get => (this._bitfield2 >> 0) & 0xF
+        set => this._bitfield2 := ((value & 0xF) << 0) | (this._bitfield2 & ~(0xF << 0))
+    }
+
+    /**
+     * Windows 7 or later: A value that specifies whether checking is supported by the DNS resolver.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x00</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Checking is enabled on the DNS resolver.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x01</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Checking is disabled on the DNS resolver.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    CheckingDisabled {
+        get => (this._bitfield2 >> 4) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 4) | (this._bitfield2 & ~(0x1 << 4))
+    }
+
+    /**
+     * Windows 7 or later: A value that specifies whether the DNS data following the <b>DNS_HEADER</b> is authenticated by the DNS server.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x00</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The DNS data is not authenticated.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x01</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * The DNS data is authenticated.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    AuthenticatedData {
+        get => (this._bitfield2 >> 5) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 5) | (this._bitfield2 & ~(0x1 << 5))
+    }
+
+    /**
+     * Reserved. Do not use.
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield2 >> 6) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 6) | (this._bitfield2 & ~(0x1 << 6))
+    }
+
+    /**
+     * A value that specifies whether recursive name query is supported by the DNS name server.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x00</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Recursive name query is not supported.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0x01</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Recursive name query is supported.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    RecursionAvailable {
+        get => (this._bitfield2 >> 7) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 7) | (this._bitfield2 & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/NetworkManagement/Dns/DNS_HEADER_EXT.ahk
+++ b/Windows/Win32/NetworkManagement/Dns/DNS_HEADER_EXT.ahk
@@ -12,11 +12,30 @@ class DNS_HEADER_EXT extends Win32Struct
     static packingSize => 2
 
     /**
+     * This bitfield backs the following members:
+     * - Reserved
+     * - DnssecOk
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "ushort")
         set => NumPut("ushort", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 0) & 0x7FFF
+        set => this._bitfield := ((value & 0x7FFF) << 0) | (this._bitfield & ~(0x7FFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    DnssecOk {
+        get => (this._bitfield >> 15) & 0x1
+        set => this._bitfield := ((value & 0x1) << 15) | (this._bitfield & ~(0x1 << 15))
     }
 
     /**

--- a/Windows/Win32/NetworkManagement/Ndis/NDIS_TCP_CONNECTION_OFFLOAD.ahk
+++ b/Windows/Win32/NetworkManagement/Ndis/NDIS_TCP_CONNECTION_OFFLOAD.ahk
@@ -32,11 +32,48 @@ class NDIS_TCP_CONNECTION_OFFLOAD extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - SupportIPv4
+     * - SupportIPv6
+     * - SupportIPv6ExtensionHeaders
+     * - SupportSack
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 8, "uint")
         set => NumPut("uint", value, this, 8)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    SupportIPv4 {
+        get => (this._bitfield >> 0) & 0x3
+        set => this._bitfield := ((value & 0x3) << 0) | (this._bitfield & ~(0x3 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    SupportIPv6 {
+        get => (this._bitfield >> 2) & 0x3
+        set => this._bitfield := ((value & 0x3) << 2) | (this._bitfield & ~(0x3 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    SupportIPv6ExtensionHeaders {
+        get => (this._bitfield >> 4) & 0x3
+        set => this._bitfield := ((value & 0x3) << 4) | (this._bitfield & ~(0x3 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    SupportSack {
+        get => (this._bitfield >> 6) & 0x3
+        set => this._bitfield := ((value & 0x3) << 6) | (this._bitfield & ~(0x3 << 6))
     }
 
     /**

--- a/Windows/Win32/NetworkManagement/Ndis/NDIS_TCP_IP_CHECKSUM_OFFLOAD.ahk
+++ b/Windows/Win32/NetworkManagement/Ndis/NDIS_TCP_IP_CHECKSUM_OFFLOAD.ahk
@@ -20,10 +20,56 @@ class NDIS_TCP_IP_CHECKSUM_OFFLOAD extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - IpOptionsSupported
+     * - TcpOptionsSupported
+     * - TcpChecksum
+     * - UdpChecksum
+     * - IpChecksum
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 4, "uint")
         set => NumPut("uint", value, this, 4)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    IpOptionsSupported {
+        get => (this._bitfield >> 0) & 0x3
+        set => this._bitfield := ((value & 0x3) << 0) | (this._bitfield & ~(0x3 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    TcpOptionsSupported {
+        get => (this._bitfield >> 2) & 0x3
+        set => this._bitfield := ((value & 0x3) << 2) | (this._bitfield & ~(0x3 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    TcpChecksum {
+        get => (this._bitfield >> 4) & 0x3
+        set => this._bitfield := ((value & 0x3) << 4) | (this._bitfield & ~(0x3 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    UdpChecksum {
+        get => (this._bitfield >> 6) & 0x3
+        set => this._bitfield := ((value & 0x3) << 6) | (this._bitfield & ~(0x3 << 6))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    IpChecksum {
+        get => (this._bitfield >> 8) & 0x3
+        set => this._bitfield := ((value & 0x3) << 8) | (this._bitfield & ~(0x3 << 8))
     }
 }

--- a/Windows/Win32/NetworkManagement/Ndis/NDIS_TCP_LARGE_SEND_OFFLOAD_V1.ahk
+++ b/Windows/Win32/NetworkManagement/Ndis/NDIS_TCP_LARGE_SEND_OFFLOAD_V1.ahk
@@ -36,10 +36,29 @@ class NDIS_TCP_LARGE_SEND_OFFLOAD_V1 extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - TcpOptions
+     * - IpOptions
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 12, "uint")
         set => NumPut("uint", value, this, 12)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    TcpOptions {
+        get => (this._bitfield >> 0) & 0x3
+        set => this._bitfield := ((value & 0x3) << 0) | (this._bitfield & ~(0x3 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    IpOptions {
+        get => (this._bitfield >> 2) & 0x3
+        set => this._bitfield := ((value & 0x3) << 2) | (this._bitfield & ~(0x3 << 2))
     }
 }

--- a/Windows/Win32/NetworkManagement/Ndis/NDIS_TCP_LARGE_SEND_OFFLOAD_V2.ahk
+++ b/Windows/Win32/NetworkManagement/Ndis/NDIS_TCP_LARGE_SEND_OFFLOAD_V2.ahk
@@ -36,10 +36,29 @@ class NDIS_TCP_LARGE_SEND_OFFLOAD_V2 extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - IpExtensionHeadersSupported
+     * - TcpOptionsSupported
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 28, "uint")
         set => NumPut("uint", value, this, 28)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    IpExtensionHeadersSupported {
+        get => (this._bitfield >> 0) & 0x3
+        set => this._bitfield := ((value & 0x3) << 0) | (this._bitfield & ~(0x3 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    TcpOptionsSupported {
+        get => (this._bitfield >> 2) & 0x3
+        set => this._bitfield := ((value & 0x3) << 2) | (this._bitfield & ~(0x3 << 2))
     }
 }

--- a/Windows/Win32/NetworkManagement/WiFi/ONEX_AUTH_PARAMS.ahk
+++ b/Windows/Win32/NetworkManagement/WiFi/ONEX_AUTH_PARAMS.ahk
@@ -62,11 +62,76 @@ class ONEX_AUTH_PARAMS extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - fSessionId
+     * - fhUserToken
+     * - fOnexUserProfile
+     * - fIdentity
+     * - fUserName
+     * - fDomain
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 24, "uint")
         set => NumPut("uint", value, this, 24)
+    }
+
+    /**
+     * Indicates if the <b>ONEX_AUTH_PARAMS</b> structure contains a session ID in the <b>dwSessionId</b> member.
+     * @type {Integer}
+     */
+    fSessionId {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * Indicates if the <b>ONEX_AUTH_PARAMS</b> structure contains a user token handle in the <b>hUserToken</b> member. 
+     * 
+     * For security reasons, the <b>hUserToken</b> member of the <b>ONEX_AUTH_PARAMS</b> structure returned in the <b>authParams</b> member of the <a href="https://docs.microsoft.com/windows/desktop/api/dot1x/ns-dot1x-onex_result_update_data">ONEX_RESULT_UPDATE_DATA</a> structure is always set to <b>NULL</b>.
+     * @type {Integer}
+     */
+    fhUserToken {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * Indicates if the <b>ONEX_AUTH_PARAMS</b> structure contains an 802.1X user profile in the <b>OneXUserProfile</b> member.
+     * 
+     * For security reasons, the <b>OneXUserProfile</b> member of the <b>ONEX_AUTH_PARAMS</b> structure returned in the <b>authParams</b> member of the <a href="https://docs.microsoft.com/windows/desktop/api/dot1x/ns-dot1x-onex_result_update_data">ONEX_RESULT_UPDATE_DATA</a> structure is always set to <b>NULL</b>.
+     * @type {Integer}
+     */
+    fOnexUserProfile {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * Indicates if the <b>ONEX_AUTH_PARAMS</b> structure contains an 802.1X identity in the <b>Identity</b> member.
+     * @type {Integer}
+     */
+    fIdentity {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * Indicates if the <b>ONEX_AUTH_PARAMS</b> structure contains a user name used for 802.1X authentication in the <b>UserName</b> member.
+     * @type {Integer}
+     */
+    fUserName {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * Indicates if the <b>ONEX_AUTH_PARAMS</b> structure contains a domain used for 802.1X authentication in the <b>Domain</b> member.
+     * @type {Integer}
+     */
+    fDomain {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
     }
 
     /**

--- a/Windows/Win32/NetworkManagement/WiFi/ONEX_EAP_ERROR.ahk
+++ b/Windows/Win32/NetworkManagement/WiFi/ONEX_EAP_ERROR.ahk
@@ -1238,11 +1238,32 @@ class ONEX_EAP_ERROR extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - fRootCauseString
+     * - fRepairString
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 56, "uint")
         set => NumPut("uint", value, this, 56)
+    }
+
+    /**
+     * Indicates if the <b>ONEX_EAP_ERROR</b> structure contains a root cause string in the <b>RootCauseString</b> member.
+     * @type {Integer}
+     */
+    fRootCauseString {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * Indicates if the <b>ONEX_EAP_ERROR</b> structure contains a repair string in the <b>RepairString</b> member.
+     * @type {Integer}
+     */
+    fRepairString {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
     }
 
     /**

--- a/Windows/Win32/NetworkManagement/WiFi/ONEX_RESULT_UPDATE_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/WiFi/ONEX_RESULT_UPDATE_DATA.ahk
@@ -55,11 +55,32 @@ class ONEX_RESULT_UPDATE_DATA extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - fOneXAuthParams
+     * - fEapError
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 20, "uint")
         set => NumPut("uint", value, this, 20)
+    }
+
+    /**
+     * Indicates if the <b>ONEX_RESULT_UPDATE_DATA</b> structure contains 802.1X authentication parameters in the <b>authParams</b> member.
+     * @type {Integer}
+     */
+    fOneXAuthParams {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * Indicates if the <b>ONEX_RESULT_UPDATE_DATA</b> structure contains an EAP error in the <b>eapError</b> member.
+     * @type {Integer}
+     */
+    fEapError {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
     }
 
     /**

--- a/Windows/Win32/NetworkManagement/WiFi/ONEX_USER_INFO.ahk
+++ b/Windows/Win32/NetworkManagement/WiFi/ONEX_USER_INFO.ahk
@@ -21,11 +21,30 @@ class ONEX_USER_INFO extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - fUserName
+     * - fDomainName
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 4, "uint")
         set => NumPut("uint", value, this, 4)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fUserName {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fDomainName {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
     }
 
     /**

--- a/Windows/Win32/Networking/WinSock/IGMPV3_QUERY_HEADER.ahk
+++ b/Windows/Win32/Networking/WinSock/IGMPV3_QUERY_HEADER.ahk
@@ -56,11 +56,39 @@ class IGMPV3_QUERY_HEADER extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - QuerierRobustnessVariable
+     * - SuppressRouterSideProcessing
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 8, "char")
         set => NumPut("char", value, this, 8)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    QuerierRobustnessVariable {
+        get => (this._bitfield >> 0) & 0x7
+        set => this._bitfield := ((value & 0x7) << 0) | (this._bitfield & ~(0x7 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    SuppressRouterSideProcessing {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 4) & 0xF
+        set => this._bitfield := ((value & 0xF) << 4) | (this._bitfield & ~(0xF << 4))
     }
 
     /**

--- a/Windows/Win32/Networking/WinSock/IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS.ahk
+++ b/Windows/Win32/Networking/WinSock/IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS.ahk
@@ -12,11 +12,48 @@ class IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS extends Win32Struct
     static packingSize => 4
 
     /**
+     * This bitfield backs the following members:
+     * - Reserved1
+     * - Override
+     * - Solicited
+     * - Router
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "char")
         set => NumPut("char", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 0) & 0x1F
+        set => this._bitfield := ((value & 0x1F) << 0) | (this._bitfield & ~(0x1F << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Override {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Solicited {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Router {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/Networking/WinSock/MLDV2_QUERY_HEADER.ahk
+++ b/Windows/Win32/Networking/WinSock/MLDV2_QUERY_HEADER.ahk
@@ -60,11 +60,39 @@ class MLDV2_QUERY_HEADER extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - QuerierRobustnessVariable
+     * - SuppressRouterSideProcessing
+     * - QueryReserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 24, "char")
         set => NumPut("char", value, this, 24)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    QuerierRobustnessVariable {
+        get => (this._bitfield >> 0) & 0x7
+        set => this._bitfield := ((value & 0x7) << 0) | (this._bitfield & ~(0x7 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    SuppressRouterSideProcessing {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    QueryReserved {
+        get => (this._bitfield >> 4) & 0xF
+        set => this._bitfield := ((value & 0xF) << 4) | (this._bitfield & ~(0xF << 4))
     }
 
     /**

--- a/Windows/Win32/Networking/WinSock/TCP_HDR.ahk
+++ b/Windows/Win32/Networking/WinSock/TCP_HDR.ahk
@@ -44,11 +44,30 @@ class TCP_HDR extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - th_x2
+     * - th_len
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 12, "char")
         set => NumPut("char", value, this, 12)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    th_x2 {
+        get => (this._bitfield >> 0) & 0xF
+        set => this._bitfield := ((value & 0xF) << 0) | (this._bitfield & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    th_len {
+        get => (this._bitfield >> 4) & 0xF
+        set => this._bitfield := ((value & 0xF) << 4) | (this._bitfield & ~(0xF << 4))
     }
 
     /**

--- a/Windows/Win32/Security/Cryptography/NCRYPT_EXPORTED_ISOLATED_KEY_HEADER.ahk
+++ b/Windows/Win32/Security/Cryptography/NCRYPT_EXPORTED_ISOLATED_KEY_HEADER.ahk
@@ -28,11 +28,30 @@ class NCRYPT_EXPORTED_ISOLATED_KEY_HEADER extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - PerBootKey
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 8, "uint")
         set => NumPut("uint", value, this, 8)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    PerBootKey {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 1) & 0x7FFFFFFF
+        set => this._bitfield := ((value & 0x7FFFFFFF) << 1) | (this._bitfield & ~(0x7FFFFFFF << 1))
     }
 
     /**

--- a/Windows/Win32/Security/Cryptography/NCRYPT_VSM_KEY_ATTESTATION_CLAIM_RESTRICTIONS.ahk
+++ b/Windows/Win32/Security/Cryptography/NCRYPT_VSM_KEY_ATTESTATION_CLAIM_RESTRICTIONS.ahk
@@ -52,10 +52,29 @@ class NCRYPT_VSM_KEY_ATTESTATION_CLAIM_RESTRICTIONS extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - AllowDebugging
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 28, "uint")
         set => NumPut("uint", value, this, 28)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    AllowDebugging {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 1) & 0x7FFFFFFF
+        set => this._bitfield := ((value & 0x7FFFFFFF) << 1) | (this._bitfield & ~(0x7FFFFFFF << 1))
     }
 }

--- a/Windows/Win32/Storage/IscsiDisc/HYBRID_INFORMATION.ahk
+++ b/Windows/Win32/Storage/IscsiDisc/HYBRID_INFORMATION.ahk
@@ -133,11 +133,66 @@ class HYBRID_INFORMATION extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - CacheDisable
+     * - SetDirtyThreshold
+     * - PriorityDemoteBySize
+     * - PriorityChangeByLbaRange
+     * - Evict
+     * - ReservedBits
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 64, "uint")
         set => NumPut("uint", value, this, 64)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    CacheDisable {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    SetDirtyThreshold {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    PriorityDemoteBySize {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    PriorityChangeByLbaRange {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Evict {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ReservedBits {
+        get => (this._bitfield >> 5) & 0x7FFFFFF
+        set => this._bitfield := ((value & 0x7FFFFFF) << 5) | (this._bitfield & ~(0x7FFFFFF << 5))
     }
 
     /**

--- a/Windows/Win32/Storage/Nvme/NVME_AUTO_POWER_STATE_TRANSITION_ENTRY.ahk
+++ b/Windows/Win32/Storage/Nvme/NVME_AUTO_POWER_STATE_TRANSITION_ENTRY.ahk
@@ -16,11 +16,42 @@ class NVME_AUTO_POWER_STATE_TRANSITION_ENTRY extends Win32Struct
     static packingSize => 4
 
     /**
+     * This bitfield backs the following members:
+     * - Reserved0
+     * - IdleTransitionPowerState
+     * - IdleTimePriorToTransition
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * Bits 0-2 are reserved.
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 0) & 0x7
+        set => this._bitfield := ((value & 0x7) << 0) | (this._bitfield & ~(0x7 << 0))
+    }
+
+    /**
+     * Idle Transition Power State (ITPS) specified in Bits 3-7 is the non-operational power state for the controller to autonomously transition to after there is a continuous period of idle time in the current power state that exceeds the time specified in the **IdleTimePriorToTransition** field.
+     * @type {Integer}
+     */
+    IdleTransitionPowerState {
+        get => (this._bitfield >> 3) & 0x1F
+        set => this._bitfield := ((value & 0x1F) << 3) | (this._bitfield & ~(0x1F << 3))
+    }
+
+    /**
+     * Idle Time Prior to Transition (ITPT) specified in Bits 8-31 is the amount of idle time that occurs in this power state prior to transitioning to the Idle Transition Power State. The time is specified in milliseconds. A value of 0h disables the autonomous power state transition feature for this power state.
+     * @type {Integer}
+     */
+    IdleTimePriorToTransition {
+        get => (this._bitfield >> 8) & 0xFFFFFF
+        set => this._bitfield := ((value & 0xFFFFFF) << 8) | (this._bitfield & ~(0xFFFFFF << 8))
     }
 
     /**

--- a/Windows/Win32/Storage/Nvme/NVME_DIRECTIVE_IDENTIFY_RETURN_PARAMETERS_DESCRIPTOR.ahk
+++ b/Windows/Win32/Storage/Nvme/NVME_DIRECTIVE_IDENTIFY_RETURN_PARAMETERS_DESCRIPTOR.ahk
@@ -16,11 +16,42 @@ class NVME_DIRECTIVE_IDENTIFY_RETURN_PARAMETERS_DESCRIPTOR extends Win32Struct
     static packingSize => 1
 
     /**
+     * This bitfield backs the following members:
+     * - Identify
+     * - Streams
+     * - Reserved0
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "char")
         set => NumPut("char", value, this, 0)
+    }
+
+    /**
+     * The return parameter is an [NVME_DIRECTIVE_TYPE_IDENTIFY](ne-nvme-nvme_directive_types.md), a directive for an Identify operation.
+     * @type {Integer}
+     */
+    Identify {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * The return parameter is an [NVME_DIRECTIVE_TYPE_STREAMS](ne-nvme-nvme_directive_types.md), a directive for a Streams operation.
+     * @type {Integer}
+     */
+    Streams {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 2) & 0x3F
+        set => this._bitfield := ((value & 0x3F) << 2) | (this._bitfield & ~(0x3F << 2))
     }
 
     /**

--- a/Windows/Win32/Storage/Nvme/NVME_HOST_METADATA_ELEMENT_DESCRIPTOR.ahk
+++ b/Windows/Win32/Storage/Nvme/NVME_HOST_METADATA_ELEMENT_DESCRIPTOR.ahk
@@ -12,11 +12,57 @@ class NVME_HOST_METADATA_ELEMENT_DESCRIPTOR extends Win32Struct
     static packingSize => 4
 
     /**
+     * This bitfield backs the following members:
+     * - ET
+     * - Reserved0
+     * - ER
+     * - Reserved1
+     * - ELEN
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ET {
+        get => (this._bitfield >> 0) & 0x3F
+        set => this._bitfield := ((value & 0x3F) << 0) | (this._bitfield & ~(0x3F << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 6) & 0x3
+        set => this._bitfield := ((value & 0x3) << 6) | (this._bitfield & ~(0x3 << 6))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ER {
+        get => (this._bitfield >> 8) & 0xF
+        set => this._bitfield := ((value & 0xF) << 8) | (this._bitfield & ~(0xF << 8))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 12) & 0xF
+        set => this._bitfield := ((value & 0xF) << 12) | (this._bitfield & ~(0xF << 12))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ELEN {
+        get => (this._bitfield >> 16) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 16) | (this._bitfield & ~(0xFFFF << 16))
     }
 
     /**

--- a/Windows/Win32/Storage/Nvme/NVME_LBA_FORMAT.ahk
+++ b/Windows/Win32/Storage/Nvme/NVME_LBA_FORMAT.ahk
@@ -32,11 +32,30 @@ class NVME_LBA_FORMAT extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - RP
+     * - Reserved0
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 3, "char")
         set => NumPut("char", value, this, 3)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    RP {
+        get => (this._bitfield >> 0) & 0x3
+        set => this._bitfield := ((value & 0x3) << 0) | (this._bitfield & ~(0x3 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 2) & 0x3F
+        set => this._bitfield := ((value & 0x3F) << 2) | (this._bitfield & ~(0x3F << 2))
     }
 
     /**

--- a/Windows/Win32/Storage/Nvme/NVME_POWER_STATE_DESC.ahk
+++ b/Windows/Win32/Storage/Nvme/NVME_POWER_STATE_DESC.ahk
@@ -36,11 +36,46 @@ class NVME_POWER_STATE_DESC extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - MPS
+     * - NOPS
+     * - Reserved1
      * @type {Integer}
      */
     _bitfield1 {
         get => NumGet(this, 3, "char")
         set => NumPut("char", value, this, 3)
+    }
+
+    /**
+     * Indicates the scale for the Maximum Power field (**MP**).
+     * 
+     * When this field is cleared to `0`, the scale of the **MP** field is in 0.01 Watts. When this field is set to `1`, the scale of the **MP** field is in 0.0001 Watts.
+     * @type {Integer}
+     */
+    MPS {
+        get => (this._bitfield1 >> 0) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 0) | (this._bitfield1 & ~(0x1 << 0))
+    }
+
+    /**
+     * Indicates whether the controller processes I/O commands in this power state.
+     * 
+     * When this field is cleared to `0`, the controller processes I/O commands in this power state. When this field is set to `1`, the controller does not process I/O commands in this power state.
+     * @type {Integer}
+     */
+    NOPS {
+        get => (this._bitfield1 >> 1) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 1) | (this._bitfield1 & ~(0x1 << 1))
+    }
+
+    /**
+     * Bits 26:31 are reserved.
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield1 >> 2) & 0x3F
+        set => this._bitfield1 := ((value & 0x3F) << 2) | (this._bitfield1 & ~(0x3F << 2))
     }
 
     /**
@@ -62,6 +97,9 @@ class NVME_POWER_STATE_DESC extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - RRT
+     * - Reserved2
      * @type {Integer}
      */
     _bitfield2 {
@@ -70,6 +108,29 @@ class NVME_POWER_STATE_DESC extends Win32Struct
     }
 
     /**
+     * Indicates the relative read throughput associated with this power state.
+     * 
+     * The value in this field should be less than the number of supported power states. For example, if the controller supports 16 power states, then the valid values for this field are 0 through 15. A lower value indicates a higher read throughput.
+     * @type {Integer}
+     */
+    RRT {
+        get => (this._bitfield2 >> 0) & 0x1F
+        set => this._bitfield2 := ((value & 0x1F) << 0) | (this._bitfield2 & ~(0x1F << 0))
+    }
+
+    /**
+     * Bits 101:103 are reserved.
+     * @type {Integer}
+     */
+    Reserved2 {
+        get => (this._bitfield2 >> 5) & 0x7
+        set => this._bitfield2 := ((value & 0x7) << 5) | (this._bitfield2 & ~(0x7 << 5))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - RRL
+     * - Reserved3
      * @type {Integer}
      */
     _bitfield3 {
@@ -78,6 +139,29 @@ class NVME_POWER_STATE_DESC extends Win32Struct
     }
 
     /**
+     * Indicates the relative read latency associated with this power state.
+     * 
+     * The value in this field should be less than the number of supported power states. For example, if the controller supports 16 power states, then the valid values for this field are 0 through 15. A lower value indicates a lower read latency.
+     * @type {Integer}
+     */
+    RRL {
+        get => (this._bitfield3 >> 0) & 0x1F
+        set => this._bitfield3 := ((value & 0x1F) << 0) | (this._bitfield3 & ~(0x1F << 0))
+    }
+
+    /**
+     * Bits 109:111 are reserved.
+     * @type {Integer}
+     */
+    Reserved3 {
+        get => (this._bitfield3 >> 5) & 0x7
+        set => this._bitfield3 := ((value & 0x7) << 5) | (this._bitfield3 & ~(0x7 << 5))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - RWT
+     * - Reserved4
      * @type {Integer}
      */
     _bitfield4 {
@@ -86,11 +170,54 @@ class NVME_POWER_STATE_DESC extends Win32Struct
     }
 
     /**
+     * Indicates the relative write throughput associated with this power state.
+     * 
+     * The value in this field should be less than the number of supported power states. For example, if the controller supports 16 power states, then the valid values for this field are 0 through 15. A lower value indicates a higher write throughput.
+     * @type {Integer}
+     */
+    RWT {
+        get => (this._bitfield4 >> 0) & 0x1F
+        set => this._bitfield4 := ((value & 0x1F) << 0) | (this._bitfield4 & ~(0x1F << 0))
+    }
+
+    /**
+     * Bits 117:119 are reserved.
+     * @type {Integer}
+     */
+    Reserved4 {
+        get => (this._bitfield4 >> 5) & 0x7
+        set => this._bitfield4 := ((value & 0x7) << 5) | (this._bitfield4 & ~(0x7 << 5))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - RWL
+     * - Reserved5
      * @type {Integer}
      */
     _bitfield5 {
         get => NumGet(this, 15, "char")
         set => NumPut("char", value, this, 15)
+    }
+
+    /**
+     * Indicates the relative write latency associated with this power state. 
+     * 
+     * The value in this field should be less than the number of supported power states. For example, if the controller supports 16 power states, then the valid values for this field are 0 through 15. A lower value indicates a lower write latency.
+     * @type {Integer}
+     */
+    RWL {
+        get => (this._bitfield5 >> 0) & 0x1F
+        set => this._bitfield5 := ((value & 0x1F) << 0) | (this._bitfield5 & ~(0x1F << 0))
+    }
+
+    /**
+     * Bits 125:127 are reserved.
+     * @type {Integer}
+     */
+    Reserved5 {
+        get => (this._bitfield5 >> 5) & 0x7
+        set => this._bitfield5 := ((value & 0x7) << 5) | (this._bitfield5 & ~(0x7 << 5))
     }
 
     /**
@@ -106,11 +233,41 @@ class NVME_POWER_STATE_DESC extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - Reserved6
+     * - IPS
      * @type {Integer}
      */
     _bitfield6 {
         get => NumGet(this, 18, "char")
         set => NumPut("char", value, this, 18)
+    }
+
+    /**
+     * Bits 144:149 are reserved.
+     * @type {Integer}
+     */
+    Reserved6 {
+        get => (this._bitfield6 >> 0) & 0x3F
+        set => this._bitfield6 := ((value & 0x3F) << 0) | (this._bitfield6 & ~(0x3F << 0))
+    }
+
+    /**
+     * This field indicates the scale for the Idle Power (**IDLP**) field.
+     * 
+     * The **IPS** field uses the following values:
+     * 
+     * | Value | Definition                         |
+     * |-------|------------------------------------|
+     * | 00b   | Not reported for this power state. |
+     * | 01b   | 0.0001 W                           |
+     * | 10b   | 0.01 W                             |
+     * | 11b   | Reserved                           |
+     * @type {Integer}
+     */
+    IPS {
+        get => (this._bitfield6 >> 6) & 0x3
+        set => this._bitfield6 := ((value & 0x3) << 6) | (this._bitfield6 & ~(0x3 << 6))
     }
 
     /**
@@ -135,11 +292,62 @@ class NVME_POWER_STATE_DESC extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - APW
+     * - Reserved8
+     * - APS
      * @type {Integer}
      */
     _bitfield7 {
         get => NumGet(this, 22, "char")
         set => NumPut("char", value, this, 22)
+    }
+
+    /**
+     * Indicates the workload used to calculate maximum power for this power state.
+     * 
+     * The **APW** field uses the following values:
+     * 
+     * | Value | Definition                                                                                             |
+     * |-------|--------------------------------------------------------------------------------------------------------|
+     * | 00b   | No Workload. The workload is unknown or not provided.                                                  |
+     * | 01b   | Workload #1. Extended Idle Period with a Burst of Random Writes. Workload #1 consists of five (5) minutes of idle followed by thirty-two (32) random write commands of size 1MB submitted to a single controller while all other controllers in the NVM subsystem are idle, and then thirty (30) seconds of idle.                                                                                                            |
+     * | 10b   | Workload #2: Heavy Sequential Writes. Workload #2 consists of 80,000 sequential write commands of size 128KB submitted to a single controller while all other controllers in the NVM subsystem are idle. The submission queue(s) should be sufficiently large allowing the host to ensure there are multiple commands pending at all times during the workload.                                                                                |
+     * | 11b   | Reserved                                                                                               |
+     * 
+     * This field will not have a value of **No Workload** unless **ACTP** is `0000h`.
+     * @type {Integer}
+     */
+    APW {
+        get => (this._bitfield7 >> 0) & 0x7
+        set => this._bitfield7 := ((value & 0x7) << 0) | (this._bitfield7 & ~(0x7 << 0))
+    }
+
+    /**
+     * Bits 179:181 are reserved.
+     * @type {Integer}
+     */
+    Reserved8 {
+        get => (this._bitfield7 >> 3) & 0x7
+        set => this._bitfield7 := ((value & 0x7) << 3) | (this._bitfield7 & ~(0x7 << 3))
+    }
+
+    /**
+     * Indicates the scale for the Active Power (**ACTP**) field. If an Active Power Workload (**APW**) is reported for a power state, then the Active Power Scale (**APS**) will also be reported for that power state.
+     * 
+     * The **APS** field uses the following values:
+     * 
+     * | Value | Definition                         |
+     * |-------|------------------------------------|
+     * | 00b   | Not reported for this power state. |
+     * | 01b   | 0.0001 W                           |
+     * | 10b   | 0.01 W                             |
+     * | 11b   | Reserved                           |
+     * @type {Integer}
+     */
+    APS {
+        get => (this._bitfield7 >> 6) & 0x3
+        set => this._bitfield7 := ((value & 0x3) << 6) | (this._bitfield7 & ~(0x3 << 6))
     }
 
     /**

--- a/Windows/Win32/System/DataExchange/DDEADVISE.ahk
+++ b/Windows/Win32/System/DataExchange/DDEADVISE.ahk
@@ -14,11 +14,48 @@ class DDEADVISE extends Win32Struct
     static packingSize => 2
 
     /**
+     * This bitfield backs the following members:
+     * - reserved
+     * - fDeferUpd
+     * - fAckReq
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "ushort")
         set => NumPut("ushort", value, this, 0)
+    }
+
+    /**
+     * Type: <b>unsigned short</b>
+     * 
+     * Reserved.
+     * @type {Integer}
+     */
+    reserved {
+        get => (this._bitfield >> 0) & 0x3FFF
+        set => this._bitfield := ((value & 0x3FFF) << 0) | (this._bitfield & ~(0x3FFF << 0))
+    }
+
+    /**
+     * Type: <b>unsigned short</b>
+     * 
+     * Indicates whether the server should defer sending updated data to the client. If this value is nonzero, the server should send a <a href="https://docs.microsoft.com/windows/desktop/dataxchg/wm-dde-data">WM_DDE_DATA</a> message with a <b>NULL</b> data handle whenever the data item changes. In response, the client can post a <a href="https://docs.microsoft.com/windows/desktop/dataxchg/wm-dde-request">WM_DDE_REQUEST</a> message to the server to get a handle to the updated data.
+     * @type {Integer}
+     */
+    fDeferUpd {
+        get => (this._bitfield >> 14) & 0x1
+        set => this._bitfield := ((value & 0x1) << 14) | (this._bitfield & ~(0x1 << 14))
+    }
+
+    /**
+     * Type: <b>short</b>
+     * 
+     * Indicates whether the server should set the <b>fAckReq</b> flag in the <a href="https://docs.microsoft.com/windows/desktop/dataxchg/wm-dde-data">WM_DDE_DATA</a> messages it posts to the client. If this value is nonzero, the server should set the <b>fAckReq</b> bit.
+     * @type {Integer}
+     */
+    fAckReq {
+        get => (this._bitfield >> 15) & 0x1
+        set => this._bitfield := ((value & 0x1) << 15) | (this._bitfield & ~(0x1 << 15))
     }
 
     /**

--- a/Windows/Win32/System/DataExchange/DDEDATA.ahk
+++ b/Windows/Win32/System/DataExchange/DDEDATA.ahk
@@ -14,11 +14,72 @@ class DDEDATA extends Win32Struct
     static packingSize => 2
 
     /**
+     * This bitfield backs the following members:
+     * - unused
+     * - fResponse
+     * - fRelease
+     * - reserved
+     * - fAckReq
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "ushort")
         set => NumPut("ushort", value, this, 0)
+    }
+
+    /**
+     * Type: <b>unsigned short</b>
+     * 
+     * Unused.
+     * @type {Integer}
+     */
+    unused {
+        get => (this._bitfield >> 0) & 0xFFF
+        set => this._bitfield := ((value & 0xFFF) << 0) | (this._bitfield & ~(0xFFF << 0))
+    }
+
+    /**
+     * Type: <b>unsigned short</b>
+     * 
+     * Indicates whether the data was sent in response to a <a href="https://docs.microsoft.com/windows/desktop/dataxchg/wm-dde-request">WM_DDE_REQUEST</a> message or a <a href="https://docs.microsoft.com/windows/desktop/dataxchg/wm-dde-advise">WM_DDE_ADVISE</a> message. If this value is nonzero, the data was sent in response to a <b>WM_DDE_REQUEST</b> message.
+     * @type {Integer}
+     */
+    fResponse {
+        get => (this._bitfield >> 12) & 0x1
+        set => this._bitfield := ((value & 0x1) << 12) | (this._bitfield & ~(0x1 << 12))
+    }
+
+    /**
+     * Type: <b>unsigned short</b>
+     * 
+     * Indicates whether the application receiving the <a href="https://docs.microsoft.com/windows/desktop/dataxchg/wm-dde-poke">WM_DDE_POKE</a> message should free the data. If this value is nonzero, the application should free the data.
+     * @type {Integer}
+     */
+    fRelease {
+        get => (this._bitfield >> 13) & 0x1
+        set => this._bitfield := ((value & 0x1) << 13) | (this._bitfield & ~(0x1 << 13))
+    }
+
+    /**
+     * Type: <b>unsigned short</b>
+     * 
+     * Reserved.
+     * @type {Integer}
+     */
+    reserved {
+        get => (this._bitfield >> 14) & 0x1
+        set => this._bitfield := ((value & 0x1) << 14) | (this._bitfield & ~(0x1 << 14))
+    }
+
+    /**
+     * Type: <b>BYTE</b>
+     * 
+     * Indicates whether the application receiving the <a href="https://docs.microsoft.com/windows/desktop/dataxchg/wm-dde-data">WM_DDE_DATA</a> message should acknowledge receipt of the data by sending a <a href="https://docs.microsoft.com/windows/desktop/dataxchg/wm-dde-ack">WM_DDE_ACK</a> message. If this value is nonzero, the application should send the acknowledgment.
+     * @type {Integer}
+     */
+    fAckReq {
+        get => (this._bitfield >> 15) & 0x1
+        set => this._bitfield := ((value & 0x1) << 15) | (this._bitfield & ~(0x1 << 15))
     }
 
     /**

--- a/Windows/Win32/System/DataExchange/DDELN.ahk
+++ b/Windows/Win32/System/DataExchange/DDELN.ahk
@@ -12,11 +12,48 @@ class DDELN extends Win32Struct
     static packingSize => 2
 
     /**
+     * This bitfield backs the following members:
+     * - unused
+     * - fRelease
+     * - fDeferUpd
+     * - fAckReq
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "ushort")
         set => NumPut("ushort", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    unused {
+        get => (this._bitfield >> 0) & 0x1FFF
+        set => this._bitfield := ((value & 0x1FFF) << 0) | (this._bitfield & ~(0x1FFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fRelease {
+        get => (this._bitfield >> 13) & 0x1
+        set => this._bitfield := ((value & 0x1) << 13) | (this._bitfield & ~(0x1 << 13))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fDeferUpd {
+        get => (this._bitfield >> 14) & 0x1
+        set => this._bitfield := ((value & 0x1) << 14) | (this._bitfield & ~(0x1 << 14))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fAckReq {
+        get => (this._bitfield >> 15) & 0x1
+        set => this._bitfield := ((value & 0x1) << 15) | (this._bitfield & ~(0x1 << 15))
     }
 
     /**

--- a/Windows/Win32/System/DataExchange/DDEPOKE.ahk
+++ b/Windows/Win32/System/DataExchange/DDEPOKE.ahk
@@ -14,11 +14,48 @@ class DDEPOKE extends Win32Struct
     static packingSize => 2
 
     /**
+     * This bitfield backs the following members:
+     * - unused
+     * - fRelease
+     * - fReserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "ushort")
         set => NumPut("ushort", value, this, 0)
+    }
+
+    /**
+     * Type: <b>unsigned short</b>
+     * 
+     * Unused.
+     * @type {Integer}
+     */
+    unused {
+        get => (this._bitfield >> 0) & 0x1FFF
+        set => this._bitfield := ((value & 0x1FFF) << 0) | (this._bitfield & ~(0x1FFF << 0))
+    }
+
+    /**
+     * Type: <b>unsigned short</b>
+     * 
+     * Indicates whether the application receiving the <a href="https://docs.microsoft.com/windows/desktop/dataxchg/wm-dde-poke">WM_DDE_POKE</a> message should free the data. If this value is nonzero, the application should free the data.
+     * @type {Integer}
+     */
+    fRelease {
+        get => (this._bitfield >> 13) & 0x1
+        set => this._bitfield := ((value & 0x1) << 13) | (this._bitfield & ~(0x1 << 13))
+    }
+
+    /**
+     * Type: <b>unsigned short</b>
+     * 
+     * Reserved.
+     * @type {Integer}
+     */
+    fReserved {
+        get => (this._bitfield >> 14) & 0x3
+        set => this._bitfield := ((value & 0x3) << 14) | (this._bitfield & ~(0x3 << 14))
     }
 
     /**

--- a/Windows/Win32/System/DataExchange/DDEUP.ahk
+++ b/Windows/Win32/System/DataExchange/DDEUP.ahk
@@ -12,11 +12,57 @@ class DDEUP extends Win32Struct
     static packingSize => 2
 
     /**
+     * This bitfield backs the following members:
+     * - unused
+     * - fAck
+     * - fRelease
+     * - fReserved
+     * - fAckReq
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "ushort")
         set => NumPut("ushort", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    unused {
+        get => (this._bitfield >> 0) & 0xFFF
+        set => this._bitfield := ((value & 0xFFF) << 0) | (this._bitfield & ~(0xFFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fAck {
+        get => (this._bitfield >> 12) & 0x1
+        set => this._bitfield := ((value & 0x1) << 12) | (this._bitfield & ~(0x1 << 12))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fRelease {
+        get => (this._bitfield >> 13) & 0x1
+        set => this._bitfield := ((value & 0x1) << 13) | (this._bitfield & ~(0x1 << 13))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fReserved {
+        get => (this._bitfield >> 14) & 0x1
+        set => this._bitfield := ((value & 0x1) << 14) | (this._bitfield & ~(0x1 << 14))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fAckReq {
+        get => (this._bitfield >> 15) & 0x1
+        set => this._bitfield := ((value & 0x1) << 15) | (this._bitfield & ~(0x1 << 15))
     }
 
     /**

--- a/Windows/Win32/System/Diagnostics/Debug/Extensions/EXT_CAB_XML_DATA.ahk
+++ b/Windows/Win32/System/Diagnostics/Debug/Extensions/EXT_CAB_XML_DATA.ahk
@@ -68,11 +68,30 @@ class EXT_CAB_XML_DATA extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - MatchType
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 52, "uint")
         set => NumPut("uint", value, this, 52)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    MatchType {
+        get => (this._bitfield >> 0) & 0x7
+        set => this._bitfield := ((value & 0x7) << 0) | (this._bitfield & ~(0x7 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 3) & 0x1FFFFFFF
+        set => this._bitfield := ((value & 0x1FFFFFFF) << 3) | (this._bitfield & ~(0x1FFFFFFF << 3))
     }
 
     /**

--- a/Windows/Win32/System/Diagnostics/Debug/Extensions/FIELD_INFO.ahk
+++ b/Windows/Win32/System/Diagnostics/Debug/Extensions/FIELD_INFO.ahk
@@ -108,10 +108,65 @@ class FIELD_INFO extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - fPointer
+     * - fArray
+     * - fStruct
+     * - fConstant
+     * - fStatic
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 56, "uint")
         set => NumPut("uint", value, this, 56)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fPointer {
+        get => (this._bitfield >> 0) & 0x3
+        set => this._bitfield := ((value & 0x3) << 0) | (this._bitfield & ~(0x3 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fArray {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fStruct {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fConstant {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fStatic {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 6) & 0x3FFFFFF
+        set => this._bitfield := ((value & 0x3FFFFFF) << 6) | (this._bitfield & ~(0x3FFFFFF << 6))
     }
 }

--- a/Windows/Win32/System/Diagnostics/Debug/Extensions/KDDEBUGGER_DATA32.ahk
+++ b/Windows/Win32/System/Diagnostics/Debug/Extensions/KDDEBUGGER_DATA32.ahk
@@ -73,11 +73,21 @@ class KDDEBUGGER_DATA32 extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - PaeEnabled
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 34, "ushort")
         set => NumPut("ushort", value, this, 34)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    PaeEnabled {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
     }
 
     /**

--- a/Windows/Win32/System/Diagnostics/Debug/Extensions/KDDEBUGGER_DATA64.ahk
+++ b/Windows/Win32/System/Diagnostics/Debug/Extensions/KDDEBUGGER_DATA64.ahk
@@ -73,11 +73,39 @@ class KDDEBUGGER_DATA64 extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - PaeEnabled
+     * - KiBugCheckRecoveryActive
+     * - PagingLevels
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 54, "ushort")
         set => NumPut("ushort", value, this, 54)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    PaeEnabled {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    KiBugCheckRecoveryActive {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    PagingLevels {
+        get => (this._bitfield >> 2) & 0xF
+        set => this._bitfield := ((value & 0xF) << 2) | (this._bitfield & ~(0xF << 2))
     }
 
     /**

--- a/Windows/Win32/System/Diagnostics/Debug/Extensions/KDEXTS_PTE_INFO.ahk
+++ b/Windows/Win32/System/Diagnostics/Debug/Extensions/KDEXTS_PTE_INFO.ahk
@@ -68,6 +68,12 @@ class KDEXTS_PTE_INFO extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - PteValid
+     * - PteTransition
+     * - Prototype
+     * - Protection
+     * - Reserved
      * @type {Integer}
      */
     _bitfield1 {
@@ -78,8 +84,76 @@ class KDEXTS_PTE_INFO extends Win32Struct
     /**
      * @type {Integer}
      */
+    PteValid {
+        get => (this._bitfield1 >> 0) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 0) | (this._bitfield1 & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    PteTransition {
+        get => (this._bitfield1 >> 1) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 1) | (this._bitfield1 & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Prototype {
+        get => (this._bitfield1 >> 2) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 2) | (this._bitfield1 & ~(0x1 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Protection {
+        get => (this._bitfield1 >> 3) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 3) | (this._bitfield1 & ~(0x1 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield1 >> 4) & 0xFFFFFFF
+        set => this._bitfield1 := ((value & 0xFFFFFFF) << 4) | (this._bitfield1 & ~(0xFFFFFFF << 4))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - ReadInProgress
+     * - WriteInProgress
+     * - Modified
+     * @type {Integer}
+     */
     _bitfield2 {
         get => NumGet(this, 60, "uint")
         set => NumPut("uint", value, this, 60)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ReadInProgress {
+        get => (this._bitfield2 >> 0) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 0) | (this._bitfield2 & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    WriteInProgress {
+        get => (this._bitfield2 >> 1) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 1) | (this._bitfield2 & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Modified {
+        get => (this._bitfield2 >> 2) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 2) | (this._bitfield2 & ~(0x1 << 2))
     }
 }

--- a/Windows/Win32/System/Diagnostics/Debug/Extensions/SYM_DUMP_PARAM.ahk
+++ b/Windows/Win32/System/Diagnostics/Debug/Extensions/SYM_DUMP_PARAM.ahk
@@ -124,10 +124,56 @@ class SYM_DUMP_PARAM extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - fPointer
+     * - fArray
+     * - fStruct
+     * - fConstant
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 92, "uint")
         set => NumPut("uint", value, this, 92)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fPointer {
+        get => (this._bitfield >> 0) & 0x3
+        set => this._bitfield := ((value & 0x3) << 0) | (this._bitfield & ~(0x3 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fArray {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fStruct {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fConstant {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 5) & 0x7FFFFFF
+        set => this._bitfield := ((value & 0x7FFFFFF) << 5) | (this._bitfield & ~(0x7FFFFFF << 5))
     }
 }

--- a/Windows/Win32/System/Diagnostics/Debug/FPO_DATA.ahk
+++ b/Windows/Win32/System/Diagnostics/Debug/FPO_DATA.ahk
@@ -50,10 +50,122 @@ class FPO_DATA extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - cbProlog
+     * - cbRegs
+     * - fHasSEH
+     * - fUseBP
+     * - reserved
+     * - cbFrame
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 14, "ushort")
         set => NumPut("ushort", value, this, 14)
+    }
+
+    /**
+     * The number of bytes in the function prolog code.
+     * @type {Integer}
+     */
+    cbProlog {
+        get => (this._bitfield >> 0) & 0xFF
+        set => this._bitfield := ((value & 0xFF) << 0) | (this._bitfield & ~(0xFF << 0))
+    }
+
+    /**
+     * The number of registers saved.
+     * @type {Integer}
+     */
+    cbRegs {
+        get => (this._bitfield >> 8) & 0x7
+        set => this._bitfield := ((value & 0x7) << 8) | (this._bitfield & ~(0x7 << 8))
+    }
+
+    /**
+     * A variable that indicates whether the function uses structured exception handling.
+     * @type {Integer}
+     */
+    fHasSEH {
+        get => (this._bitfield >> 11) & 0x1
+        set => this._bitfield := ((value & 0x1) << 11) | (this._bitfield & ~(0x1 << 11))
+    }
+
+    /**
+     * A variable that indicates whether the EBP register has been allocated.
+     * @type {Integer}
+     */
+    fUseBP {
+        get => (this._bitfield >> 12) & 0x1
+        set => this._bitfield := ((value & 0x1) << 12) | (this._bitfield & ~(0x1 << 12))
+    }
+
+    /**
+     * Reserved for future use.
+     * @type {Integer}
+     */
+    reserved {
+        get => (this._bitfield >> 13) & 0x1
+        set => this._bitfield := ((value & 0x1) << 13) | (this._bitfield & ~(0x1 << 13))
+    }
+
+    /**
+     * A variable that indicates the frame type.
+     * 
+     * <table>
+     * <tr>
+     * <th>Type</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FRAME_FPO"></a><a id="frame_fpo"></a><dl>
+     * <dt><b>FRAME_FPO</b></dt>
+     * <dt>0</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * FPO frame
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FRAME_NONFPO"></a><a id="frame_nonfpo"></a><dl>
+     * <dt><b>FRAME_NONFPO</b></dt>
+     * <dt>3</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Non-FPO frame
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FRAME_TRAP"></a><a id="frame_trap"></a><dl>
+     * <dt><b>FRAME_TRAP</b></dt>
+     * <dt>1</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Trap frame
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%"><a id="FRAME_TSS"></a><a id="frame_tss"></a><dl>
+     * <dt><b>FRAME_TSS</b></dt>
+     * <dt>2</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * TSS frame
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    cbFrame {
+        get => (this._bitfield >> 14) & 0x3
+        set => this._bitfield := ((value & 0x3) << 14) | (this._bitfield & ~(0x3 << 14))
     }
 }

--- a/Windows/Win32/System/Hypervisor/WHV_CAPABILITY_PROCESSOR_FREQUENCY_CAP.ahk
+++ b/Windows/Win32/System/Hypervisor/WHV_CAPABILITY_PROCESSOR_FREQUENCY_CAP.ahk
@@ -12,11 +12,30 @@ class WHV_CAPABILITY_PROCESSOR_FREQUENCY_CAP extends Win32Struct
     static packingSize => 4
 
     /**
+     * This bitfield backs the following members:
+     * - IsSupported
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    IsSupported {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 1) & 0x7FFFFFFF
+        set => this._bitfield := ((value & 0x7FFFFFFF) << 1) | (this._bitfield & ~(0x7FFFFFFF << 1))
     }
 
     /**

--- a/Windows/Win32/System/Hypervisor/WHV_DOORBELL_MATCH_DATA.ahk
+++ b/Windows/Win32/System/Hypervisor/WHV_DOORBELL_MATCH_DATA.ahk
@@ -36,10 +36,38 @@ class WHV_DOORBELL_MATCH_DATA extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - MatchOnValue
+     * - MatchOnLength
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 20, "uint")
         set => NumPut("uint", value, this, 20)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    MatchOnValue {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    MatchOnLength {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 2) & 0x3FFFFFFF
+        set => this._bitfield := ((value & 0x3FFFFFFF) << 2) | (this._bitfield & ~(0x3FFFFFFF << 2))
     }
 }

--- a/Windows/Win32/System/Hypervisor/WHV_INTERRUPT_CONTROL.ahk
+++ b/Windows/Win32/System/Hypervisor/WHV_INTERRUPT_CONTROL.ahk
@@ -12,11 +12,48 @@ class WHV_INTERRUPT_CONTROL extends Win32Struct
     static packingSize => 8
 
     /**
+     * This bitfield backs the following members:
+     * - Type
+     * - DestinationMode
+     * - TriggerMode
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Type {
+        get => (this._bitfield >> 0) & 0xFF
+        set => this._bitfield := ((value & 0xFF) << 0) | (this._bitfield & ~(0xFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    DestinationMode {
+        get => (this._bitfield >> 8) & 0xF
+        set => this._bitfield := ((value & 0xF) << 8) | (this._bitfield & ~(0xF << 8))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    TriggerMode {
+        get => (this._bitfield >> 12) & 0xF
+        set => this._bitfield := ((value & 0xF) << 12) | (this._bitfield & ~(0xF << 12))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 16) & 0xFFFFFFFFFFFF
+        set => this._bitfield := ((value & 0xFFFFFFFFFFFF) << 16) | (this._bitfield & ~(0xFFFFFFFFFFFF << 16))
     }
 
     /**

--- a/Windows/Win32/System/Hypervisor/WHV_VP_EXIT_CONTEXT.ahk
+++ b/Windows/Win32/System/Hypervisor/WHV_VP_EXIT_CONTEXT.ahk
@@ -25,11 +25,30 @@ class WHV_VP_EXIT_CONTEXT extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - InstructionLength
+     * - Cr8
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 4, "char")
         set => NumPut("char", value, this, 4)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    InstructionLength {
+        get => (this._bitfield >> 0) & 0xF
+        set => this._bitfield := ((value & 0xF) << 0) | (this._bitfield & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Cr8 {
+        get => (this._bitfield >> 4) & 0xF
+        set => this._bitfield := ((value & 0xF) << 4) | (this._bitfield & ~(0xF << 4))
     }
 
     /**

--- a/Windows/Win32/System/Hypervisor/WHV_X64_FP_REGISTER.ahk
+++ b/Windows/Win32/System/Hypervisor/WHV_X64_FP_REGISTER.ahk
@@ -21,11 +21,39 @@ class WHV_X64_FP_REGISTER extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - BiasedExponent
+     * - Sign
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 8, "uint")
         set => NumPut("uint", value, this, 8)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    BiasedExponent {
+        get => (this._bitfield >> 0) & 0x7FFF
+        set => this._bitfield := ((value & 0x7FFF) << 0) | (this._bitfield & ~(0x7FFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Sign {
+        get => (this._bitfield >> 15) & 0x1
+        set => this._bitfield := ((value & 0x1) << 15) | (this._bitfield & ~(0x1 << 15))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 16) & 0xFFFFFFFFFFFF
+        set => this._bitfield := ((value & 0xFFFFFFFFFFFF) << 16) | (this._bitfield & ~(0xFFFFFFFFFFFF << 16))
     }
 
     /**

--- a/Windows/Win32/System/Hypervisor/WHV_X64_PENDING_EXCEPTION_EVENT.ahk
+++ b/Windows/Win32/System/Hypervisor/WHV_X64_PENDING_EXCEPTION_EVENT.ahk
@@ -13,11 +13,66 @@ class WHV_X64_PENDING_EXCEPTION_EVENT extends Win32Struct
     static packingSize => 8
 
     /**
+     * This bitfield backs the following members:
+     * - EventPending
+     * - EventType
+     * - Reserved0
+     * - DeliverErrorCode
+     * - Reserved1
+     * - Vector
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    EventPending {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    EventType {
+        get => (this._bitfield >> 1) & 0x7
+        set => this._bitfield := ((value & 0x7) << 1) | (this._bitfield & ~(0x7 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 4) & 0xF
+        set => this._bitfield := ((value & 0xF) << 4) | (this._bitfield & ~(0xF << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    DeliverErrorCode {
+        get => (this._bitfield >> 8) & 0x1
+        set => this._bitfield := ((value & 0x1) << 8) | (this._bitfield & ~(0x1 << 8))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 9) & 0x7F
+        set => this._bitfield := ((value & 0x7F) << 9) | (this._bitfield & ~(0x7F << 9))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Vector {
+        get => (this._bitfield >> 16) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 16) | (this._bitfield & ~(0xFFFF << 16))
     }
 
     /**

--- a/Windows/Win32/System/Hypervisor/WHV_X64_PENDING_EXT_INT_EVENT.ahk
+++ b/Windows/Win32/System/Hypervisor/WHV_X64_PENDING_EXT_INT_EVENT.ahk
@@ -13,11 +13,57 @@ class WHV_X64_PENDING_EXT_INT_EVENT extends Win32Struct
     static packingSize => 8
 
     /**
+     * This bitfield backs the following members:
+     * - EventPending
+     * - EventType
+     * - Reserved0
+     * - Vector
+     * - Reserved1
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    EventPending {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    EventType {
+        get => (this._bitfield >> 1) & 0x7
+        set => this._bitfield := ((value & 0x7) << 1) | (this._bitfield & ~(0x7 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 4) & 0xF
+        set => this._bitfield := ((value & 0xF) << 4) | (this._bitfield & ~(0xF << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Vector {
+        get => (this._bitfield >> 8) & 0xFF
+        set => this._bitfield := ((value & 0xFF) << 8) | (this._bitfield & ~(0xFF << 8))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 16) & 0xFFFFFFFFFFFF
+        set => this._bitfield := ((value & 0xFFFFFFFFFFFF) << 16) | (this._bitfield & ~(0xFFFFFFFFFFFF << 16))
     }
 
     /**

--- a/Windows/Win32/System/Hypervisor/WHV_X64_PENDING_INTERRUPTION_REGISTER.ahk
+++ b/Windows/Win32/System/Hypervisor/WHV_X64_PENDING_INTERRUPTION_REGISTER.ahk
@@ -12,11 +12,75 @@ class WHV_X64_PENDING_INTERRUPTION_REGISTER extends Win32Struct
     static packingSize => 8
 
     /**
+     * This bitfield backs the following members:
+     * - InterruptionPending
+     * - InterruptionType
+     * - DeliverErrorCode
+     * - InstructionLength
+     * - NestedEvent
+     * - Reserved
+     * - InterruptionVector
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    InterruptionPending {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    InterruptionType {
+        get => (this._bitfield >> 1) & 0x7
+        set => this._bitfield := ((value & 0x7) << 1) | (this._bitfield & ~(0x7 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    DeliverErrorCode {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    InstructionLength {
+        get => (this._bitfield >> 5) & 0xF
+        set => this._bitfield := ((value & 0xF) << 5) | (this._bitfield & ~(0xF << 5))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    NestedEvent {
+        get => (this._bitfield >> 9) & 0x1
+        set => this._bitfield := ((value & 0x1) << 9) | (this._bitfield & ~(0x1 << 9))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 10) & 0x3F
+        set => this._bitfield := ((value & 0x3F) << 10) | (this._bitfield & ~(0x3F << 10))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    InterruptionVector {
+        get => (this._bitfield >> 16) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 16) | (this._bitfield & ~(0xFFFF << 16))
     }
 
     /**

--- a/Windows/Win32/System/Ioctl/DEVICE_LB_PROVISIONING_DESCRIPTOR.ahk
+++ b/Windows/Win32/System/Ioctl/DEVICE_LB_PROVISIONING_DESCRIPTOR.ahk
@@ -43,11 +43,186 @@ class DEVICE_LB_PROVISIONING_DESCRIPTOR extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - ThinProvisioningEnabled
+     * - ThinProvisioningReadZeros
+     * - AnchorSupported
+     * - UnmapGranularityAlignmentValid
+     * - GetFreeSpaceSupported
+     * - MapSupported
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 8, "char")
         set => NumPut("char", value, this, 8)
+    }
+
+    /**
+     * The thin provisioning–enabled status.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Thin provisioning is disabled.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>1</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Thin provisioning is enabled.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    ThinProvisioningEnabled {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * Reads to unmapped regions return zeros.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Data read from unmapped regions is undefined.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>1</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Reads return zeros.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    ThinProvisioningReadZeros {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * Deterministic read after trim support.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Deterministic read after trim is not supported.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>1</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Deterministic read after trim is supported.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    AnchorSupported {
+        get => (this._bitfield >> 2) & 0x7
+        set => this._bitfield := ((value & 0x7) << 2) | (this._bitfield & ~(0x7 << 2))
+    }
+
+    /**
+     * The validity of unmap granularity alignment for the device.
+     * 
+     * <table>
+     * <tr>
+     * <th>Value</th>
+     * <th>Meaning</th>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>0</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Unmap granularity alignment is not valid.
+     * 
+     * </td>
+     * </tr>
+     * <tr>
+     * <td width="40%">
+     * <dl>
+     * <dt>1</dt>
+     * </dl>
+     * </td>
+     * <td width="60%">
+     * Unmap granularity alignment is valid.
+     * 
+     * </td>
+     * </tr>
+     * </table>
+     * @type {Integer}
+     */
+    UnmapGranularityAlignmentValid {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    GetFreeSpaceSupported {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    MapSupported {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/System/Ioctl/PERSISTENT_RESERVE_COMMAND.ahk
+++ b/Windows/Win32/System/Ioctl/PERSISTENT_RESERVE_COMMAND.ahk
@@ -28,11 +28,30 @@ class PERSISTENT_RESERVE_COMMAND extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - ServiceAction
+     * - Reserved1
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 12, "char")
         set => NumPut("char", value, this, 12)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ServiceAction {
+        get => (this._bitfield >> 0) & 0x1F
+        set => this._bitfield := ((value & 0x1F) << 0) | (this._bitfield & ~(0x1F << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield >> 5) & 0x7
+        set => this._bitfield := ((value & 0x7) << 5) | (this._bitfield & ~(0x7 << 5))
     }
 
     /**
@@ -44,6 +63,9 @@ class PERSISTENT_RESERVE_COMMAND extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - ServiceAction
+     * - Reserved1
      * @type {Integer}
      */
     _bitfield1 {
@@ -54,9 +76,44 @@ class PERSISTENT_RESERVE_COMMAND extends Win32Struct
     /**
      * @type {Integer}
      */
+    ServiceAction {
+        get => (this._bitfield1 >> 0) & 0x1F
+        set => this._bitfield1 := ((value & 0x1F) << 0) | (this._bitfield1 & ~(0x1F << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved1 {
+        get => (this._bitfield1 >> 5) & 0x7
+        set => this._bitfield1 := ((value & 0x7) << 5) | (this._bitfield1 & ~(0x7 << 5))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - Type
+     * - Scope
+     * @type {Integer}
+     */
     _bitfield2 {
         get => NumGet(this, 13, "char")
         set => NumPut("char", value, this, 13)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Type {
+        get => (this._bitfield2 >> 0) & 0xF
+        set => this._bitfield2 := ((value & 0xF) << 0) | (this._bitfield2 & ~(0xF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Scope {
+        get => (this._bitfield2 >> 4) & 0xF
+        set => this._bitfield2 := ((value & 0xF) << 4) | (this._bitfield2 & ~(0xF << 4))
     }
 
     /**

--- a/Windows/Win32/System/Ioctl/SCM_PD_FIRMWARE_SLOT_INFO.ahk
+++ b/Windows/Win32/System/Ioctl/SCM_PD_FIRMWARE_SLOT_INFO.ahk
@@ -36,11 +36,30 @@ class SCM_PD_FIRMWARE_SLOT_INFO extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - ReadOnly
+     * - Reserved0
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 9, "char")
         set => NumPut("char", value, this, 9)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ReadOnly {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 1) & 0x7F
+        set => this._bitfield := ((value & 0x7F) << 1) | (this._bitfield & ~(0x7F << 1))
     }
 
     /**

--- a/Windows/Win32/System/Ioctl/STORAGE_HW_FIRMWARE_INFO.ahk
+++ b/Windows/Win32/System/Ioctl/STORAGE_HW_FIRMWARE_INFO.ahk
@@ -33,11 +33,32 @@ class STORAGE_HW_FIRMWARE_INFO extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - SupportUpgrade
+     * - Reserved0
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 8, "char")
         set => NumPut("char", value, this, 8)
+    }
+
+    /**
+     * Indicates that this firmware supports an upgrade.
+     * @type {Integer}
+     */
+    SupportUpgrade {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * Reserved for future use.
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 1) & 0x7F
+        set => this._bitfield := ((value & 0x7F) << 1) | (this._bitfield & ~(0x7F << 1))
     }
 
     /**

--- a/Windows/Win32/System/Ioctl/STORAGE_HW_FIRMWARE_SLOT_INFO.ahk
+++ b/Windows/Win32/System/Ioctl/STORAGE_HW_FIRMWARE_SLOT_INFO.ahk
@@ -41,11 +41,32 @@ class STORAGE_HW_FIRMWARE_SLOT_INFO extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - ReadOnly
+     * - Reserved0
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 9, "char")
         set => NumPut("char", value, this, 9)
+    }
+
+    /**
+     * Indicates whether this slot is read-only or not.
+     * @type {Integer}
+     */
+    ReadOnly {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * Reserved for future use.
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield >> 1) & 0x7F
+        set => this._bitfield := ((value & 0x7F) << 1) | (this._bitfield & ~(0x7F << 1))
     }
 
     /**

--- a/Windows/Win32/System/Ioctl/STORAGE_IDLE_POWER.ahk
+++ b/Windows/Win32/System/Ioctl/STORAGE_IDLE_POWER.ahk
@@ -28,11 +28,39 @@ class STORAGE_IDLE_POWER extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - WakeCapableHint
+     * - D3ColdSupported
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 8, "uint")
         set => NumPut("uint", value, this, 8)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    WakeCapableHint {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    D3ColdSupported {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 2) & 0x3FFFFFFF
+        set => this._bitfield := ((value & 0x3FFFFFFF) << 2) | (this._bitfield & ~(0x3FFFFFFF << 2))
     }
 
     /**

--- a/Windows/Win32/System/Ioctl/STORAGE_LB_PROVISIONING_MAP_RESOURCES.ahk
+++ b/Windows/Win32/System/Ioctl/STORAGE_LB_PROVISIONING_MAP_RESOURCES.ahk
@@ -28,11 +28,39 @@ class STORAGE_LB_PROVISIONING_MAP_RESOURCES extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - AvailableMappingResourcesValid
+     * - UsedMappingResourcesValid
+     * - Reserved0
      * @type {Integer}
      */
     _bitfield1 {
         get => NumGet(this, 8, "char")
         set => NumPut("char", value, this, 8)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    AvailableMappingResourcesValid {
+        get => (this._bitfield1 >> 0) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 0) | (this._bitfield1 & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    UsedMappingResourcesValid {
+        get => (this._bitfield1 >> 1) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 1) | (this._bitfield1 & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved0 {
+        get => (this._bitfield1 >> 2) & 0x3F
+        set => this._bitfield1 := ((value & 0x3F) << 2) | (this._bitfield1 & ~(0x3F << 2))
     }
 
     /**
@@ -47,11 +75,39 @@ class STORAGE_LB_PROVISIONING_MAP_RESOURCES extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - AvailableMappingResourcesScope
+     * - UsedMappingResourcesScope
+     * - Reserved2
      * @type {Integer}
      */
     _bitfield2 {
         get => NumGet(this, 12, "char")
         set => NumPut("char", value, this, 12)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    AvailableMappingResourcesScope {
+        get => (this._bitfield2 >> 0) & 0x3
+        set => this._bitfield2 := ((value & 0x3) << 0) | (this._bitfield2 & ~(0x3 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    UsedMappingResourcesScope {
+        get => (this._bitfield2 >> 2) & 0x3
+        set => this._bitfield2 := ((value & 0x3) << 2) | (this._bitfield2 & ~(0x3 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved2 {
+        get => (this._bitfield2 >> 4) & 0xF
+        set => this._bitfield2 := ((value & 0xF) << 4) | (this._bitfield2 & ~(0xF << 4))
     }
 
     /**

--- a/Windows/Win32/System/Kernel/RTL_BALANCED_NODE.ahk
+++ b/Windows/Win32/System/Kernel/RTL_BALANCED_NODE.ahk
@@ -39,11 +39,30 @@ class RTL_BALANCED_NODE extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - Red
+     * - Balance
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 16, "char")
         set => NumPut("char", value, this, 16)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Red {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Balance {
+        get => (this._bitfield >> 1) & 0x3
+        set => this._bitfield := ((value & 0x3) << 1) | (this._bitfield & ~(0x3 << 1))
     }
 
     /**

--- a/Windows/Win32/System/Performance/PDH_BROWSE_DLG_CONFIG_A.ahk
+++ b/Windows/Win32/System/Performance/PDH_BROWSE_DLG_CONFIG_A.ahk
@@ -19,11 +19,142 @@ class PDH_BROWSE_DLG_CONFIG_A extends Win32Struct
     static packingSize => 8
 
     /**
+     * This bitfield backs the following members:
+     * - bIncludeInstanceIndex
+     * - bSingleCounterPerAdd
+     * - bSingleCounterPerDialog
+     * - bLocalCountersOnly
+     * - bWildCardInstances
+     * - bHideDetailBox
+     * - bInitializePath
+     * - bDisableMachineSelection
+     * - bIncludeCostlyObjects
+     * - bShowObjectBrowser
+     * - bReserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog box includes an index number for duplicate instance names. For example, if there are two cmd instances, the instance list will contain cmd and cmd#1. If this flag is <b>FALSE</b>, duplicate instance names will not contain an index number.
+     * @type {Integer}
+     */
+    bIncludeInstanceIndex {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog returns only one counter. If this flag is <b>FALSE</b>, the dialog can return multiple selections, and wildcard selections are permitted. Selected counters are returned as a MULTI_SZ string.
+     * @type {Integer}
+     */
+    bSingleCounterPerAdd {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog box uses an OK and Cancel button. The dialog returns when the user clicks either button. If this flag is <b>FALSE</b>, the dialog box uses an Add and Close button. The dialog box closes when the user clicks the Close button. The Add button can be clicked multiple times. The Add button overwrites the previously selected items with the currently selected items.
+     * @type {Integer}
+     */
+    bSingleCounterPerDialog {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog box lets the user select counters only from the local computer (the path will not contain a computer name). If this flag is <b>FALSE</b>, the user can specify a computer from which to select counters. The computer name will prefix the counter path unless the user selects <b>Use local computer counters</b>.
+     * @type {Integer}
+     */
+    bLocalCountersOnly {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b> and the user selects <b>All instances</b>, the counter path will include the wildcard character for the instance field. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, and the user selects <b>All instances</b>, all the instances currently found for that object will be returned in a MULTI_SZ string.
+     * @type {Integer}
+     */
+    bWildCardInstances {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, this removes <b>Detail level</b> from the dialog box so the user cannot change the detail level of the counters displayed in the dialog box. The detail level will be fixed to the value of the <b>dwDefaultDetailLevel</b> member. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, this displays <b>Detail level</b> in the dialog box, allowing the user to change the detail level of the counters displayed. 
+     * 
+     * 
+     * 
+     * Note that the counters displayed will be those whose detail level is less than or equal to the current detail level selection. Selecting a detail level of Wizard will display all counters and objects.
+     * @type {Integer}
+     */
+    bHideDetailBox {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog highlights the counter and object specified in <b>szReturnPathBuffer</b> when the dialog box is first displayed, instead of using the default counter and object specified by the computer. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, this selects the initial counter and object using the default counter and object information returned by the computer.
+     * @type {Integer}
+     */
+    bInitializePath {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the user cannot select a computer from  <b>Select counters from computer</b>. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, the user can select a computer from <b>Select counters from computer</b>. This is the default value. 
+     * The list contains the local computer only unless you call the <a href="https://docs.microsoft.com/windows/desktop/api/pdh/nf-pdh-pdhconnectmachinea">PdhConnectMachine</a> to connect to other computers first.
+     * @type {Integer}
+     */
+    bDisableMachineSelection {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the counters list will also contain costly data—that is, data that requires a relatively large amount of processor time or memory overhead to collect. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, the list will not contain costly counters. This is the default value.
+     * @type {Integer}
+     */
+    bIncludeCostlyObjects {
+        get => (this._bitfield >> 8) & 0x1
+        set => this._bitfield := ((value & 0x1) << 8) | (this._bitfield & ~(0x1 << 8))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog lists only performance objects. When the user selects an object, the dialog returns a counter path that includes the object and wildcard characters for the instance name and counter if the object is a multiple instance object. For example, if the "Process" object is selected, the dialog returns the string "\Process(*)\*". If the object is a single instance object, the path contains a wildcard character for counter only. For example, "\System\*". You can then pass the path to <a href="https://docs.microsoft.com/windows/desktop/api/pdh/nf-pdh-pdhexpandwildcardpatha">PdhExpandWildCardPath</a> to retrieve a list of actual paths for the object.
+     * @type {Integer}
+     */
+    bShowObjectBrowser {
+        get => (this._bitfield >> 9) & 0x1
+        set => this._bitfield := ((value & 0x1) << 9) | (this._bitfield & ~(0x1 << 9))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    bReserved {
+        get => (this._bitfield >> 10) & 0x3FFFFF
+        set => this._bitfield := ((value & 0x3FFFFF) << 10) | (this._bitfield & ~(0x3FFFFF << 10))
     }
 
     /**

--- a/Windows/Win32/System/Performance/PDH_BROWSE_DLG_CONFIG_HA.ahk
+++ b/Windows/Win32/System/Performance/PDH_BROWSE_DLG_CONFIG_HA.ahk
@@ -26,11 +26,142 @@ class PDH_BROWSE_DLG_CONFIG_HA extends Win32Struct
     static packingSize => 8
 
     /**
+     * This bitfield backs the following members:
+     * - bIncludeInstanceIndex
+     * - bSingleCounterPerAdd
+     * - bSingleCounterPerDialog
+     * - bLocalCountersOnly
+     * - bWildCardInstances
+     * - bHideDetailBox
+     * - bInitializePath
+     * - bDisableMachineSelection
+     * - bIncludeCostlyObjects
+     * - bShowObjectBrowser
+     * - bReserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog box includes an index number for duplicate instance names. For example, if there are two cmd instances, the instance list will contain cmd and cmd#1. If this flag is <b>FALSE</b>, duplicate instance names will not contain an index number.
+     * @type {Integer}
+     */
+    bIncludeInstanceIndex {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog returns only one counter. If this flag is <b>FALSE</b>, the dialog can return multiple selections, and wildcard selections are permitted. Selected counters are returned as a MULTI_SZ string.
+     * @type {Integer}
+     */
+    bSingleCounterPerAdd {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog box uses an OK and Cancel button. The dialog returns when the user clicks either button. If this flag is <b>FALSE</b>, the dialog box uses an Add and Close button. The dialog box closes when the user clicks the Close button. The Add button can be clicked multiple times. The Add button overwrites the previously selected items with the currently selected items.
+     * @type {Integer}
+     */
+    bSingleCounterPerDialog {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog box lets the user select counters only from the local computer (the path will not contain a computer name). If this flag is <b>FALSE</b>, the user can specify a computer from which to select counters. The computer name will prefix the counter path unless the user selects <b>Use local computer counters</b>.
+     * @type {Integer}
+     */
+    bLocalCountersOnly {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b> and the user selects <b>All instances</b>, the counter path will include the wildcard character for the instance field. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, and the user selects <b>All instances</b>, all the instances currently found for that object will be returned in a MULTI_SZ string.
+     * @type {Integer}
+     */
+    bWildCardInstances {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, this removes <b>Detail level</b> from the dialog box so the user cannot change the detail level of the counters displayed in the dialog box. The detail level will be fixed to the value of the <b>dwDefaultDetailLevel</b> member. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, this displays <b>Detail level</b> in the dialog box, allowing the user to change the detail level of the counters displayed. 
+     * 
+     * 
+     * 
+     * Note that the counters displayed will be those whose detail level is less than or equal to the current detail level selection. Selecting a detail level of Wizard will display all counters and objects.
+     * @type {Integer}
+     */
+    bHideDetailBox {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog highlights the counter and object specified in <b>szReturnPathBuffer</b> when the dialog box is first displayed, instead of using the default counter and object specified by the computer. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, this selects the initial counter and object using the default counter and object information returned by the computer.
+     * @type {Integer}
+     */
+    bInitializePath {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the user cannot select a computer from  <b>Select counters from computer</b>. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, the user can select a computer from <b>Select counters from computer</b>. This is the default value. 
+     * The list contains the local computer only unless you call the <a href="https://docs.microsoft.com/windows/desktop/api/pdh/nf-pdh-pdhconnectmachinea">PdhConnectMachine</a> to connect to other computers first.
+     * @type {Integer}
+     */
+    bDisableMachineSelection {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the counters list will also contain costly data—that is, data that requires a relatively large amount of processor time or memory overhead to collect. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, the list will not contain costly counters. This is the default value.
+     * @type {Integer}
+     */
+    bIncludeCostlyObjects {
+        get => (this._bitfield >> 8) & 0x1
+        set => this._bitfield := ((value & 0x1) << 8) | (this._bitfield & ~(0x1 << 8))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog lists only performance objects. When the user selects an object, the dialog returns a counter path that includes the object and wildcard characters for the instance name and counter if the object is a multiple instance object. For example, if the "Process" object is selected, the dialog returns the string "\Process(*)\*". If the object is a single instance object, the path contains a wildcard character for counter only. For example, "\System\*". You can then pass the path to <a href="https://docs.microsoft.com/windows/desktop/api/pdh/nf-pdh-pdhexpandwildcardpatha">PdhExpandWildCardPath</a> to retrieve a list of actual paths for the object.
+     * @type {Integer}
+     */
+    bShowObjectBrowser {
+        get => (this._bitfield >> 9) & 0x1
+        set => this._bitfield := ((value & 0x1) << 9) | (this._bitfield & ~(0x1 << 9))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    bReserved {
+        get => (this._bitfield >> 10) & 0x3FFFFF
+        set => this._bitfield := ((value & 0x3FFFFF) << 10) | (this._bitfield & ~(0x3FFFFF << 10))
     }
 
     /**

--- a/Windows/Win32/System/Performance/PDH_BROWSE_DLG_CONFIG_HW.ahk
+++ b/Windows/Win32/System/Performance/PDH_BROWSE_DLG_CONFIG_HW.ahk
@@ -26,11 +26,142 @@ class PDH_BROWSE_DLG_CONFIG_HW extends Win32Struct
     static packingSize => 8
 
     /**
+     * This bitfield backs the following members:
+     * - bIncludeInstanceIndex
+     * - bSingleCounterPerAdd
+     * - bSingleCounterPerDialog
+     * - bLocalCountersOnly
+     * - bWildCardInstances
+     * - bHideDetailBox
+     * - bInitializePath
+     * - bDisableMachineSelection
+     * - bIncludeCostlyObjects
+     * - bShowObjectBrowser
+     * - bReserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog box includes an index number for duplicate instance names. For example, if there are two cmd instances, the instance list will contain cmd and cmd#1. If this flag is <b>FALSE</b>, duplicate instance names will not contain an index number.
+     * @type {Integer}
+     */
+    bIncludeInstanceIndex {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog returns only one counter. If this flag is <b>FALSE</b>, the dialog can return multiple selections, and wildcard selections are permitted. Selected counters are returned as a MULTI_SZ string.
+     * @type {Integer}
+     */
+    bSingleCounterPerAdd {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog box uses an OK and Cancel button. The dialog returns when the user clicks either button. If this flag is <b>FALSE</b>, the dialog box uses an Add and Close button. The dialog box closes when the user clicks the Close button. The Add button can be clicked multiple times. The Add button overwrites the previously selected items with the currently selected items.
+     * @type {Integer}
+     */
+    bSingleCounterPerDialog {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog box lets the user select counters only from the local computer (the path will not contain a computer name). If this flag is <b>FALSE</b>, the user can specify a computer from which to select counters. The computer name will prefix the counter path unless the user selects <b>Use local computer counters</b>.
+     * @type {Integer}
+     */
+    bLocalCountersOnly {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b> and the user selects <b>All instances</b>, the counter path will include the wildcard character for the instance field. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, and the user selects <b>All instances</b>, all the instances currently found for that object will be returned in a MULTI_SZ string.
+     * @type {Integer}
+     */
+    bWildCardInstances {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, this removes <b>Detail level</b> from the dialog box so the user cannot change the detail level of the counters displayed in the dialog box. The detail level will be fixed to the value of the <b>dwDefaultDetailLevel</b> member. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, this displays <b>Detail level</b> in the dialog box, allowing the user to change the detail level of the counters displayed. 
+     * 
+     * 
+     * 
+     * Note that the counters displayed will be those whose detail level is less than or equal to the current detail level selection. Selecting a detail level of Wizard will display all counters and objects.
+     * @type {Integer}
+     */
+    bHideDetailBox {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog highlights the counter and object specified in <b>szReturnPathBuffer</b> when the dialog box is first displayed, instead of using the default counter and object specified by the computer. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, this selects the initial counter and object using the default counter and object information returned by the computer.
+     * @type {Integer}
+     */
+    bInitializePath {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the user cannot select a computer from  <b>Select counters from computer</b>. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, the user can select a computer from <b>Select counters from computer</b>. This is the default value. 
+     * The list contains the local computer only unless you call the <a href="https://docs.microsoft.com/windows/desktop/api/pdh/nf-pdh-pdhconnectmachinea">PdhConnectMachine</a> to connect to other computers first.
+     * @type {Integer}
+     */
+    bDisableMachineSelection {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the counters list will also contain costly data—that is, data that requires a relatively large amount of processor time or memory overhead to collect. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, the list will not contain costly counters. This is the default value.
+     * @type {Integer}
+     */
+    bIncludeCostlyObjects {
+        get => (this._bitfield >> 8) & 0x1
+        set => this._bitfield := ((value & 0x1) << 8) | (this._bitfield & ~(0x1 << 8))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog lists only performance objects. When the user selects an object, the dialog returns a counter path that includes the object and wildcard characters for the instance name and counter if the object is a multiple instance object. For example, if the "Process" object is selected, the dialog returns the string "\Process(*)\*". If the object is a single instance object, the path contains a wildcard character for counter only. For example, "\System\*". You can then pass the path to <a href="https://docs.microsoft.com/windows/desktop/api/pdh/nf-pdh-pdhexpandwildcardpatha">PdhExpandWildCardPath</a> to retrieve a list of actual paths for the object.
+     * @type {Integer}
+     */
+    bShowObjectBrowser {
+        get => (this._bitfield >> 9) & 0x1
+        set => this._bitfield := ((value & 0x1) << 9) | (this._bitfield & ~(0x1 << 9))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    bReserved {
+        get => (this._bitfield >> 10) & 0x3FFFFF
+        set => this._bitfield := ((value & 0x3FFFFF) << 10) | (this._bitfield & ~(0x3FFFFF << 10))
     }
 
     /**

--- a/Windows/Win32/System/Performance/PDH_BROWSE_DLG_CONFIG_W.ahk
+++ b/Windows/Win32/System/Performance/PDH_BROWSE_DLG_CONFIG_W.ahk
@@ -19,11 +19,142 @@ class PDH_BROWSE_DLG_CONFIG_W extends Win32Struct
     static packingSize => 8
 
     /**
+     * This bitfield backs the following members:
+     * - bIncludeInstanceIndex
+     * - bSingleCounterPerAdd
+     * - bSingleCounterPerDialog
+     * - bLocalCountersOnly
+     * - bWildCardInstances
+     * - bHideDetailBox
+     * - bInitializePath
+     * - bDisableMachineSelection
+     * - bIncludeCostlyObjects
+     * - bShowObjectBrowser
+     * - bReserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog box includes an index number for duplicate instance names. For example, if there are two cmd instances, the instance list will contain cmd and cmd#1. If this flag is <b>FALSE</b>, duplicate instance names will not contain an index number.
+     * @type {Integer}
+     */
+    bIncludeInstanceIndex {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog returns only one counter. If this flag is <b>FALSE</b>, the dialog can return multiple selections, and wildcard selections are permitted. Selected counters are returned as a MULTI_SZ string.
+     * @type {Integer}
+     */
+    bSingleCounterPerAdd {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog box uses an OK and Cancel button. The dialog returns when the user clicks either button. If this flag is <b>FALSE</b>, the dialog box uses an Add and Close button. The dialog box closes when the user clicks the Close button. The Add button can be clicked multiple times. The Add button overwrites the previously selected items with the currently selected items.
+     * @type {Integer}
+     */
+    bSingleCounterPerDialog {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog box lets the user select counters only from the local computer (the path will not contain a computer name). If this flag is <b>FALSE</b>, the user can specify a computer from which to select counters. The computer name will prefix the counter path unless the user selects <b>Use local computer counters</b>.
+     * @type {Integer}
+     */
+    bLocalCountersOnly {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b> and the user selects <b>All instances</b>, the counter path will include the wildcard character for the instance field. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, and the user selects <b>All instances</b>, all the instances currently found for that object will be returned in a MULTI_SZ string.
+     * @type {Integer}
+     */
+    bWildCardInstances {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, this removes <b>Detail level</b> from the dialog box so the user cannot change the detail level of the counters displayed in the dialog box. The detail level will be fixed to the value of the <b>dwDefaultDetailLevel</b> member. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, this displays <b>Detail level</b> in the dialog box, allowing the user to change the detail level of the counters displayed. 
+     * 
+     * 
+     * 
+     * Note that the counters displayed will be those whose detail level is less than or equal to the current detail level selection. Selecting a detail level of Wizard will display all counters and objects.
+     * @type {Integer}
+     */
+    bHideDetailBox {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog highlights the counter and object specified in <b>szReturnPathBuffer</b> when the dialog box is first displayed, instead of using the default counter and object specified by the computer. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, this selects the initial counter and object using the default counter and object information returned by the computer.
+     * @type {Integer}
+     */
+    bInitializePath {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the user cannot select a computer from  <b>Select counters from computer</b>. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, the user can select a computer from <b>Select counters from computer</b>. This is the default value. 
+     * The list contains the local computer only unless you call the <a href="https://docs.microsoft.com/windows/desktop/api/pdh/nf-pdh-pdhconnectmachinea">PdhConnectMachine</a> to connect to other computers first.
+     * @type {Integer}
+     */
+    bDisableMachineSelection {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the counters list will also contain costly data—that is, data that requires a relatively large amount of processor time or memory overhead to collect. 
+     * 
+     * 
+     * If this flag is <b>FALSE</b>, the list will not contain costly counters. This is the default value.
+     * @type {Integer}
+     */
+    bIncludeCostlyObjects {
+        get => (this._bitfield >> 8) & 0x1
+        set => this._bitfield := ((value & 0x1) << 8) | (this._bitfield & ~(0x1 << 8))
+    }
+
+    /**
+     * If this flag is <b>TRUE</b>, the dialog lists only performance objects. When the user selects an object, the dialog returns a counter path that includes the object and wildcard characters for the instance name and counter if the object is a multiple instance object. For example, if the "Process" object is selected, the dialog returns the string "\Process(*)\*". If the object is a single instance object, the path contains a wildcard character for counter only. For example, "\System\*". You can then pass the path to <a href="https://docs.microsoft.com/windows/desktop/api/pdh/nf-pdh-pdhexpandwildcardpatha">PdhExpandWildCardPath</a> to retrieve a list of actual paths for the object.
+     * @type {Integer}
+     */
+    bShowObjectBrowser {
+        get => (this._bitfield >> 9) & 0x1
+        set => this._bitfield := ((value & 0x1) << 9) | (this._bitfield & ~(0x1 << 9))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    bReserved {
+        get => (this._bitfield >> 10) & 0x3FFFFF
+        set => this._bitfield := ((value & 0x3FFFFF) << 10) | (this._bitfield & ~(0x3FFFFF << 10))
     }
 
     /**

--- a/Windows/Win32/System/Power/PROCESSOR_POWER_POLICY.ahk
+++ b/Windows/Win32/System/Power/PROCESSOR_POWER_POLICY.ahk
@@ -46,11 +46,32 @@ class PROCESSOR_POWER_POLICY extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - DisableCStates
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 8, "uint")
         set => NumPut("uint", value, this, 8)
+    }
+
+    /**
+     * Reserved; set to zero.
+     * @type {Integer}
+     */
+    DisableCStates {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * Reserved; set to zero.
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 1) & 0x7FFFFFFF
+        set => this._bitfield := ((value & 0x7FFFFFFF) << 1) | (this._bitfield & ~(0x7FFFFFFF << 1))
     }
 
     /**

--- a/Windows/Win32/System/Power/PROCESSOR_POWER_POLICY_INFO.ahk
+++ b/Windows/Win32/System/Power/PROCESSOR_POWER_POLICY_INFO.ahk
@@ -71,10 +71,41 @@ class PROCESSOR_POWER_POLICY_INFO extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - AllowDemotion
+     * - AllowPromotion
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 16, "uint")
         set => NumPut("uint", value, this, 16)
+    }
+
+    /**
+     * When set, allows the kernel power policy manager to demote from the current state.
+     * @type {Integer}
+     */
+    AllowDemotion {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * When set, allows the kernel power policy manager to promote from the current state.
+     * @type {Integer}
+     */
+    AllowPromotion {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * Reserved.
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 2) & 0x3FFFFFFF
+        set => this._bitfield := ((value & 0x3FFFFFFF) << 2) | (this._bitfield & ~(0x3FFFFFFF << 2))
     }
 }

--- a/Windows/Win32/System/Rpc/MIDL_STUB_MESSAGE.ahk
+++ b/Windows/Win32/System/Rpc/MIDL_STUB_MESSAGE.ahk
@@ -302,11 +302,162 @@ class MIDL_STUB_MESSAGE extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - fInDontFree
+     * - fDontCallFreeInst
+     * - fUnused1
+     * - fHasReturn
+     * - fHasExtensions
+     * - fHasNewCorrDesc
+     * - fIsIn
+     * - fIsOut
+     * - fIsOicf
+     * - fBufferValid
+     * - fHasMemoryValidateCallback
+     * - fInFree
+     * - fNeedMCCP
+     * - fUnused2
+     * - fUnused3
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 192, "int")
         set => NumPut("int", value, this, 192)
+    }
+
+    /**
+     * Reserved.
+     * @type {Integer}
+     */
+    fInDontFree {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * Reserved.
+     * @type {Integer}
+     */
+    fDontCallFreeInst {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fUnused1 {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * Reserved.
+     * @type {Integer}
+     */
+    fHasReturn {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * Reserved.
+     * @type {Integer}
+     */
+    fHasExtensions {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * Reserved.
+     * @type {Integer}
+     */
+    fHasNewCorrDesc {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fIsIn {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fIsOut {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fIsOicf {
+        get => (this._bitfield >> 8) & 0x1
+        set => this._bitfield := ((value & 0x1) << 8) | (this._bitfield & ~(0x1 << 8))
+    }
+
+    /**
+     * Reserved.
+     * @type {Integer}
+     */
+    fBufferValid {
+        get => (this._bitfield >> 9) & 0x1
+        set => this._bitfield := ((value & 0x1) << 9) | (this._bitfield & ~(0x1 << 9))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fHasMemoryValidateCallback {
+        get => (this._bitfield >> 10) & 0x1
+        set => this._bitfield := ((value & 0x1) << 10) | (this._bitfield & ~(0x1 << 10))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fInFree {
+        get => (this._bitfield >> 11) & 0x1
+        set => this._bitfield := ((value & 0x1) << 11) | (this._bitfield & ~(0x1 << 11))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fNeedMCCP {
+        get => (this._bitfield >> 12) & 0x1
+        set => this._bitfield := ((value & 0x1) << 12) | (this._bitfield & ~(0x1 << 12))
+    }
+
+    /**
+     * Reserved.
+     * @type {Integer}
+     */
+    fUnused2 {
+        get => (this._bitfield >> 13) & 0x7
+        set => this._bitfield := ((value & 0x7) << 13) | (this._bitfield & ~(0x7 << 13))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fUnused3 {
+        get => (this._bitfield >> 16) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 16) | (this._bitfield & ~(0xFFFF << 16))
     }
 
     /**

--- a/Windows/Win32/System/SystemServices/IMAGE_ARCHITECTURE_HEADER.ahk
+++ b/Windows/Win32/System/SystemServices/IMAGE_ARCHITECTURE_HEADER.ahk
@@ -12,11 +12,48 @@ class IMAGE_ARCHITECTURE_HEADER extends Win32Struct
     static packingSize => 4
 
     /**
+     * This bitfield backs the following members:
+     * - AmaskValue
+     * - Anonymous1
+     * - AmaskShift
+     * - Anonymous2
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    AmaskValue {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Anonymous1 {
+        get => (this._bitfield >> 1) & 0x7F
+        set => this._bitfield := ((value & 0x7F) << 1) | (this._bitfield & ~(0x7F << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    AmaskShift {
+        get => (this._bitfield >> 8) & 0xFF
+        set => this._bitfield := ((value & 0xFF) << 8) | (this._bitfield & ~(0xFF << 8))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Anonymous2 {
+        get => (this._bitfield >> 16) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 16) | (this._bitfield & ~(0xFFFF << 16))
     }
 
     /**

--- a/Windows/Win32/System/SystemServices/IMAGE_CE_RUNTIME_FUNCTION_ENTRY.ahk
+++ b/Windows/Win32/System/SystemServices/IMAGE_CE_RUNTIME_FUNCTION_ENTRY.ahk
@@ -20,10 +20,47 @@ class IMAGE_CE_RUNTIME_FUNCTION_ENTRY extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - PrologLen
+     * - FuncLen
+     * - ThirtyTwoBit
+     * - ExceptionFlag
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 4, "uint")
         set => NumPut("uint", value, this, 4)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    PrologLen {
+        get => (this._bitfield >> 0) & 0xFF
+        set => this._bitfield := ((value & 0xFF) << 0) | (this._bitfield & ~(0xFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    FuncLen {
+        get => (this._bitfield >> 8) & 0x3FFFFF
+        set => this._bitfield := ((value & 0x3FFFFF) << 8) | (this._bitfield & ~(0x3FFFFF << 8))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ThirtyTwoBit {
+        get => (this._bitfield >> 30) & 0x1
+        set => this._bitfield := ((value & 0x1) << 30) | (this._bitfield & ~(0x1 << 30))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    ExceptionFlag {
+        get => (this._bitfield >> 31) & 0x1
+        set => this._bitfield := ((value & 0x1) << 31) | (this._bitfield & ~(0x1 << 31))
     }
 }

--- a/Windows/Win32/System/SystemServices/IMPORT_OBJECT_HEADER.ahk
+++ b/Windows/Win32/System/SystemServices/IMPORT_OBJECT_HEADER.ahk
@@ -76,10 +76,38 @@ class IMPORT_OBJECT_HEADER extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - Type
+     * - NameType
+     * - Reserved
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 18, "ushort")
         set => NumPut("ushort", value, this, 18)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Type {
+        get => (this._bitfield >> 0) & 0x3
+        set => this._bitfield := ((value & 0x3) << 0) | (this._bitfield & ~(0x3 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    NameType {
+        get => (this._bitfield >> 2) & 0x7
+        set => this._bitfield := ((value & 0x7) << 2) | (this._bitfield & ~(0x7 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Reserved {
+        get => (this._bitfield >> 5) & 0x7FF
+        set => this._bitfield := ((value & 0x7FF) << 5) | (this._bitfield & ~(0x7FF << 5))
     }
 }

--- a/Windows/Win32/System/WinRT/Metadata/IMAGE_COR_ILMETHOD_FAT.ahk
+++ b/Windows/Win32/System/WinRT/Metadata/IMAGE_COR_ILMETHOD_FAT.ahk
@@ -12,11 +12,39 @@ class IMAGE_COR_ILMETHOD_FAT extends Win32Struct
     static packingSize => 4
 
     /**
+     * This bitfield backs the following members:
+     * - Flags
+     * - Size
+     * - MaxStack
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 0, "uint")
         set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Flags {
+        get => (this._bitfield >> 0) & 0xFFF
+        set => this._bitfield := ((value & 0xFFF) << 0) | (this._bitfield & ~(0xFFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Size {
+        get => (this._bitfield >> 12) & 0xF
+        set => this._bitfield := ((value & 0xF) << 12) | (this._bitfield & ~(0xF << 12))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    MaxStack {
+        get => (this._bitfield >> 16) & 0xFFFF
+        set => this._bitfield := ((value & 0xFFFF) << 16) | (this._bitfield & ~(0xFFFF << 16))
     }
 
     /**

--- a/Windows/Win32/System/WinRT/Metadata/IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL.ahk
+++ b/Windows/Win32/System/WinRT/Metadata/IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL.ahk
@@ -12,6 +12,9 @@ class IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL extends Win32Struct
     static packingSize => 4
 
     /**
+     * This bitfield backs the following members:
+     * - Flags
+     * - TryOffset
      * @type {Integer}
      */
     _bitfield1 {
@@ -22,9 +25,53 @@ class IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL extends Win32Struct
     /**
      * @type {Integer}
      */
+    Flags {
+        get => (this._bitfield1 >> 0) & 0xFFFF
+        set => this._bitfield1 := ((value & 0xFFFF) << 0) | (this._bitfield1 & ~(0xFFFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    TryOffset {
+        get => (this._bitfield1 >> 16) & 0xFFFF
+        set => this._bitfield1 := ((value & 0xFFFF) << 16) | (this._bitfield1 & ~(0xFFFF << 16))
+    }
+
+    /**
+     * This bitfield backs the following members:
+     * - TryLength
+     * - HandlerOffset
+     * - HandlerLength
+     * @type {Integer}
+     */
     _bitfield2 {
         get => NumGet(this, 4, "uint")
         set => NumPut("uint", value, this, 4)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    TryLength {
+        get => (this._bitfield2 >> 0) & 0xFF
+        set => this._bitfield2 := ((value & 0xFF) << 0) | (this._bitfield2 & ~(0xFF << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    HandlerOffset {
+        get => (this._bitfield2 >> 8) & 0xFFFF
+        set => this._bitfield2 := ((value & 0xFFFF) << 8) | (this._bitfield2 & ~(0xFFFF << 8))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    HandlerLength {
+        get => (this._bitfield2 >> 24) & 0xFF
+        set => this._bitfield2 := ((value & 0xFF) << 24) | (this._bitfield2 & ~(0xFF << 24))
     }
 
     /**

--- a/Windows/Win32/UI/Controls/RichEdit/TABLECELLPARMS.ahk
+++ b/Windows/Win32/UI/Controls/RichEdit/TABLECELLPARMS.ahk
@@ -25,11 +25,72 @@ class TABLECELLPARMS extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - nVertAlign
+     * - fMergeTop
+     * - fMergePrev
+     * - fVertical
+     * - fMergeStart
+     * - fMergeCont
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 4, "ushort")
         set => NumPut("ushort", value, this, 4)
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    nVertAlign {
+        get => (this._bitfield >> 0) & 0x3
+        set => this._bitfield := ((value & 0x3) << 0) | (this._bitfield & ~(0x3 << 0))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fMergeTop {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fMergePrev {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fVertical {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fMergeStart {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fMergeCont {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
     }
 
     /**

--- a/Windows/Win32/UI/Controls/RichEdit/TABLEROWPARMS.ahk
+++ b/Windows/Win32/UI/Controls/RichEdit/TABLEROWPARMS.ahk
@@ -91,11 +91,72 @@ class TABLEROWPARMS extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - nAlignment
+     * - fRTL
+     * - fKeep
+     * - fKeepFollow
+     * - fWrap
+     * - fIdentCells
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 16, "uint")
         set => NumPut("uint", value, this, 16)
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    nAlignment {
+        get => (this._bitfield >> 0) & 0x7
+        set => this._bitfield := ((value & 0x7) << 0) | (this._bitfield & ~(0x7 << 0))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fRTL {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fKeep {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fKeepFollow {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fWrap {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * 
+     * @type {Integer}
+     */
+    fIdentCells {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
     }
 
     /**

--- a/Windows/Win32/UI/Input/Ime/WDD.ahk
+++ b/Windows/Win32/UI/Input/Ime/WDD.ahk
@@ -76,11 +76,75 @@ class WDD extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - fPhrase
+     * - fAutoCorrect
+     * - fNumericPrefix
+     * - fUserRegistered
+     * - fUnknown
+     * - fRecentUsed
+     * - Anonymous3
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 14, "ushort")
         set => NumPut("ushort", value, this, 14)
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fPhrase {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fAutoCorrect {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fNumericPrefix {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fUserRegistered {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fUnknown {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fRecentUsed {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    Anonymous3 {
+        get => (this._bitfield >> 6) & 0x3FF
+        set => this._bitfield := ((value & 0x3FF) << 6) | (this._bitfield & ~(0x3FF << 6))
     }
 
     /**

--- a/Windows/Win32/UI/Shell/BASEBROWSERDATALH.ahk
+++ b/Windows/Win32/UI/Shell/BASEBROWSERDATALH.ahk
@@ -94,11 +94,24 @@ class BASEBROWSERDATALH extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - _fCreatingViewWindow
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 52, "uint")
         set => NumPut("uint", value, this, 52)
+    }
+
+    /**
+     * Type: <b>UINT</b>
+     * 
+     * A view window is being created by the browser.
+     * @type {Integer}
+     */
+    _fCreatingViewWindow {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
     }
 
     /**

--- a/Windows/Win32/UI/Shell/BASEBROWSERDATAXP.ahk
+++ b/Windows/Win32/UI/Shell/BASEBROWSERDATAXP.ahk
@@ -94,11 +94,24 @@ class BASEBROWSERDATAXP extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - _fCreatingViewWindow
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 52, "uint")
         set => NumPut("uint", value, this, 52)
+    }
+
+    /**
+     * Type: <b>UINT</b>
+     * 
+     * A view window is being created by the browser.
+     * @type {Integer}
+     */
+    _fCreatingViewWindow {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
     }
 
     /**

--- a/Windows/Win32/UI/Shell/CABINETSTATE.ahk
+++ b/Windows/Win32/UI/Shell/CABINETSTATE.ahk
@@ -34,11 +34,124 @@ class CABINETSTATE extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - fFullPathTitle
+     * - fSaveLocalView
+     * - fNotShell
+     * - fSimpleDefault
+     * - fDontShowDescBar
+     * - fNewWindowMode
+     * - fShowCompColor
+     * - fDontPrettyNames
+     * - fAdminsCreateCommonGroups
+     * - fUnusedFlags
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 4, "int")
         set => NumPut("int", value, this, 4)
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * @type {Integer}
+     */
+    fFullPathTitle {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * @type {Integer}
+     */
+    fSaveLocalView {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * Not used.
+     * @type {Integer}
+     */
+    fNotShell {
+        get => (this._bitfield >> 2) & 0x1
+        set => this._bitfield := ((value & 0x1) << 2) | (this._bitfield & ~(0x1 << 2))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * Not used.
+     * @type {Integer}
+     */
+    fSimpleDefault {
+        get => (this._bitfield >> 3) & 0x1
+        set => this._bitfield := ((value & 0x1) << 3) | (this._bitfield & ~(0x1 << 3))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * Not used.
+     * @type {Integer}
+     */
+    fDontShowDescBar {
+        get => (this._bitfield >> 4) & 0x1
+        set => this._bitfield := ((value & 0x1) << 4) | (this._bitfield & ~(0x1 << 4))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * @type {Integer}
+     */
+    fNewWindowMode {
+        get => (this._bitfield >> 5) & 0x1
+        set => this._bitfield := ((value & 0x1) << 5) | (this._bitfield & ~(0x1 << 5))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * @type {Integer}
+     */
+    fShowCompColor {
+        get => (this._bitfield >> 6) & 0x1
+        set => this._bitfield := ((value & 0x1) << 6) | (this._bitfield & ~(0x1 << 6))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * Not used.
+     * @type {Integer}
+     */
+    fDontPrettyNames {
+        get => (this._bitfield >> 7) & 0x1
+        set => this._bitfield := ((value & 0x1) << 7) | (this._bitfield & ~(0x1 << 7))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * Used when an administrator installs an application that places an icon in the <b>Start</b> menu.
+     * @type {Integer}
+     */
+    fAdminsCreateCommonGroups {
+        get => (this._bitfield >> 8) & 0x1
+        set => this._bitfield := ((value & 0x1) << 8) | (this._bitfield & ~(0x1 << 8))
+    }
+
+    /**
+     * Type: <b>UINT</b>
+     * 
+     * Not used.
+     * @type {Integer}
+     */
+    fUnusedFlags {
+        get => (this._bitfield >> 9) & 0x7F
+        set => this._bitfield := ((value & 0x7F) << 9) | (this._bitfield & ~(0x7F << 9))
     }
 
     /**

--- a/Windows/Win32/UI/Shell/SHELLSTATEA.ahk
+++ b/Windows/Win32/UI/Shell/SHELLSTATEA.ahk
@@ -18,11 +18,216 @@ class SHELLSTATEA extends Win32Struct
     static packingSize => 4
 
     /**
+     * This bitfield backs the following members:
+     * - fShowAllObjects
+     * - fShowExtensions
+     * - fNoConfirmRecycle
+     * - fShowSysFiles
+     * - fShowCompColor
+     * - fDoubleClickInWebView
+     * - fDesktopHTML
+     * - fWin95Classic
+     * - fDontPrettyPath
+     * - fShowAttribCol
+     * - fMapNetDrvBtn
+     * - fShowInfoTip
+     * - fHideIcons
+     * - fWebView
+     * - fFilter
+     * - fShowSuperHidden
+     * - fNoNetCrawling
      * @type {Integer}
      */
     _bitfield1 {
         get => NumGet(this, 0, "int")
         set => NumPut("int", value, this, 0)
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show all objects, including hidden files and folders. <b>FALSE</b> to hide hidden files and folders.
+     * @type {Integer}
+     */
+    fShowAllObjects {
+        get => (this._bitfield1 >> 0) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 0) | (this._bitfield1 & ~(0x1 << 0))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show file name extensions, <b>FALSE</b> to hide them.
+     * @type {Integer}
+     */
+    fShowExtensions {
+        get => (this._bitfield1 >> 1) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 1) | (this._bitfield1 & ~(0x1 << 1))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show no confirmation dialog box when deleting items to the Recycle Bin, <b>FALSE</b> to display the confirmation dialog box.
+     * @type {Integer}
+     */
+    fNoConfirmRecycle {
+        get => (this._bitfield1 >> 2) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 2) | (this._bitfield1 & ~(0x1 << 2))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show system files, <b>FALSE</b> to hide them.
+     * @type {Integer}
+     */
+    fShowSysFiles {
+        get => (this._bitfield1 >> 3) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 3) | (this._bitfield1 & ~(0x1 << 3))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show encrypted or compressed NTFS files in color.
+     * @type {Integer}
+     */
+    fShowCompColor {
+        get => (this._bitfield1 >> 4) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 4) | (this._bitfield1 & ~(0x1 << 4))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to require a double-click to open an item when in web view.
+     * @type {Integer}
+     */
+    fDoubleClickInWebView {
+        get => (this._bitfield1 >> 5) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 5) | (this._bitfield1 & ~(0x1 << 5))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to use Active Desktop, <b>FALSE</b> otherwise.
+     * @type {Integer}
+     */
+    fDesktopHTML {
+        get => (this._bitfield1 >> 6) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 6) | (this._bitfield1 & ~(0x1 << 6))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to enforce Windows 95 Shell behavior and restrictions.
+     * @type {Integer}
+     */
+    fWin95Classic {
+        get => (this._bitfield1 >> 7) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 7) | (this._bitfield1 & ~(0x1 << 7))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to prevent the conversion of the path to all lowercase characters.
+     * @type {Integer}
+     */
+    fDontPrettyPath {
+        get => (this._bitfield1 >> 8) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 8) | (this._bitfield1 & ~(0x1 << 8))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * Not used.
+     * @type {Integer}
+     */
+    fShowAttribCol {
+        get => (this._bitfield1 >> 9) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 9) | (this._bitfield1 & ~(0x1 << 9))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to display a <b>Map Network Drive</b> button.
+     * @type {Integer}
+     */
+    fMapNetDrvBtn {
+        get => (this._bitfield1 >> 10) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 10) | (this._bitfield1 & ~(0x1 << 10))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show a pop-up description for folders and files.
+     * @type {Integer}
+     */
+    fShowInfoTip {
+        get => (this._bitfield1 >> 11) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 11) | (this._bitfield1 & ~(0x1 << 11))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to hide desktop icons, <b>FALSE</b> to show them.
+     * @type {Integer}
+     */
+    fHideIcons {
+        get => (this._bitfield1 >> 12) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 12) | (this._bitfield1 & ~(0x1 << 12))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to display as a web view.
+     * @type {Integer}
+     */
+    fWebView {
+        get => (this._bitfield1 >> 13) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 13) | (this._bitfield1 & ~(0x1 << 13))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * Not used.
+     * @type {Integer}
+     */
+    fFilter {
+        get => (this._bitfield1 >> 14) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 14) | (this._bitfield1 & ~(0x1 << 14))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show operating system files.
+     * @type {Integer}
+     */
+    fShowSuperHidden {
+        get => (this._bitfield1 >> 15) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 15) | (this._bitfield1 & ~(0x1 << 15))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to disable automatic searching for network folders and printers.
+     * @type {Integer}
+     */
+    fNoNetCrawling {
+        get => (this._bitfield1 >> 16) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 16) | (this._bitfield1 & ~(0x1 << 16))
     }
 
     /**
@@ -92,10 +297,107 @@ class SHELLSTATEA extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - fSepProcess
+     * - fStartPanelOn
+     * - fShowStartPage
+     * - fAutoCheckSelect
+     * - fIconsOnly
+     * - fShowTypeOverlay
+     * - fShowStatusBar
+     * - fSpareFlags
      * @type {Integer}
      */
     _bitfield2 {
         get => NumGet(this, 28, "int")
         set => NumPut("int", value, this, 28)
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to launch folder windows in separate processes, <b>FALSE</b> to launch in the same process.
+     * @type {Integer}
+     */
+    fSepProcess {
+        get => (this._bitfield2 >> 0) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 0) | (this._bitfield2 & ~(0x1 << 0))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>Windows XP only</b>. <b>TRUE</b> to use the Windows XP-style Start menu, <b>FALSE</b> to use the classic Start menu.
+     * @type {Integer}
+     */
+    fStartPanelOn {
+        get => (this._bitfield2 >> 1) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 1) | (this._bitfield2 & ~(0x1 << 1))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * Not used.
+     * @type {Integer}
+     */
+    fShowStartPage {
+        get => (this._bitfield2 >> 2) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 2) | (this._bitfield2 & ~(0x1 << 2))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>Introduced in Windows Vista</b>. <b>TRUE</b> to use the Windows Vista-style checkbox folder views, <b>FALSE</b> to use the classic views.
+     * @type {Integer}
+     */
+    fAutoCheckSelect {
+        get => (this._bitfield2 >> 3) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 3) | (this._bitfield2 & ~(0x1 << 3))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>Introduced in Windows Vista</b>. <b>TRUE</b> to show generic icons only, <b>FALSE</b> to show thumbnail-style icons in folders.
+     * @type {Integer}
+     */
+    fIconsOnly {
+        get => (this._bitfield2 >> 4) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 4) | (this._bitfield2 & ~(0x1 << 4))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>Introduced in Windows Vista</b>. <b>TRUE</b> indicates a thumbnail should show the application that would be invoked when opening the item, <b>FALSE</b> indicates that no application will be shown.
+     * @type {Integer}
+     */
+    fShowTypeOverlay {
+        get => (this._bitfield2 >> 5) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 5) | (this._bitfield2 & ~(0x1 << 5))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>Introduced in Windows 8</b>. <b>TRUE</b> to show the status bar; otherwise, <b>FALSE</b>.
+     * @type {Integer}
+     */
+    fShowStatusBar {
+        get => (this._bitfield2 >> 6) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 6) | (this._bitfield2 & ~(0x1 << 6))
+    }
+
+    /**
+     * Type: <b>UINT</b>
+     * 
+     * Not used.
+     * @type {Integer}
+     */
+    fSpareFlags {
+        get => (this._bitfield2 >> 7) & 0x1FF
+        set => this._bitfield2 := ((value & 0x1FF) << 7) | (this._bitfield2 & ~(0x1FF << 7))
     }
 }

--- a/Windows/Win32/UI/Shell/SHELLSTATEW.ahk
+++ b/Windows/Win32/UI/Shell/SHELLSTATEW.ahk
@@ -18,11 +18,216 @@ class SHELLSTATEW extends Win32Struct
     static packingSize => 4
 
     /**
+     * This bitfield backs the following members:
+     * - fShowAllObjects
+     * - fShowExtensions
+     * - fNoConfirmRecycle
+     * - fShowSysFiles
+     * - fShowCompColor
+     * - fDoubleClickInWebView
+     * - fDesktopHTML
+     * - fWin95Classic
+     * - fDontPrettyPath
+     * - fShowAttribCol
+     * - fMapNetDrvBtn
+     * - fShowInfoTip
+     * - fHideIcons
+     * - fWebView
+     * - fFilter
+     * - fShowSuperHidden
+     * - fNoNetCrawling
      * @type {Integer}
      */
     _bitfield1 {
         get => NumGet(this, 0, "int")
         set => NumPut("int", value, this, 0)
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show all objects, including hidden files and folders. <b>FALSE</b> to hide hidden files and folders.
+     * @type {Integer}
+     */
+    fShowAllObjects {
+        get => (this._bitfield1 >> 0) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 0) | (this._bitfield1 & ~(0x1 << 0))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show file name extensions, <b>FALSE</b> to hide them.
+     * @type {Integer}
+     */
+    fShowExtensions {
+        get => (this._bitfield1 >> 1) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 1) | (this._bitfield1 & ~(0x1 << 1))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show no confirmation dialog box when deleting items to the Recycle Bin, <b>FALSE</b> to display the confirmation dialog box.
+     * @type {Integer}
+     */
+    fNoConfirmRecycle {
+        get => (this._bitfield1 >> 2) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 2) | (this._bitfield1 & ~(0x1 << 2))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show system files, <b>FALSE</b> to hide them.
+     * @type {Integer}
+     */
+    fShowSysFiles {
+        get => (this._bitfield1 >> 3) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 3) | (this._bitfield1 & ~(0x1 << 3))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show encrypted or compressed NTFS files in color.
+     * @type {Integer}
+     */
+    fShowCompColor {
+        get => (this._bitfield1 >> 4) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 4) | (this._bitfield1 & ~(0x1 << 4))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to require a double-click to open an item when in web view.
+     * @type {Integer}
+     */
+    fDoubleClickInWebView {
+        get => (this._bitfield1 >> 5) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 5) | (this._bitfield1 & ~(0x1 << 5))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to use Active Desktop, <b>FALSE</b> otherwise.
+     * @type {Integer}
+     */
+    fDesktopHTML {
+        get => (this._bitfield1 >> 6) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 6) | (this._bitfield1 & ~(0x1 << 6))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to enforce Windows 95 Shell behavior and restrictions.
+     * @type {Integer}
+     */
+    fWin95Classic {
+        get => (this._bitfield1 >> 7) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 7) | (this._bitfield1 & ~(0x1 << 7))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to prevent the conversion of the path to all lowercase characters.
+     * @type {Integer}
+     */
+    fDontPrettyPath {
+        get => (this._bitfield1 >> 8) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 8) | (this._bitfield1 & ~(0x1 << 8))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * Not used.
+     * @type {Integer}
+     */
+    fShowAttribCol {
+        get => (this._bitfield1 >> 9) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 9) | (this._bitfield1 & ~(0x1 << 9))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to display a <b>Map Network Drive</b> button.
+     * @type {Integer}
+     */
+    fMapNetDrvBtn {
+        get => (this._bitfield1 >> 10) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 10) | (this._bitfield1 & ~(0x1 << 10))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show a pop-up description for folders and files.
+     * @type {Integer}
+     */
+    fShowInfoTip {
+        get => (this._bitfield1 >> 11) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 11) | (this._bitfield1 & ~(0x1 << 11))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to hide desktop icons, <b>FALSE</b> to show them.
+     * @type {Integer}
+     */
+    fHideIcons {
+        get => (this._bitfield1 >> 12) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 12) | (this._bitfield1 & ~(0x1 << 12))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to display as a web view.
+     * @type {Integer}
+     */
+    fWebView {
+        get => (this._bitfield1 >> 13) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 13) | (this._bitfield1 & ~(0x1 << 13))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * Not used.
+     * @type {Integer}
+     */
+    fFilter {
+        get => (this._bitfield1 >> 14) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 14) | (this._bitfield1 & ~(0x1 << 14))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to show operating system files.
+     * @type {Integer}
+     */
+    fShowSuperHidden {
+        get => (this._bitfield1 >> 15) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 15) | (this._bitfield1 & ~(0x1 << 15))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to disable automatic searching for network folders and printers.
+     * @type {Integer}
+     */
+    fNoNetCrawling {
+        get => (this._bitfield1 >> 16) & 0x1
+        set => this._bitfield1 := ((value & 0x1) << 16) | (this._bitfield1 & ~(0x1 << 16))
     }
 
     /**
@@ -92,10 +297,107 @@ class SHELLSTATEW extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - fSepProcess
+     * - fStartPanelOn
+     * - fShowStartPage
+     * - fAutoCheckSelect
+     * - fIconsOnly
+     * - fShowTypeOverlay
+     * - fShowStatusBar
+     * - fSpareFlags
      * @type {Integer}
      */
     _bitfield2 {
         get => NumGet(this, 28, "int")
         set => NumPut("int", value, this, 28)
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>TRUE</b> to launch folder windows in separate processes, <b>FALSE</b> to launch in the same process.
+     * @type {Integer}
+     */
+    fSepProcess {
+        get => (this._bitfield2 >> 0) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 0) | (this._bitfield2 & ~(0x1 << 0))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>Windows XP only</b>. <b>TRUE</b> to use the Windows XP-style Start menu, <b>FALSE</b> to use the classic Start menu.
+     * @type {Integer}
+     */
+    fStartPanelOn {
+        get => (this._bitfield2 >> 1) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 1) | (this._bitfield2 & ~(0x1 << 1))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * Not used.
+     * @type {Integer}
+     */
+    fShowStartPage {
+        get => (this._bitfield2 >> 2) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 2) | (this._bitfield2 & ~(0x1 << 2))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>Introduced in Windows Vista</b>. <b>TRUE</b> to use the Windows Vista-style checkbox folder views, <b>FALSE</b> to use the classic views.
+     * @type {Integer}
+     */
+    fAutoCheckSelect {
+        get => (this._bitfield2 >> 3) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 3) | (this._bitfield2 & ~(0x1 << 3))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>Introduced in Windows Vista</b>. <b>TRUE</b> to show generic icons only, <b>FALSE</b> to show thumbnail-style icons in folders.
+     * @type {Integer}
+     */
+    fIconsOnly {
+        get => (this._bitfield2 >> 4) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 4) | (this._bitfield2 & ~(0x1 << 4))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>Introduced in Windows Vista</b>. <b>TRUE</b> indicates a thumbnail should show the application that would be invoked when opening the item, <b>FALSE</b> indicates that no application will be shown.
+     * @type {Integer}
+     */
+    fShowTypeOverlay {
+        get => (this._bitfield2 >> 5) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 5) | (this._bitfield2 & ~(0x1 << 5))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * <b>Introduced in Windows 8</b>. <b>TRUE</b> to show the status bar; otherwise, <b>FALSE</b>.
+     * @type {Integer}
+     */
+    fShowStatusBar {
+        get => (this._bitfield2 >> 6) & 0x1
+        set => this._bitfield2 := ((value & 0x1) << 6) | (this._bitfield2 & ~(0x1 << 6))
+    }
+
+    /**
+     * Type: <b>UINT</b>
+     * 
+     * Not used.
+     * @type {Integer}
+     */
+    fSpareFlags {
+        get => (this._bitfield2 >> 7) & 0x1FF
+        set => this._bitfield2 := ((value & 0x1FF) << 7) | (this._bitfield2 & ~(0x1FF << 7))
     }
 }

--- a/Windows/Win32/UI/WindowsAndMessaging/MENUBARINFO.ahk
+++ b/Windows/Win32/UI/WindowsAndMessaging/MENUBARINFO.ahk
@@ -62,11 +62,45 @@ class MENUBARINFO extends Win32Struct
     }
 
     /**
+     * This bitfield backs the following members:
+     * - fBarFocused
+     * - fFocused
+     * - fUnused
      * @type {Integer}
      */
     _bitfield {
         get => NumGet(this, 40, "int")
         set => NumPut("int", value, this, 40)
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * If the menu bar or popup menu has the focus, this member is <b>TRUE</b>. Otherwise, the member is <b>FALSE</b>.
+     * @type {Integer}
+     */
+    fBarFocused {
+        get => (this._bitfield >> 0) & 0x1
+        set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
+    }
+
+    /**
+     * Type: <b>BOOL</b>
+     * 
+     * If the menu item has the focus, this member is <b>TRUE</b>. Otherwise, the member is <b>FALSE</b>.
+     * @type {Integer}
+     */
+    fFocused {
+        get => (this._bitfield >> 1) & 0x1
+        set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
+    }
+
+    /**
+     * @type {Integer}
+     */
+    fUnused {
+        get => (this._bitfield >> 2) & 0x3FFFFFFF
+        set => this._bitfield := ((value & 0x3FFFFFFF) << 2) | (this._bitfield & ~(0x3FFFFFFF << 2))
     }
 
     /**


### PR DESCRIPTION
Parse the `[NativeBitfield]` attribute on struct members and create properties that get and set bits accordingly. For example, this ([`MENUBARINFO`](https://github.com/holy-tao/AhkWin32Projection/blob/492dc6734bb8ebfa581a7c646c2f3e5270d23d46/Windows/Win32/UI/WindowsAndMessaging/MENUBARINFO.ahk)):

```c#
[NativeBitfield("fBarFocused", 0L, 1L)]
[NativeBitfield("fFocused", 1L, 1L)]
[NativeBitfield("fUnused", 2L, 30L)]
public int _bitfield;
```

Becomes:
```autohotkey v2
/**
 * This bitfield backs the following members:
 * - fBarFocused
 * - fFocused
 * - fUnused
 * @type {Integer}
 */
_bitfield {
    get => NumGet(this, 40, "int")
    set => NumPut("int", value, this, 40)
}

/**
 * Type: <b>BOOL</b>
 * 
 * If the menu bar or popup menu has the focus, this member is <b>TRUE</b>. Otherwise, the member is <b>FALSE</b>.
 * @type {Integer}
 */
fBarFocused {
    get => (this._bitfield >> 0) & 0x1
    set => this._bitfield := ((value & 0x1) << 0) | (this._bitfield & ~(0x1 << 0))
}

/**
 * Type: <b>BOOL</b>
 * 
 * If the menu item has the focus, this member is <b>TRUE</b>. Otherwise, the member is <b>FALSE</b>.
 * @type {Integer}
 */
fFocused {
    get => (this._bitfield >> 1) & 0x1
    set => this._bitfield := ((value & 0x1) << 1) | (this._bitfield & ~(0x1 << 1))
}
```