### PR TITLE
Feature/use bindings for entrypoints

### DIFF
--- a/Windows/Win32/Data/HtmlHelp/Apis.ahk
+++ b/Windows/Win32/Data/HtmlHelp/Apis.ahk
@@ -1263,7 +1263,7 @@ class HtmlHelp {
     static HtmlHelpA(hwndCaller, pszFile, uCommand, dwData) {
         pszFile := pszFile is String? StrPtr(pszFile) : pszFile
 
-        result := DllCall("hhctrl.ocx\HtmlHelpA", "ptr", hwndCaller, "ptr", pszFile, "uint", uCommand, "ptr", dwData)
+        result := DllCall("hhctrl.ocx\HtmlHelpA", "ptr", hwndCaller, "ptr", pszFile, "uint", uCommand, "ptr", dwData, "ptr")
         return result
     }
 
@@ -1300,7 +1300,7 @@ class HtmlHelp {
     static HtmlHelpW(hwndCaller, pszFile, uCommand, dwData) {
         pszFile := pszFile is String? StrPtr(pszFile) : pszFile
 
-        result := DllCall("hhctrl.ocx\HtmlHelpW", "ptr", hwndCaller, "ptr", pszFile, "uint", uCommand, "ptr", dwData)
+        result := DllCall("hhctrl.ocx\HtmlHelpW", "ptr", hwndCaller, "ptr", pszFile, "uint", uCommand, "ptr", dwData, "ptr")
         return result
     }
 

--- a/Windows/Win32/Devices/Bluetooth/Apis.ahk
+++ b/Windows/Win32/Devices/Bluetooth/Apis.ahk
@@ -4229,7 +4229,7 @@ class Bluetooth {
     static BluetoothFindFirstRadio(pbtfrp, phRadio) {
         A_LastError := 0
 
-        result := DllCall("BluetoothApis.dll\BluetoothFindFirstRadio", "uint*", pbtfrp, "ptr", phRadio)
+        result := DllCall("BluetoothApis.dll\BluetoothFindFirstRadio", "uint*", pbtfrp, "ptr", phRadio, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4418,7 +4418,7 @@ class Bluetooth {
     static BluetoothFindFirstDevice(pbtsp, pbtdi) {
         A_LastError := 0
 
-        result := DllCall("BluetoothApis.dll\BluetoothFindFirstDevice", "ptr", pbtsp, "ptr", pbtdi)
+        result := DllCall("BluetoothApis.dll\BluetoothFindFirstDevice", "ptr", pbtsp, "ptr", pbtdi, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/Devices/Communication/Apis.ahk
+++ b/Windows/Win32/Devices/Communication/Apis.ahk
@@ -1046,7 +1046,7 @@ class Communication {
      * @since windows10.0.16299
      */
     static OpenCommPort(uPortNumber, dwDesiredAccess, dwFlagsAndAttributes) {
-        result := DllCall("api-ms-win-core-comm-l1-1-1.dll\OpenCommPort", "uint", uPortNumber, "uint", dwDesiredAccess, "uint", dwFlagsAndAttributes)
+        result := DllCall("api-ms-win-core-comm-l1-1-1.dll\OpenCommPort", "uint", uPortNumber, "uint", dwDesiredAccess, "uint", dwFlagsAndAttributes, "ptr")
         return result
     }
 

--- a/Windows/Win32/Devices/DeviceAndDriverInstallation/Apis.ahk
+++ b/Windows/Win32/Devices/DeviceAndDriverInstallation/Apis.ahk
@@ -5844,7 +5844,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupOpenInfFileW", "ptr", FileName, "ptr", InfClass, "uint", InfStyle, "uint*", ErrorLine)
+        result := DllCall("SETUPAPI.dll\SetupOpenInfFileW", "ptr", FileName, "ptr", InfClass, "uint", InfStyle, "uint*", ErrorLine, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5887,7 +5887,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupOpenInfFileA", "ptr", FileName, "ptr", InfClass, "uint", InfStyle, "uint*", ErrorLine)
+        result := DllCall("SETUPAPI.dll\SetupOpenInfFileA", "ptr", FileName, "ptr", InfClass, "uint", InfStyle, "uint*", ErrorLine, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5905,7 +5905,7 @@ class DeviceAndDriverInstallation {
     static SetupOpenMasterInf() {
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupOpenMasterInf")
+        result := DllCall("SETUPAPI.dll\SetupOpenMasterInf", "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -8296,7 +8296,7 @@ class DeviceAndDriverInstallation {
     static SetupOpenFileQueue() {
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupOpenFileQueue")
+        result := DllCall("SETUPAPI.dll\SetupOpenFileQueue", "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -10038,7 +10038,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupCreateDiskSpaceListA", "ptr", Reserved1, "uint", Reserved2, "uint", Flags)
+        result := DllCall("SETUPAPI.dll\SetupCreateDiskSpaceListA", "ptr", Reserved1, "uint", Reserved2, "uint", Flags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -10063,7 +10063,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupCreateDiskSpaceListW", "ptr", Reserved1, "uint", Reserved2, "uint", Flags)
+        result := DllCall("SETUPAPI.dll\SetupCreateDiskSpaceListW", "ptr", Reserved1, "uint", Reserved2, "uint", Flags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -10089,7 +10089,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupDuplicateDiskSpaceListA", "ptr", DiskSpace, "ptr", Reserved1, "uint", Reserved2, "uint", Flags)
+        result := DllCall("SETUPAPI.dll\SetupDuplicateDiskSpaceListA", "ptr", DiskSpace, "ptr", Reserved1, "uint", Reserved2, "uint", Flags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -10115,7 +10115,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupDuplicateDiskSpaceListW", "ptr", DiskSpace, "ptr", Reserved1, "uint", Reserved2, "uint", Flags)
+        result := DllCall("SETUPAPI.dll\SetupDuplicateDiskSpaceListW", "ptr", DiskSpace, "ptr", Reserved1, "uint", Reserved2, "uint", Flags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -10981,7 +10981,7 @@ class DeviceAndDriverInstallation {
     static SetupInitDefaultQueueCallback(OwnerWindow) {
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupInitDefaultQueueCallback", "ptr", OwnerWindow)
+        result := DllCall("SETUPAPI.dll\SetupInitDefaultQueueCallback", "ptr", OwnerWindow, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11012,7 +11012,7 @@ class DeviceAndDriverInstallation {
     static SetupInitDefaultQueueCallbackEx(OwnerWindow, AlternateProgressWindow, ProgressMessage) {
         static Reserved1 := 0, Reserved2 := 0 ;Reserved parameters must always be NULL
 
-        result := DllCall("SETUPAPI.dll\SetupInitDefaultQueueCallbackEx", "ptr", OwnerWindow, "ptr", AlternateProgressWindow, "uint", ProgressMessage, "uint", Reserved1, "ptr", Reserved2)
+        result := DllCall("SETUPAPI.dll\SetupInitDefaultQueueCallbackEx", "ptr", OwnerWindow, "ptr", AlternateProgressWindow, "uint", ProgressMessage, "uint", Reserved1, "ptr", Reserved2, "ptr")
         return result
     }
 
@@ -12813,7 +12813,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupInitializeFileLogA", "ptr", LogFileName, "uint", Flags)
+        result := DllCall("SETUPAPI.dll\SetupInitializeFileLogA", "ptr", LogFileName, "uint", Flags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12837,7 +12837,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupInitializeFileLogW", "ptr", LogFileName, "uint", Flags)
+        result := DllCall("SETUPAPI.dll\SetupInitializeFileLogW", "ptr", LogFileName, "uint", Flags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -16351,7 +16351,7 @@ class DeviceAndDriverInstallation {
     static SetupDiOpenClassRegKey(ClassGuid, samDesired) {
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupDiOpenClassRegKey", "ptr", ClassGuid, "uint", samDesired)
+        result := DllCall("SETUPAPI.dll\SetupDiOpenClassRegKey", "ptr", ClassGuid, "uint", samDesired, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -16393,7 +16393,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupDiOpenClassRegKeyExA", "ptr", ClassGuid, "uint", samDesired, "uint", Flags, "ptr", MachineName, "ptr", Reserved)
+        result := DllCall("SETUPAPI.dll\SetupDiOpenClassRegKeyExA", "ptr", ClassGuid, "uint", samDesired, "uint", Flags, "ptr", MachineName, "ptr", Reserved, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -16435,7 +16435,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupDiOpenClassRegKeyExW", "ptr", ClassGuid, "uint", samDesired, "uint", Flags, "ptr", MachineName, "ptr", Reserved)
+        result := DllCall("SETUPAPI.dll\SetupDiOpenClassRegKeyExW", "ptr", ClassGuid, "uint", samDesired, "uint", Flags, "ptr", MachineName, "ptr", Reserved, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -16477,7 +16477,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupDiCreateDeviceInterfaceRegKeyA", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "uint", Reserved, "uint", samDesired, "ptr", InfHandle, "ptr", InfSectionName)
+        result := DllCall("SETUPAPI.dll\SetupDiCreateDeviceInterfaceRegKeyA", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "uint", Reserved, "uint", samDesired, "ptr", InfHandle, "ptr", InfSectionName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -16519,7 +16519,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupDiCreateDeviceInterfaceRegKeyW", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "uint", Reserved, "uint", samDesired, "ptr", InfHandle, "ptr", InfSectionName)
+        result := DllCall("SETUPAPI.dll\SetupDiCreateDeviceInterfaceRegKeyW", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "uint", Reserved, "uint", samDesired, "ptr", InfHandle, "ptr", InfSectionName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -16544,7 +16544,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupDiOpenDeviceInterfaceRegKey", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "uint", Reserved, "uint", samDesired)
+        result := DllCall("SETUPAPI.dll\SetupDiOpenDeviceInterfaceRegKey", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "uint", Reserved, "uint", samDesired, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -16614,7 +16614,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupDiCreateDevRegKeyA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Scope, "uint", HwProfile, "uint", KeyType, "ptr", InfHandle, "ptr", InfSectionName)
+        result := DllCall("SETUPAPI.dll\SetupDiCreateDevRegKeyA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Scope, "uint", HwProfile, "uint", KeyType, "ptr", InfHandle, "ptr", InfSectionName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -16658,7 +16658,7 @@ class DeviceAndDriverInstallation {
 
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupDiCreateDevRegKeyW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Scope, "uint", HwProfile, "uint", KeyType, "ptr", InfHandle, "ptr", InfSectionName)
+        result := DllCall("SETUPAPI.dll\SetupDiCreateDevRegKeyW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Scope, "uint", HwProfile, "uint", KeyType, "ptr", InfHandle, "ptr", InfSectionName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -16703,7 +16703,7 @@ class DeviceAndDriverInstallation {
     static SetupDiOpenDevRegKey(DeviceInfoSet, DeviceInfoData, Scope, HwProfile, KeyType, samDesired) {
         A_LastError := 0
 
-        result := DllCall("SETUPAPI.dll\SetupDiOpenDevRegKey", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Scope, "uint", HwProfile, "uint", KeyType, "uint", samDesired)
+        result := DllCall("SETUPAPI.dll\SetupDiOpenDevRegKey", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Scope, "uint", HwProfile, "uint", KeyType, "uint", samDesired, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -20446,7 +20446,7 @@ class DeviceAndDriverInstallation {
      * @returns {Pointer<Void>} 
      */
     static SetupDiGetWizardPage(DeviceInfoSet, DeviceInfoData, InstallWizardData, PageType, Flags) {
-        result := DllCall("SETUPAPI.dll\SetupDiGetWizardPage", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", InstallWizardData, "uint", PageType, "uint", Flags)
+        result := DllCall("SETUPAPI.dll\SetupDiGetWizardPage", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", InstallWizardData, "uint", PageType, "uint", Flags, "ptr")
         return result
     }
 

--- a/Windows/Win32/Devices/Display/Apis.ahk
+++ b/Windows/Win32/Devices/Display/Apis.ahk
@@ -4638,7 +4638,7 @@ class Display {
      * @since windows5.0
      */
     static BRUSHOBJ_pvAllocRbrush(pbo, cj) {
-        result := DllCall("GDI32.dll\BRUSHOBJ_pvAllocRbrush", "ptr", pbo, "uint", cj)
+        result := DllCall("GDI32.dll\BRUSHOBJ_pvAllocRbrush", "ptr", pbo, "uint", cj, "ptr")
         return result
     }
 
@@ -4654,7 +4654,7 @@ class Display {
      * @since windows5.0
      */
     static BRUSHOBJ_pvGetRbrush(pbo) {
-        result := DllCall("GDI32.dll\BRUSHOBJ_pvGetRbrush", "ptr", pbo)
+        result := DllCall("GDI32.dll\BRUSHOBJ_pvGetRbrush", "ptr", pbo, "ptr")
         return result
     }
 
@@ -4684,7 +4684,7 @@ class Display {
      * @since windows5.0
      */
     static BRUSHOBJ_hGetColorTransform(pbo) {
-        result := DllCall("GDI32.dll\BRUSHOBJ_hGetColorTransform", "ptr", pbo)
+        result := DllCall("GDI32.dll\BRUSHOBJ_hGetColorTransform", "ptr", pbo, "ptr")
         return result
     }
 
@@ -4921,7 +4921,7 @@ class Display {
      * @since windows5.0
      */
     static FONTOBJ_pvTrueTypeFontFile(pfo, pcjFile) {
-        result := DllCall("GDI32.dll\FONTOBJ_pvTrueTypeFontFile", "ptr", pfo, "uint*", pcjFile)
+        result := DllCall("GDI32.dll\FONTOBJ_pvTrueTypeFontFile", "ptr", pfo, "uint*", pcjFile, "ptr")
         return result
     }
 
@@ -5338,7 +5338,7 @@ class Display {
      * @since windows5.0
      */
     static XLATEOBJ_hGetColorTransform(pxlo) {
-        result := DllCall("GDI32.dll\XLATEOBJ_hGetColorTransform", "ptr", pxlo)
+        result := DllCall("GDI32.dll\XLATEOBJ_hGetColorTransform", "ptr", pxlo, "ptr")
         return result
     }
 
@@ -5364,7 +5364,7 @@ class Display {
      * @since windows5.0
      */
     static EngCreateBitmap(sizl, lWidth, iFormat, fl, pvBits) {
-        result := DllCall("GDI32.dll\EngCreateBitmap", "ptr", sizl, "int", lWidth, "uint", iFormat, "uint", fl, "ptr", pvBits)
+        result := DllCall("GDI32.dll\EngCreateBitmap", "ptr", sizl, "int", lWidth, "uint", iFormat, "uint", fl, "ptr", pvBits, "ptr")
         return result
     }
 
@@ -5380,7 +5380,7 @@ class Display {
      * @since windows5.0
      */
     static EngCreateDeviceSurface(dhsurf, sizl, iFormatCompat) {
-        result := DllCall("GDI32.dll\EngCreateDeviceSurface", "ptr", dhsurf, "ptr", sizl, "uint", iFormatCompat)
+        result := DllCall("GDI32.dll\EngCreateDeviceSurface", "ptr", dhsurf, "ptr", sizl, "uint", iFormatCompat, "ptr")
         return result
     }
 
@@ -5396,7 +5396,7 @@ class Display {
      * @since windows5.0
      */
     static EngCreateDeviceBitmap(dhsurf, sizl, iFormatCompat) {
-        result := DllCall("GDI32.dll\EngCreateDeviceBitmap", "ptr", dhsurf, "ptr", sizl, "uint", iFormatCompat)
+        result := DllCall("GDI32.dll\EngCreateDeviceBitmap", "ptr", dhsurf, "ptr", sizl, "uint", iFormatCompat, "ptr")
         return result
     }
 
@@ -5541,7 +5541,7 @@ class Display {
      * @since windows5.0
      */
     static EngCreatePalette(iMode, cColors, pulColors, flRed, flGreen, flBlue) {
-        result := DllCall("GDI32.dll\EngCreatePalette", "uint", iMode, "uint", cColors, "uint*", pulColors, "uint", flRed, "uint", flGreen, "uint", flBlue)
+        result := DllCall("GDI32.dll\EngCreatePalette", "uint", iMode, "uint", cColors, "uint*", pulColors, "uint", flRed, "uint", flGreen, "uint", flBlue, "ptr")
         return result
     }
 
@@ -6251,7 +6251,7 @@ class Display {
     static EngLoadModule(pwsz) {
         pwsz := pwsz is String? StrPtr(pwsz) : pwsz
 
-        result := DllCall("GDI32.dll\EngLoadModule", "ptr", pwsz)
+        result := DllCall("GDI32.dll\EngLoadModule", "ptr", pwsz, "ptr")
         return result
     }
 
@@ -6268,7 +6268,7 @@ class Display {
      * @since windows5.0
      */
     static EngFindResource(h, iName, iType, pulSize) {
-        result := DllCall("GDI32.dll\EngFindResource", "ptr", h, "int", iName, "int", iType, "uint*", pulSize)
+        result := DllCall("GDI32.dll\EngFindResource", "ptr", h, "int", iName, "int", iType, "uint*", pulSize, "ptr")
         return result
     }
 
@@ -6305,7 +6305,7 @@ class Display {
      * @since windows5.0
      */
     static EngCreateSemaphore() {
-        result := DllCall("GDI32.dll\EngCreateSemaphore")
+        result := DllCall("GDI32.dll\EngCreateSemaphore", "ptr")
         return result
     }
 

--- a/Windows/Win32/Devices/WebServicesOnDevices/Apis.ahk
+++ b/Windows/Win32/Devices/WebServicesOnDevices/Apis.ahk
@@ -1390,7 +1390,7 @@ class WebServicesOnDevices {
      * @since windows6.0.6000
      */
     static WSDAllocateLinkedMemory(pParent, cbSize) {
-        result := DllCall("wsdapi.dll\WSDAllocateLinkedMemory", "ptr", pParent, "ptr", cbSize)
+        result := DllCall("wsdapi.dll\WSDAllocateLinkedMemory", "ptr", pParent, "ptr", cbSize, "ptr")
         return result
     }
 

--- a/Windows/Win32/Foundation/Apis.ahk
+++ b/Windows/Win32/Foundation/Apis.ahk
@@ -35415,7 +35415,7 @@ class Foundation {
     static GlobalFree(hMem) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\GlobalFree", "ptr", hMem)
+        result := DllCall("KERNEL32.dll\GlobalFree", "ptr", hMem, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -35452,7 +35452,7 @@ class Foundation {
     static LocalFree(hMem) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\LocalFree", "ptr", hMem)
+        result := DllCall("KERNEL32.dll\LocalFree", "ptr", hMem, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/Graphics/Gdi/Apis.ahk
+++ b/Windows/Win32/Graphics/Gdi/Apis.ahk
@@ -4547,7 +4547,7 @@ class Gdi {
      * @since windows5.0
      */
     static CloseMetaFile(hdc) {
-        result := DllCall("GDI32.dll\CloseMetaFile", "ptr", hdc)
+        result := DllCall("GDI32.dll\CloseMetaFile", "ptr", hdc, "ptr")
         return result
     }
 
@@ -4643,7 +4643,7 @@ class Gdi {
     static CopyMetaFileA(param0, param1) {
         param1 := param1 is String? StrPtr(param1) : param1
 
-        result := DllCall("GDI32.dll\CopyMetaFileA", "ptr", param0, "ptr", param1)
+        result := DllCall("GDI32.dll\CopyMetaFileA", "ptr", param0, "ptr", param1, "ptr")
         return result
     }
 
@@ -4671,7 +4671,7 @@ class Gdi {
     static CopyMetaFileW(param0, param1) {
         param1 := param1 is String? StrPtr(param1) : param1
 
-        result := DllCall("GDI32.dll\CopyMetaFileW", "ptr", param0, "ptr", param1)
+        result := DllCall("GDI32.dll\CopyMetaFileW", "ptr", param0, "ptr", param1, "ptr")
         return result
     }
 
@@ -4727,7 +4727,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateBitmap(nWidth, nHeight, nPlanes, nBitCount, lpBits) {
-        result := DllCall("GDI32.dll\CreateBitmap", "int", nWidth, "int", nHeight, "uint", nPlanes, "uint", nBitCount, "ptr", lpBits)
+        result := DllCall("GDI32.dll\CreateBitmap", "int", nWidth, "int", nHeight, "uint", nPlanes, "uint", nBitCount, "ptr", lpBits, "ptr")
         return result
     }
 
@@ -4782,7 +4782,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateBitmapIndirect(pbm) {
-        result := DllCall("GDI32.dll\CreateBitmapIndirect", "ptr", pbm)
+        result := DllCall("GDI32.dll\CreateBitmapIndirect", "ptr", pbm, "ptr")
         return result
     }
 
@@ -4806,7 +4806,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateBrushIndirect(plbrush) {
-        result := DllCall("GDI32.dll\CreateBrushIndirect", "ptr", plbrush)
+        result := DllCall("GDI32.dll\CreateBrushIndirect", "ptr", plbrush, "ptr")
         return result
     }
 
@@ -4844,7 +4844,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateCompatibleBitmap(hdc, cx, cy) {
-        result := DllCall("GDI32.dll\CreateCompatibleBitmap", "ptr", hdc, "int", cx, "int", cy)
+        result := DllCall("GDI32.dll\CreateCompatibleBitmap", "ptr", hdc, "int", cx, "int", cy, "ptr")
         return result
     }
 
@@ -4862,7 +4862,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateDiscardableBitmap(hdc, cx, cy) {
-        result := DllCall("GDI32.dll\CreateDiscardableBitmap", "ptr", hdc, "int", cx, "int", cy)
+        result := DllCall("GDI32.dll\CreateDiscardableBitmap", "ptr", hdc, "int", cx, "int", cy, "ptr")
         return result
     }
 
@@ -4888,7 +4888,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateCompatibleDC(hdc) {
-        result := DllCall("GDI32.dll\CreateCompatibleDC", "ptr", hdc)
+        result := DllCall("GDI32.dll\CreateCompatibleDC", "ptr", hdc, "ptr")
         return result
     }
 
@@ -4931,7 +4931,7 @@ class Gdi {
         pwszDevice := pwszDevice is String? StrPtr(pwszDevice) : pwszDevice
         pszPort := pszPort is String? StrPtr(pszPort) : pszPort
 
-        result := DllCall("GDI32.dll\CreateDCA", "ptr", pwszDriver, "ptr", pwszDevice, "ptr", pszPort, "ptr", pdm)
+        result := DllCall("GDI32.dll\CreateDCA", "ptr", pwszDriver, "ptr", pwszDevice, "ptr", pszPort, "ptr", pdm, "ptr")
         return result
     }
 
@@ -4974,7 +4974,7 @@ class Gdi {
         pwszDevice := pwszDevice is String? StrPtr(pwszDevice) : pwszDevice
         pszPort := pszPort is String? StrPtr(pszPort) : pszPort
 
-        result := DllCall("GDI32.dll\CreateDCW", "ptr", pwszDriver, "ptr", pwszDevice, "ptr", pszPort, "ptr", pdm)
+        result := DllCall("GDI32.dll\CreateDCW", "ptr", pwszDriver, "ptr", pwszDevice, "ptr", pszPort, "ptr", pdm, "ptr")
         return result
     }
 
@@ -5027,7 +5027,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateDIBitmap(hdc, pbmih, flInit, pjBits, pbmi, iUsage) {
-        result := DllCall("GDI32.dll\CreateDIBitmap", "ptr", hdc, "ptr", pbmih, "uint", flInit, "ptr", pjBits, "ptr", pbmi, "uint", iUsage)
+        result := DllCall("GDI32.dll\CreateDIBitmap", "ptr", hdc, "ptr", pbmih, "uint", flInit, "ptr", pjBits, "ptr", pbmi, "uint", iUsage, "ptr")
         return result
     }
 
@@ -5048,7 +5048,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateDIBPatternBrush(h, iUsage) {
-        result := DllCall("GDI32.dll\CreateDIBPatternBrush", "ptr", h, "uint", iUsage)
+        result := DllCall("GDI32.dll\CreateDIBPatternBrush", "ptr", h, "uint", iUsage, "ptr")
         return result
     }
 
@@ -5071,7 +5071,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateDIBPatternBrushPt(lpPackedDIB, iUsage) {
-        result := DllCall("GDI32.dll\CreateDIBPatternBrushPt", "ptr", lpPackedDIB, "uint", iUsage)
+        result := DllCall("GDI32.dll\CreateDIBPatternBrushPt", "ptr", lpPackedDIB, "uint", iUsage, "ptr")
         return result
     }
 
@@ -5092,7 +5092,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateEllipticRgn(x1, y1, x2, y2) {
-        result := DllCall("GDI32.dll\CreateEllipticRgn", "int", x1, "int", y1, "int", x2, "int", y2)
+        result := DllCall("GDI32.dll\CreateEllipticRgn", "int", x1, "int", y1, "int", x2, "int", y2, "ptr")
         return result
     }
 
@@ -5110,7 +5110,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateEllipticRgnIndirect(lprect) {
-        result := DllCall("GDI32.dll\CreateEllipticRgnIndirect", "ptr", lprect)
+        result := DllCall("GDI32.dll\CreateEllipticRgnIndirect", "ptr", lprect, "ptr")
         return result
     }
 
@@ -5134,7 +5134,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateFontIndirectA(lplf) {
-        result := DllCall("GDI32.dll\CreateFontIndirectA", "ptr", lplf)
+        result := DllCall("GDI32.dll\CreateFontIndirectA", "ptr", lplf, "ptr")
         return result
     }
 
@@ -5158,7 +5158,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateFontIndirectW(lplf) {
-        result := DllCall("GDI32.dll\CreateFontIndirectW", "ptr", lplf)
+        result := DllCall("GDI32.dll\CreateFontIndirectW", "ptr", lplf, "ptr")
         return result
     }
 
@@ -5468,7 +5468,7 @@ class Gdi {
     static CreateFontA(cHeight, cWidth, cEscapement, cOrientation, cWeight, bItalic, bUnderline, bStrikeOut, iCharSet, iOutPrecision, iClipPrecision, iQuality, iPitchAndFamily, pszFaceName) {
         pszFaceName := pszFaceName is String? StrPtr(pszFaceName) : pszFaceName
 
-        result := DllCall("GDI32.dll\CreateFontA", "int", cHeight, "int", cWidth, "int", cEscapement, "int", cOrientation, "int", cWeight, "uint", bItalic, "uint", bUnderline, "uint", bStrikeOut, "uint", iCharSet, "uint", iOutPrecision, "uint", iClipPrecision, "uint", iQuality, "uint", iPitchAndFamily, "ptr", pszFaceName)
+        result := DllCall("GDI32.dll\CreateFontA", "int", cHeight, "int", cWidth, "int", cEscapement, "int", cOrientation, "int", cWeight, "uint", bItalic, "uint", bUnderline, "uint", bStrikeOut, "uint", iCharSet, "uint", iOutPrecision, "uint", iClipPrecision, "uint", iQuality, "uint", iPitchAndFamily, "ptr", pszFaceName, "ptr")
         return result
     }
 
@@ -5778,7 +5778,7 @@ class Gdi {
     static CreateFontW(cHeight, cWidth, cEscapement, cOrientation, cWeight, bItalic, bUnderline, bStrikeOut, iCharSet, iOutPrecision, iClipPrecision, iQuality, iPitchAndFamily, pszFaceName) {
         pszFaceName := pszFaceName is String? StrPtr(pszFaceName) : pszFaceName
 
-        result := DllCall("GDI32.dll\CreateFontW", "int", cHeight, "int", cWidth, "int", cEscapement, "int", cOrientation, "int", cWeight, "uint", bItalic, "uint", bUnderline, "uint", bStrikeOut, "uint", iCharSet, "uint", iOutPrecision, "uint", iClipPrecision, "uint", iQuality, "uint", iPitchAndFamily, "ptr", pszFaceName)
+        result := DllCall("GDI32.dll\CreateFontW", "int", cHeight, "int", cWidth, "int", cEscapement, "int", cOrientation, "int", cWeight, "uint", bItalic, "uint", bUnderline, "uint", bStrikeOut, "uint", iCharSet, "uint", iOutPrecision, "uint", iClipPrecision, "uint", iQuality, "uint", iPitchAndFamily, "ptr", pszFaceName, "ptr")
         return result
     }
 
@@ -5803,7 +5803,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateHatchBrush(iHatch, color) {
-        result := DllCall("GDI32.dll\CreateHatchBrush", "int", iHatch, "uint", color)
+        result := DllCall("GDI32.dll\CreateHatchBrush", "int", iHatch, "uint", color, "ptr")
         return result
     }
 
@@ -5833,7 +5833,7 @@ class Gdi {
         pszDevice := pszDevice is String? StrPtr(pszDevice) : pszDevice
         pszPort := pszPort is String? StrPtr(pszPort) : pszPort
 
-        result := DllCall("GDI32.dll\CreateICA", "ptr", pszDriver, "ptr", pszDevice, "ptr", pszPort, "ptr", pdm)
+        result := DllCall("GDI32.dll\CreateICA", "ptr", pszDriver, "ptr", pszDevice, "ptr", pszPort, "ptr", pdm, "ptr")
         return result
     }
 
@@ -5863,7 +5863,7 @@ class Gdi {
         pszDevice := pszDevice is String? StrPtr(pszDevice) : pszDevice
         pszPort := pszPort is String? StrPtr(pszPort) : pszPort
 
-        result := DllCall("GDI32.dll\CreateICW", "ptr", pszDriver, "ptr", pszDevice, "ptr", pszPort, "ptr", pdm)
+        result := DllCall("GDI32.dll\CreateICW", "ptr", pszDriver, "ptr", pszDevice, "ptr", pszPort, "ptr", pdm, "ptr")
         return result
     }
 
@@ -5894,7 +5894,7 @@ class Gdi {
     static CreateMetaFileA(pszFile) {
         pszFile := pszFile is String? StrPtr(pszFile) : pszFile
 
-        result := DllCall("GDI32.dll\CreateMetaFileA", "ptr", pszFile)
+        result := DllCall("GDI32.dll\CreateMetaFileA", "ptr", pszFile, "ptr")
         return result
     }
 
@@ -5925,7 +5925,7 @@ class Gdi {
     static CreateMetaFileW(pszFile) {
         pszFile := pszFile is String? StrPtr(pszFile) : pszFile
 
-        result := DllCall("GDI32.dll\CreateMetaFileW", "ptr", pszFile)
+        result := DllCall("GDI32.dll\CreateMetaFileW", "ptr", pszFile, "ptr")
         return result
     }
 
@@ -5945,7 +5945,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreatePalette(plpal) {
-        result := DllCall("GDI32.dll\CreatePalette", "ptr", plpal)
+        result := DllCall("GDI32.dll\CreatePalette", "ptr", plpal, "ptr")
         return result
     }
 
@@ -5979,7 +5979,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreatePen(iStyle, cWidth, color) {
-        result := DllCall("GDI32.dll\CreatePen", "int", iStyle, "int", cWidth, "uint", color)
+        result := DllCall("GDI32.dll\CreatePen", "int", iStyle, "int", cWidth, "uint", color, "ptr")
         return result
     }
 
@@ -5997,7 +5997,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreatePenIndirect(plpen) {
-        result := DllCall("GDI32.dll\CreatePenIndirect", "ptr", plpen)
+        result := DllCall("GDI32.dll\CreatePenIndirect", "ptr", plpen, "ptr")
         return result
     }
 
@@ -6018,7 +6018,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreatePolyPolygonRgn(pptl, pc, cPoly, iMode) {
-        result := DllCall("GDI32.dll\CreatePolyPolygonRgn", "ptr", pptl, "int*", pc, "int", cPoly, "int", iMode)
+        result := DllCall("GDI32.dll\CreatePolyPolygonRgn", "ptr", pptl, "int*", pc, "int", cPoly, "int", iMode, "ptr")
         return result
     }
 
@@ -6042,7 +6042,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreatePatternBrush(hbm) {
-        result := DllCall("GDI32.dll\CreatePatternBrush", "ptr", hbm)
+        result := DllCall("GDI32.dll\CreatePatternBrush", "ptr", hbm, "ptr")
         return result
     }
 
@@ -6065,7 +6065,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateRectRgn(x1, y1, x2, y2) {
-        result := DllCall("GDI32.dll\CreateRectRgn", "int", x1, "int", y1, "int", x2, "int", y2)
+        result := DllCall("GDI32.dll\CreateRectRgn", "int", x1, "int", y1, "int", x2, "int", y2, "ptr")
         return result
     }
 
@@ -6085,7 +6085,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateRectRgnIndirect(lprect) {
-        result := DllCall("GDI32.dll\CreateRectRgnIndirect", "ptr", lprect)
+        result := DllCall("GDI32.dll\CreateRectRgnIndirect", "ptr", lprect, "ptr")
         return result
     }
 
@@ -6108,7 +6108,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateRoundRectRgn(x1, y1, x2, y2, w, h) {
-        result := DllCall("GDI32.dll\CreateRoundRectRgn", "int", x1, "int", y1, "int", x2, "int", y2, "int", w, "int", h)
+        result := DllCall("GDI32.dll\CreateRoundRectRgn", "int", x1, "int", y1, "int", x2, "int", y2, "int", w, "int", h, "ptr")
         return result
     }
 
@@ -6222,7 +6222,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateSolidBrush(color) {
-        result := DllCall("GDI32.dll\CreateSolidBrush", "uint", color)
+        result := DllCall("GDI32.dll\CreateSolidBrush", "uint", color, "ptr")
         return result
     }
 
@@ -6836,7 +6836,7 @@ class Gdi {
      * @since windows5.0
      */
     static ExtCreateRegion(lpx, nCount, lpData) {
-        result := DllCall("GDI32.dll\ExtCreateRegion", "ptr", lpx, "uint", nCount, "ptr", lpData)
+        result := DllCall("GDI32.dll\ExtCreateRegion", "ptr", lpx, "uint", nCount, "ptr", lpData, "ptr")
         return result
     }
 
@@ -7635,7 +7635,7 @@ class Gdi {
      * @since windows5.0
      */
     static GetCurrentObject(hdc, type) {
-        result := DllCall("GDI32.dll\GetCurrentObject", "ptr", hdc, "uint", type)
+        result := DllCall("GDI32.dll\GetCurrentObject", "ptr", hdc, "uint", type, "ptr")
         return result
     }
 
@@ -8027,7 +8027,7 @@ class Gdi {
     static GetMetaFileA(lpName) {
         lpName := lpName is String? StrPtr(lpName) : lpName
 
-        result := DllCall("GDI32.dll\GetMetaFileA", "ptr", lpName)
+        result := DllCall("GDI32.dll\GetMetaFileA", "ptr", lpName, "ptr")
         return result
     }
 
@@ -8051,7 +8051,7 @@ class Gdi {
     static GetMetaFileW(lpName) {
         lpName := lpName is String? StrPtr(lpName) : lpName
 
-        result := DllCall("GDI32.dll\GetMetaFileW", "ptr", lpName)
+        result := DllCall("GDI32.dll\GetMetaFileW", "ptr", lpName, "ptr")
         return result
     }
 
@@ -8400,7 +8400,7 @@ class Gdi {
      * @since windows5.0
      */
     static GetStockObject(i) {
-        result := DllCall("GDI32.dll\GetStockObject", "int", i)
+        result := DllCall("GDI32.dll\GetStockObject", "int", i, "ptr")
         return result
     }
 
@@ -9595,7 +9595,7 @@ class Gdi {
     static AddFontMemResourceEx(pFileView, cjSize, pNumFonts) {
         static pvResrved := 0 ;Reserved parameters must always be NULL
 
-        result := DllCall("GDI32.dll\AddFontMemResourceEx", "ptr", pFileView, "uint", cjSize, "ptr", pvResrved, "uint*", pNumFonts)
+        result := DllCall("GDI32.dll\AddFontMemResourceEx", "ptr", pFileView, "uint", cjSize, "ptr", pvResrved, "uint*", pNumFonts, "ptr")
         return result
     }
 
@@ -9638,7 +9638,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateFontIndirectExA(param0) {
-        result := DllCall("GDI32.dll\CreateFontIndirectExA", "ptr", param0)
+        result := DllCall("GDI32.dll\CreateFontIndirectExA", "ptr", param0, "ptr")
         return result
     }
 
@@ -9665,7 +9665,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateFontIndirectExW(param0) {
-        result := DllCall("GDI32.dll\CreateFontIndirectExW", "ptr", param0)
+        result := DllCall("GDI32.dll\CreateFontIndirectExW", "ptr", param0, "ptr")
         return result
     }
 
@@ -10303,7 +10303,7 @@ class Gdi {
      * @since windows5.0
      */
     static ResetDCA(hdc, lpdm) {
-        result := DllCall("GDI32.dll\ResetDCA", "ptr", hdc, "ptr", lpdm)
+        result := DllCall("GDI32.dll\ResetDCA", "ptr", hdc, "ptr", lpdm, "ptr")
         return result
     }
 
@@ -10333,7 +10333,7 @@ class Gdi {
      * @since windows5.0
      */
     static ResetDCW(hdc, lpdm) {
-        result := DllCall("GDI32.dll\ResetDCW", "ptr", hdc, "ptr", lpdm)
+        result := DllCall("GDI32.dll\ResetDCW", "ptr", hdc, "ptr", lpdm, "ptr")
         return result
     }
 
@@ -10832,7 +10832,7 @@ class Gdi {
      * @since windows5.0
      */
     static SelectObject(hdc, h) {
-        result := DllCall("GDI32.dll\SelectObject", "ptr", hdc, "ptr", h)
+        result := DllCall("GDI32.dll\SelectObject", "ptr", hdc, "ptr", h, "ptr")
         return result
     }
 
@@ -10856,7 +10856,7 @@ class Gdi {
      * @since windows5.0
      */
     static SelectPalette(hdc, hPal, bForceBkgd) {
-        result := DllCall("GDI32.dll\SelectPalette", "ptr", hdc, "ptr", hPal, "int", bForceBkgd)
+        result := DllCall("GDI32.dll\SelectPalette", "ptr", hdc, "ptr", hPal, "int", bForceBkgd, "ptr")
         return result
     }
 
@@ -11272,7 +11272,7 @@ class Gdi {
      * @since windows5.0
      */
     static SetMetaFileBitsEx(cbBuffer, lpData) {
-        result := DllCall("GDI32.dll\SetMetaFileBitsEx", "uint", cbBuffer, "ptr", lpData)
+        result := DllCall("GDI32.dll\SetMetaFileBitsEx", "uint", cbBuffer, "ptr", lpData, "ptr")
         return result
     }
 
@@ -12174,7 +12174,7 @@ class Gdi {
      * @since windows5.0
      */
     static CloseEnhMetaFile(hdc) {
-        result := DllCall("GDI32.dll\CloseEnhMetaFile", "ptr", hdc)
+        result := DllCall("GDI32.dll\CloseEnhMetaFile", "ptr", hdc, "ptr")
         return result
     }
 
@@ -12204,7 +12204,7 @@ class Gdi {
     static CopyEnhMetaFileA(hEnh, lpFileName) {
         lpFileName := lpFileName is String? StrPtr(lpFileName) : lpFileName
 
-        result := DllCall("GDI32.dll\CopyEnhMetaFileA", "ptr", hEnh, "ptr", lpFileName)
+        result := DllCall("GDI32.dll\CopyEnhMetaFileA", "ptr", hEnh, "ptr", lpFileName, "ptr")
         return result
     }
 
@@ -12234,7 +12234,7 @@ class Gdi {
     static CopyEnhMetaFileW(hEnh, lpFileName) {
         lpFileName := lpFileName is String? StrPtr(lpFileName) : lpFileName
 
-        result := DllCall("GDI32.dll\CopyEnhMetaFileW", "ptr", hEnh, "ptr", lpFileName)
+        result := DllCall("GDI32.dll\CopyEnhMetaFileW", "ptr", hEnh, "ptr", lpFileName, "ptr")
         return result
     }
 
@@ -12272,7 +12272,7 @@ class Gdi {
         lpFilename := lpFilename is String? StrPtr(lpFilename) : lpFilename
         lpDesc := lpDesc is String? StrPtr(lpDesc) : lpDesc
 
-        result := DllCall("GDI32.dll\CreateEnhMetaFileA", "ptr", hdc, "ptr", lpFilename, "ptr", lprc, "ptr", lpDesc)
+        result := DllCall("GDI32.dll\CreateEnhMetaFileA", "ptr", hdc, "ptr", lpFilename, "ptr", lprc, "ptr", lpDesc, "ptr")
         return result
     }
 
@@ -12310,7 +12310,7 @@ class Gdi {
         lpFilename := lpFilename is String? StrPtr(lpFilename) : lpFilename
         lpDesc := lpDesc is String? StrPtr(lpDesc) : lpDesc
 
-        result := DllCall("GDI32.dll\CreateEnhMetaFileW", "ptr", hdc, "ptr", lpFilename, "ptr", lprc, "ptr", lpDesc)
+        result := DllCall("GDI32.dll\CreateEnhMetaFileW", "ptr", hdc, "ptr", lpFilename, "ptr", lprc, "ptr", lpDesc, "ptr")
         return result
     }
 
@@ -12372,7 +12372,7 @@ class Gdi {
     static GetEnhMetaFileA(lpName) {
         lpName := lpName is String? StrPtr(lpName) : lpName
 
-        result := DllCall("GDI32.dll\GetEnhMetaFileA", "ptr", lpName)
+        result := DllCall("GDI32.dll\GetEnhMetaFileA", "ptr", lpName, "ptr")
         return result
     }
 
@@ -12394,7 +12394,7 @@ class Gdi {
     static GetEnhMetaFileW(lpName) {
         lpName := lpName is String? StrPtr(lpName) : lpName
 
-        result := DllCall("GDI32.dll\GetEnhMetaFileW", "ptr", lpName)
+        result := DllCall("GDI32.dll\GetEnhMetaFileW", "ptr", lpName, "ptr")
         return result
     }
 
@@ -12620,7 +12620,7 @@ class Gdi {
      * @since windows5.0
      */
     static SetEnhMetaFileBits(nSize, pb) {
-        result := DllCall("GDI32.dll\SetEnhMetaFileBits", "uint", nSize, "ptr", pb)
+        result := DllCall("GDI32.dll\SetEnhMetaFileBits", "uint", nSize, "ptr", pb, "ptr")
         return result
     }
 
@@ -12979,7 +12979,7 @@ class Gdi {
     static CreateDIBSection(hdc, pbmi, usage, ppvBits, hSection, offset) {
         A_LastError := 0
 
-        result := DllCall("GDI32.dll\CreateDIBSection", "ptr", hdc, "ptr", pbmi, "uint", usage, "ptr", ppvBits, "ptr", hSection, "uint", offset)
+        result := DllCall("GDI32.dll\CreateDIBSection", "ptr", hdc, "ptr", pbmi, "uint", usage, "ptr", ppvBits, "ptr", hSection, "uint", offset, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -13078,7 +13078,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreateHalftonePalette(hdc) {
-        result := DllCall("GDI32.dll\CreateHalftonePalette", "ptr", hdc)
+        result := DllCall("GDI32.dll\CreateHalftonePalette", "ptr", hdc, "ptr")
         return result
     }
 
@@ -13315,7 +13315,7 @@ class Gdi {
      * @since windows5.0
      */
     static PathToRegion(hdc) {
-        result := DllCall("GDI32.dll\PathToRegion", "ptr", hdc)
+        result := DllCall("GDI32.dll\PathToRegion", "ptr", hdc, "ptr")
         return result
     }
 
@@ -13517,7 +13517,7 @@ class Gdi {
      * @since windows5.0
      */
     static ExtCreatePen(iPenStyle, cWidth, plbrush, cStyle, pstyle) {
-        result := DllCall("GDI32.dll\ExtCreatePen", "uint", iPenStyle, "uint", cWidth, "ptr", plbrush, "uint", cStyle, "uint*", pstyle)
+        result := DllCall("GDI32.dll\ExtCreatePen", "uint", iPenStyle, "uint", cWidth, "ptr", plbrush, "uint", cStyle, "uint*", pstyle, "ptr")
         return result
     }
 
@@ -14287,7 +14287,7 @@ class Gdi {
      * @since windows5.0
      */
     static CreatePolygonRgn(pptl, cPoint, iMode) {
-        result := DllCall("GDI32.dll\CreatePolygonRgn", "ptr", pptl, "int", cPoint, "int", iMode)
+        result := DllCall("GDI32.dll\CreatePolygonRgn", "ptr", pptl, "int", cPoint, "int", iMode, "ptr")
         return result
     }
 
@@ -16589,7 +16589,7 @@ class Gdi {
      * @since windows5.0
      */
     static WindowFromDC(hDC) {
-        result := DllCall("USER32.dll\WindowFromDC", "ptr", hDC)
+        result := DllCall("USER32.dll\WindowFromDC", "ptr", hDC, "ptr")
         return result
     }
 
@@ -16609,7 +16609,7 @@ class Gdi {
      * @since windows5.0
      */
     static GetDC(hWnd) {
-        result := DllCall("USER32.dll\GetDC", "ptr", hWnd)
+        result := DllCall("USER32.dll\GetDC", "ptr", hWnd, "ptr")
         return result
     }
 
@@ -16629,7 +16629,7 @@ class Gdi {
      * @since windows5.0
      */
     static GetDCEx(hWnd, hrgnClip, flags) {
-        result := DllCall("USER32.dll\GetDCEx", "ptr", hWnd, "ptr", hrgnClip, "uint", flags)
+        result := DllCall("USER32.dll\GetDCEx", "ptr", hWnd, "ptr", hrgnClip, "uint", flags, "ptr")
         return result
     }
 
@@ -16653,7 +16653,7 @@ class Gdi {
      * @since windows5.0
      */
     static GetWindowDC(hWnd) {
-        result := DllCall("USER32.dll\GetWindowDC", "ptr", hWnd)
+        result := DllCall("USER32.dll\GetWindowDC", "ptr", hWnd, "ptr")
         return result
     }
 
@@ -16698,7 +16698,7 @@ class Gdi {
      * @since windows5.0
      */
     static BeginPaint(hWnd, lpPaint) {
-        result := DllCall("USER32.dll\BeginPaint", "ptr", hWnd, "ptr", lpPaint)
+        result := DllCall("USER32.dll\BeginPaint", "ptr", hWnd, "ptr", lpPaint, "ptr")
         return result
     }
 
@@ -17367,7 +17367,7 @@ class Gdi {
      * @since windows5.0
      */
     static GetSysColorBrush(nIndex) {
-        result := DllCall("USER32.dll\GetSysColorBrush", "int", nIndex)
+        result := DllCall("USER32.dll\GetSysColorBrush", "int", nIndex, "ptr")
         return result
     }
 
@@ -17806,7 +17806,7 @@ class Gdi {
     static LoadBitmapA(hInstance, lpBitmapName) {
         lpBitmapName := lpBitmapName is String? StrPtr(lpBitmapName) : lpBitmapName
 
-        result := DllCall("USER32.dll\LoadBitmapA", "ptr", hInstance, "ptr", lpBitmapName)
+        result := DllCall("USER32.dll\LoadBitmapA", "ptr", hInstance, "ptr", lpBitmapName, "ptr")
         return result
     }
 
@@ -17911,7 +17911,7 @@ class Gdi {
     static LoadBitmapW(hInstance, lpBitmapName) {
         lpBitmapName := lpBitmapName is String? StrPtr(lpBitmapName) : lpBitmapName
 
-        result := DllCall("USER32.dll\LoadBitmapW", "ptr", hInstance, "ptr", lpBitmapName)
+        result := DllCall("USER32.dll\LoadBitmapW", "ptr", hInstance, "ptr", lpBitmapName, "ptr")
         return result
     }
 
@@ -18978,7 +18978,7 @@ class Gdi {
      * @since windows5.0
      */
     static MonitorFromPoint(pt, dwFlags) {
-        result := DllCall("USER32.dll\MonitorFromPoint", "ptr", pt, "uint", dwFlags)
+        result := DllCall("USER32.dll\MonitorFromPoint", "ptr", pt, "uint", dwFlags, "ptr")
         return result
     }
 
@@ -18993,7 +18993,7 @@ class Gdi {
      * @since windows5.0
      */
     static MonitorFromRect(lprc, dwFlags) {
-        result := DllCall("USER32.dll\MonitorFromRect", "ptr", lprc, "uint", dwFlags)
+        result := DllCall("USER32.dll\MonitorFromRect", "ptr", lprc, "uint", dwFlags, "ptr")
         return result
     }
 
@@ -19010,7 +19010,7 @@ class Gdi {
      * @since windows5.0
      */
     static MonitorFromWindow(hwnd, dwFlags) {
-        result := DllCall("USER32.dll\MonitorFromWindow", "ptr", hwnd, "uint", dwFlags)
+        result := DllCall("USER32.dll\MonitorFromWindow", "ptr", hwnd, "uint", dwFlags, "ptr")
         return result
     }
 

--- a/Windows/Win32/Graphics/GdiPlus/Apis.ahk
+++ b/Windows/Win32/Graphics/GdiPlus/Apis.ahk
@@ -1531,7 +1531,7 @@ class GdiPlus {
      * @returns {Pointer<Void>} 
      */
     static GdipAlloc(size) {
-        result := DllCall("gdiplus.dll\GdipAlloc", "ptr", size)
+        result := DllCall("gdiplus.dll\GdipAlloc", "ptr", size, "ptr")
         return result
     }
 
@@ -6690,7 +6690,7 @@ class GdiPlus {
      * @returns {Pointer<Void>} 
      */
     static GdipCreateHalftonePalette() {
-        result := DllCall("gdiplus.dll\GdipCreateHalftonePalette")
+        result := DllCall("gdiplus.dll\GdipCreateHalftonePalette", "ptr")
         return result
     }
 

--- a/Windows/Win32/Graphics/OpenGL/Apis.ahk
+++ b/Windows/Win32/Graphics/OpenGL/Apis.ahk
@@ -3815,7 +3815,7 @@ class OpenGL {
     static wglCreateContext(param0) {
         A_LastError := 0
 
-        result := DllCall("OPENGL32.dll\wglCreateContext", "ptr", param0)
+        result := DllCall("OPENGL32.dll\wglCreateContext", "ptr", param0, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3841,7 +3841,7 @@ class OpenGL {
     static wglCreateLayerContext(param0, param1) {
         A_LastError := 0
 
-        result := DllCall("OPENGL32.dll\wglCreateLayerContext", "ptr", param0, "int", param1)
+        result := DllCall("OPENGL32.dll\wglCreateLayerContext", "ptr", param0, "int", param1, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3880,7 +3880,7 @@ class OpenGL {
      * @since windows5.0
      */
     static wglGetCurrentContext() {
-        result := DllCall("OPENGL32.dll\wglGetCurrentContext")
+        result := DllCall("OPENGL32.dll\wglGetCurrentContext", "ptr")
         return result
     }
 
@@ -3893,7 +3893,7 @@ class OpenGL {
      * @since windows5.0
      */
     static wglGetCurrentDC() {
-        result := DllCall("OPENGL32.dll\wglGetCurrentDC")
+        result := DllCall("OPENGL32.dll\wglGetCurrentDC", "ptr")
         return result
     }
 

--- a/Windows/Win32/Graphics/Printing/Apis.ahk
+++ b/Windows/Win32/Graphics/Printing/Apis.ahk
@@ -7354,7 +7354,7 @@ class Printing {
     static GetSpoolFileHandle(hPrinter) {
         A_LastError := 0
 
-        result := DllCall("winspool.drv\GetSpoolFileHandle", "ptr", hPrinter)
+        result := DllCall("winspool.drv\GetSpoolFileHandle", "ptr", hPrinter, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -7378,7 +7378,7 @@ class Printing {
      * @see https://learn.microsoft.com/windows/win32/printdocs/commitspooldata
      */
     static CommitSpoolData(hPrinter, hSpoolFile, cbCommit) {
-        result := DllCall("winspool.drv\CommitSpoolData", "ptr", hPrinter, "ptr", hSpoolFile, "uint", cbCommit)
+        result := DllCall("winspool.drv\CommitSpoolData", "ptr", hPrinter, "ptr", hSpoolFile, "uint", cbCommit, "ptr")
         return result
     }
 
@@ -7919,7 +7919,7 @@ class Printing {
 
         A_LastError := 0
 
-        result := DllCall("winspool.drv\AddPrinterA", "ptr", pName, "uint", Level, "char*", pPrinter)
+        result := DllCall("winspool.drv\AddPrinterA", "ptr", pName, "uint", Level, "char*", pPrinter, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -7997,7 +7997,7 @@ class Printing {
 
         A_LastError := 0
 
-        result := DllCall("winspool.drv\AddPrinterW", "ptr", pName, "uint", Level, "char*", pPrinter)
+        result := DllCall("winspool.drv\AddPrinterW", "ptr", pName, "uint", Level, "char*", pPrinter, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11130,7 +11130,7 @@ class Printing {
      * @see https://learn.microsoft.com/windows/win32/printdocs/findfirstprinterchangenotification
      */
     static FindFirstPrinterChangeNotification(hPrinter, fdwFilter, fdwOptions, pPrinterNotifyOptions) {
-        result := DllCall("winspool.drv\FindFirstPrinterChangeNotification", "ptr", hPrinter, "uint", fdwFilter, "uint", fdwOptions, "ptr", pPrinterNotifyOptions)
+        result := DllCall("winspool.drv\FindFirstPrinterChangeNotification", "ptr", hPrinter, "uint", fdwFilter, "uint", fdwOptions, "ptr", pPrinterNotifyOptions, "ptr")
         return result
     }
 
@@ -12257,7 +12257,7 @@ class Printing {
      * @see https://learn.microsoft.com/windows/win32/printdocs/connecttoprinterdlg
      */
     static ConnectToPrinterDlg(hwnd, Flags) {
-        result := DllCall("winspool.drv\ConnectToPrinterDlg", "ptr", hwnd, "uint", Flags)
+        result := DllCall("winspool.drv\ConnectToPrinterDlg", "ptr", hwnd, "uint", Flags, "ptr")
         return result
     }
 
@@ -13584,7 +13584,7 @@ class Printing {
         pwszPrinterName := pwszPrinterName is String? StrPtr(pwszPrinterName) : pwszPrinterName
         pwszDocName := pwszDocName is String? StrPtr(pwszDocName) : pwszDocName
 
-        result := DllCall("GDI32.dll\GdiGetSpoolFileHandle", "ptr", pwszPrinterName, "ptr", pDevmode, "ptr", pwszDocName)
+        result := DllCall("GDI32.dll\GdiGetSpoolFileHandle", "ptr", pwszPrinterName, "ptr", pDevmode, "ptr", pwszDocName, "ptr")
         return result
     }
 
@@ -13614,7 +13614,7 @@ class Printing {
      * @returns {Pointer<Void>} 
      */
     static GdiGetDC(SpoolFileHandle) {
-        result := DllCall("GDI32.dll\GdiGetDC", "ptr", SpoolFileHandle)
+        result := DllCall("GDI32.dll\GdiGetDC", "ptr", SpoolFileHandle, "ptr")
         return result
     }
 
@@ -13626,7 +13626,7 @@ class Printing {
      * @returns {Pointer<Void>} 
      */
     static GdiGetPageHandle(SpoolFileHandle, Page, pdwPageType) {
-        result := DllCall("GDI32.dll\GdiGetPageHandle", "ptr", SpoolFileHandle, "uint", Page, "uint*", pdwPageType)
+        result := DllCall("GDI32.dll\GdiGetPageHandle", "ptr", SpoolFileHandle, "uint", Page, "uint*", pdwPageType, "ptr")
         return result
     }
 
@@ -13748,7 +13748,7 @@ class Printing {
      * @returns {Pointer<Void>} 
      */
     static CreatePrinterIC(hPrinter, pDevMode) {
-        result := DllCall("winspool.drv\CreatePrinterIC", "ptr", hPrinter, "ptr", pDevMode)
+        result := DllCall("winspool.drv\CreatePrinterIC", "ptr", hPrinter, "ptr", pDevMode, "ptr")
         return result
     }
 
@@ -13794,7 +13794,7 @@ class Printing {
      * @returns {Pointer<Void>} 
      */
     static RevertToPrinterSelf() {
-        result := DllCall("SPOOLSS.dll\RevertToPrinterSelf")
+        result := DllCall("SPOOLSS.dll\RevertToPrinterSelf", "ptr")
         return result
     }
 
@@ -13882,7 +13882,7 @@ class Printing {
      * @returns {Pointer<Void>} 
      */
     static RouterAllocBidiMem(NumBytes) {
-        result := DllCall("SPOOLSS.dll\RouterAllocBidiMem", "ptr", NumBytes)
+        result := DllCall("SPOOLSS.dll\RouterAllocBidiMem", "ptr", NumBytes, "ptr")
         return result
     }
 

--- a/Windows/Win32/Media/MediaFoundation/Apis.ahk
+++ b/Windows/Win32/Media/MediaFoundation/Apis.ahk
@@ -19223,7 +19223,7 @@ class MediaFoundation {
     static MFHeapAlloc(nSize, dwFlags, pszFile, line, eat) {
         pszFile := pszFile is String? StrPtr(pszFile) : pszFile
 
-        result := DllCall("MFPlat.dll\MFHeapAlloc", "ptr", nSize, "uint", dwFlags, "ptr", pszFile, "int", line, "int", eat)
+        result := DllCall("MFPlat.dll\MFHeapAlloc", "ptr", nSize, "uint", dwFlags, "ptr", pszFile, "int", line, "int", eat, "ptr")
         return result
     }
 

--- a/Windows/Win32/Media/Multimedia/Apis.ahk
+++ b/Windows/Win32/Media/Multimedia/Apis.ahk
@@ -23404,7 +23404,7 @@ class Multimedia {
      * @returns {Pointer<Void>} 
      */
     static mciGetCreatorTask(mciId) {
-        result := DllCall("WINMM.dll\mciGetCreatorTask", "uint", mciId)
+        result := DllCall("WINMM.dll\mciGetCreatorTask", "uint", mciId, "ptr")
         return result
     }
 
@@ -23515,7 +23515,7 @@ class Multimedia {
         szDriverName := szDriverName is String? StrPtr(szDriverName) : szDriverName
         szSectionName := szSectionName is String? StrPtr(szSectionName) : szSectionName
 
-        result := DllCall("WINMM.dll\OpenDriver", "ptr", szDriverName, "ptr", szSectionName, "ptr", lParam2)
+        result := DllCall("WINMM.dll\OpenDriver", "ptr", szDriverName, "ptr", szSectionName, "ptr", lParam2, "ptr")
         return result
     }
 
@@ -23589,7 +23589,7 @@ class Multimedia {
      * @since windows5.0
      */
     static DrvGetModuleHandle(hDriver) {
-        result := DllCall("WINMM.dll\DrvGetModuleHandle", "ptr", hDriver)
+        result := DllCall("WINMM.dll\DrvGetModuleHandle", "ptr", hDriver, "ptr")
         return result
     }
 
@@ -23601,7 +23601,7 @@ class Multimedia {
      * @since windows5.0
      */
     static GetDriverModuleHandle(hDriver) {
-        result := DllCall("WINMM.dll\GetDriverModuleHandle", "ptr", hDriver)
+        result := DllCall("WINMM.dll\GetDriverModuleHandle", "ptr", hDriver, "ptr")
         return result
     }
 
@@ -24008,7 +24008,7 @@ class Multimedia {
     static mmioOpenA(pszFileName, pmmioinfo, fdwOpen) {
         pszFileName := pszFileName is String? StrPtr(pszFileName) : pszFileName
 
-        result := DllCall("WINMM.dll\mmioOpenA", "ptr", pszFileName, "ptr", pmmioinfo, "uint", fdwOpen)
+        result := DllCall("WINMM.dll\mmioOpenA", "ptr", pszFileName, "ptr", pmmioinfo, "uint", fdwOpen, "ptr")
         return result
     }
 
@@ -24141,7 +24141,7 @@ class Multimedia {
     static mmioOpenW(pszFileName, pmmioinfo, fdwOpen) {
         pszFileName := pszFileName is String? StrPtr(pszFileName) : pszFileName
 
-        result := DllCall("WINMM.dll\mmioOpenW", "ptr", pszFileName, "ptr", pmmioinfo, "uint", fdwOpen)
+        result := DllCall("WINMM.dll\mmioOpenW", "ptr", pszFileName, "ptr", pmmioinfo, "uint", fdwOpen, "ptr")
         return result
     }
 
@@ -25378,7 +25378,7 @@ class Multimedia {
      * @since windows5.0
      */
     static ICOpen(fccType, fccHandler, wMode) {
-        result := DllCall("MSVFW32.dll\ICOpen", "uint", fccType, "uint", fccHandler, "uint", wMode)
+        result := DllCall("MSVFW32.dll\ICOpen", "uint", fccType, "uint", fccHandler, "uint", wMode, "ptr")
         return result
     }
 
@@ -25426,7 +25426,7 @@ class Multimedia {
      * @since windows5.0
      */
     static ICOpenFunction(fccType, fccHandler, wMode, lpfnHandler) {
-        result := DllCall("MSVFW32.dll\ICOpenFunction", "uint", fccType, "uint", fccHandler, "uint", wMode, "ptr", lpfnHandler)
+        result := DllCall("MSVFW32.dll\ICOpenFunction", "uint", fccType, "uint", fccHandler, "uint", wMode, "ptr", lpfnHandler, "ptr")
         return result
     }
 
@@ -25732,7 +25732,7 @@ class Multimedia {
      * @since windows5.0
      */
     static ICLocate(fccType, fccHandler, lpbiIn, lpbiOut, wFlags) {
-        result := DllCall("MSVFW32.dll\ICLocate", "uint", fccType, "uint", fccHandler, "ptr", lpbiIn, "ptr", lpbiOut, "ushort", wFlags)
+        result := DllCall("MSVFW32.dll\ICLocate", "uint", fccType, "uint", fccHandler, "ptr", lpbiIn, "ptr", lpbiOut, "ushort", wFlags, "ptr")
         return result
     }
 
@@ -25749,7 +25749,7 @@ class Multimedia {
      * @since windows5.0
      */
     static ICGetDisplayFormat(hic, lpbiIn, lpbiOut, BitDepth, dx, dy) {
-        result := DllCall("MSVFW32.dll\ICGetDisplayFormat", "ptr", hic, "ptr", lpbiIn, "ptr", lpbiOut, "int", BitDepth, "int", dx, "int", dy)
+        result := DllCall("MSVFW32.dll\ICGetDisplayFormat", "ptr", hic, "ptr", lpbiIn, "ptr", lpbiOut, "int", BitDepth, "int", dx, "int", dy, "ptr")
         return result
     }
 
@@ -25769,7 +25769,7 @@ class Multimedia {
      * @since windows5.0
      */
     static ICImageCompress(hic, uiFlags, lpbiIn, lpBits, lpbiOut, lQuality, plSize) {
-        result := DllCall("MSVFW32.dll\ICImageCompress", "ptr", hic, "uint", uiFlags, "ptr", lpbiIn, "ptr", lpBits, "ptr", lpbiOut, "int", lQuality, "int*", plSize)
+        result := DllCall("MSVFW32.dll\ICImageCompress", "ptr", hic, "uint", uiFlags, "ptr", lpbiIn, "ptr", lpBits, "ptr", lpbiOut, "int", lQuality, "int*", plSize, "ptr")
         return result
     }
 
@@ -25787,7 +25787,7 @@ class Multimedia {
      * @since windows5.0
      */
     static ICImageDecompress(hic, uiFlags, lpbiIn, lpBits, lpbiOut) {
-        result := DllCall("MSVFW32.dll\ICImageDecompress", "ptr", hic, "uint", uiFlags, "ptr", lpbiIn, "ptr", lpBits, "ptr", lpbiOut)
+        result := DllCall("MSVFW32.dll\ICImageDecompress", "ptr", hic, "uint", uiFlags, "ptr", lpbiIn, "ptr", lpBits, "ptr", lpbiOut, "ptr")
         return result
     }
 
@@ -25895,7 +25895,7 @@ class Multimedia {
     static ICSeqCompressFrame(pc, lpBits, pfKey, plSize) {
         static uiFlags := 0 ;Reserved parameters must always be NULL
 
-        result := DllCall("MSVFW32.dll\ICSeqCompressFrame", "ptr", pc, "uint", uiFlags, "ptr", lpBits, "int*", pfKey, "int*", plSize)
+        result := DllCall("MSVFW32.dll\ICSeqCompressFrame", "ptr", pc, "uint", uiFlags, "ptr", lpBits, "int*", pfKey, "int*", plSize, "ptr")
         return result
     }
 
@@ -25948,7 +25948,7 @@ class Multimedia {
      * @since windows5.0
      */
     static DrawDibGetBuffer(hdd, lpbi, dwSize, dwFlags) {
-        result := DllCall("MSVFW32.dll\DrawDibGetBuffer", "ptr", hdd, "ptr", lpbi, "uint", dwSize, "uint", dwFlags)
+        result := DllCall("MSVFW32.dll\DrawDibGetBuffer", "ptr", hdd, "ptr", lpbi, "uint", dwSize, "uint", dwFlags, "ptr")
         return result
     }
 
@@ -25964,7 +25964,7 @@ class Multimedia {
      * @since windows5.0
      */
     static DrawDibGetPalette(hdd) {
-        result := DllCall("MSVFW32.dll\DrawDibGetPalette", "ptr", hdd)
+        result := DllCall("MSVFW32.dll\DrawDibGetPalette", "ptr", hdd, "ptr")
         return result
     }
 
@@ -27298,7 +27298,7 @@ class Multimedia {
      * @since windows5.0
      */
     static AVIStreamGetFrame(pg, lPos) {
-        result := DllCall("AVIFIL32.dll\AVIStreamGetFrame", "ptr", pg, "int", lPos)
+        result := DllCall("AVIFIL32.dll\AVIStreamGetFrame", "ptr", pg, "int", lPos, "ptr")
         return result
     }
 
@@ -28469,7 +28469,7 @@ class Multimedia {
     static capCreateCaptureWindowA(lpszWindowName, dwStyle, x, y, nWidth, nHeight, hwndParent, nID) {
         lpszWindowName := lpszWindowName is String? StrPtr(lpszWindowName) : lpszWindowName
 
-        result := DllCall("AVICAP32.dll\capCreateCaptureWindowA", "ptr", lpszWindowName, "uint", dwStyle, "int", x, "int", y, "int", nWidth, "int", nHeight, "ptr", hwndParent, "int", nID)
+        result := DllCall("AVICAP32.dll\capCreateCaptureWindowA", "ptr", lpszWindowName, "uint", dwStyle, "int", x, "int", y, "int", nWidth, "int", nHeight, "ptr", hwndParent, "int", nID, "ptr")
         return result
     }
 
@@ -28523,7 +28523,7 @@ class Multimedia {
     static capCreateCaptureWindowW(lpszWindowName, dwStyle, x, y, nWidth, nHeight, hwndParent, nID) {
         lpszWindowName := lpszWindowName is String? StrPtr(lpszWindowName) : lpszWindowName
 
-        result := DllCall("AVICAP32.dll\capCreateCaptureWindowW", "ptr", lpszWindowName, "uint", dwStyle, "int", x, "int", y, "int", nWidth, "int", nHeight, "ptr", hwndParent, "int", nID)
+        result := DllCall("AVICAP32.dll\capCreateCaptureWindowW", "ptr", lpszWindowName, "uint", dwStyle, "int", x, "int", y, "int", nWidth, "int", nHeight, "ptr", hwndParent, "int", nID, "ptr")
         return result
     }
 

--- a/Windows/Win32/NetworkManagement/IpHelper/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/IpHelper/Apis.ahk
@@ -2402,7 +2402,7 @@ class IpHelper {
     static IcmpCreateFile() {
         A_LastError := 0
 
-        result := DllCall("IPHLPAPI.dll\IcmpCreateFile")
+        result := DllCall("IPHLPAPI.dll\IcmpCreateFile", "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2429,7 +2429,7 @@ class IpHelper {
     static Icmp6CreateFile() {
         A_LastError := 0
 
-        result := DllCall("IPHLPAPI.dll\Icmp6CreateFile")
+        result := DllCall("IPHLPAPI.dll\Icmp6CreateFile", "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/NetworkManagement/NetManagement/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/NetManagement/Apis.ahk
@@ -21394,7 +21394,7 @@ class NetManagement {
     static RouterLogRegisterA(lpszSource) {
         lpszSource := lpszSource is String? StrPtr(lpszSource) : lpszSource
 
-        result := DllCall("rtutils.dll\RouterLogRegisterA", "ptr", lpszSource)
+        result := DllCall("rtutils.dll\RouterLogRegisterA", "ptr", lpszSource, "ptr")
         return result
     }
 
@@ -21501,7 +21501,7 @@ class NetManagement {
     static RouterLogRegisterW(lpszSource) {
         lpszSource := lpszSource is String? StrPtr(lpszSource) : lpszSource
 
-        result := DllCall("rtutils.dll\RouterLogRegisterW", "ptr", lpszSource)
+        result := DllCall("rtutils.dll\RouterLogRegisterW", "ptr", lpszSource, "ptr")
         return result
     }
 

--- a/Windows/Win32/NetworkManagement/Snmp/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/Snmp/Apis.ahk
@@ -806,7 +806,7 @@ class Snmp {
      * @since windows5.0
      */
     static SnmpUtilMemAlloc(nBytes) {
-        result := DllCall("snmpapi.dll\SnmpUtilMemAlloc", "uint", nBytes)
+        result := DllCall("snmpapi.dll\SnmpUtilMemAlloc", "uint", nBytes, "ptr")
         return result
     }
 
@@ -825,7 +825,7 @@ class Snmp {
      * @since windows5.0
      */
     static SnmpUtilMemReAlloc(pMem, nBytes) {
-        result := DllCall("snmpapi.dll\SnmpUtilMemReAlloc", "ptr", pMem, "uint", nBytes)
+        result := DllCall("snmpapi.dll\SnmpUtilMemReAlloc", "ptr", pMem, "uint", nBytes, "ptr")
         return result
     }
 
@@ -1046,7 +1046,7 @@ class Snmp {
 
         A_LastError := 0
 
-        result := DllCall("mgmtapi.dll\SnmpMgrOpen", "ptr", lpAgentAddress, "ptr", lpAgentCommunity, "int", nTimeOut, "int", nRetries)
+        result := DllCall("mgmtapi.dll\SnmpMgrOpen", "ptr", lpAgentAddress, "ptr", lpAgentCommunity, "int", nTimeOut, "int", nRetries, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/NetworkManagement/WiFi/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/WiFi/Apis.ahk
@@ -7161,7 +7161,7 @@ class WiFi {
     static WlanAllocateMemory(dwMemorySize) {
         A_LastError := 0
 
-        result := DllCall("wlanapi.dll\WlanAllocateMemory", "uint", dwMemorySize)
+        result := DllCall("wlanapi.dll\WlanAllocateMemory", "uint", dwMemorySize, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/NetworkManagement/WindowsNetworkVirtualization/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/WindowsNetworkVirtualization/Apis.ahk
@@ -31,7 +31,7 @@ class WindowsNetworkVirtualization {
      * @since windowsserver2012
      */
     static WnvOpen() {
-        result := DllCall("wnvapi.dll\WnvOpen")
+        result := DllCall("wnvapi.dll\WnvOpen", "ptr")
         return result
     }
 

--- a/Windows/Win32/Networking/ActiveDirectory/Apis.ahk
+++ b/Windows/Win32/Networking/ActiveDirectory/Apis.ahk
@@ -4021,7 +4021,7 @@ class ActiveDirectory {
      * @since windows6.0.6000
      */
     static AllocADsMem(cb) {
-        result := DllCall("ACTIVEDS.dll\AllocADsMem", "uint", cb)
+        result := DllCall("ACTIVEDS.dll\AllocADsMem", "uint", cb, "ptr")
         return result
     }
 
@@ -4067,7 +4067,7 @@ class ActiveDirectory {
      * @since windows6.0.6000
      */
     static ReallocADsMem(pOldMem, cbOld, cbNew) {
-        result := DllCall("ACTIVEDS.dll\ReallocADsMem", "ptr", pOldMem, "uint", cbOld, "uint", cbNew)
+        result := DllCall("ACTIVEDS.dll\ReallocADsMem", "ptr", pOldMem, "uint", cbOld, "uint", cbNew, "ptr")
         return result
     }
 
@@ -4392,7 +4392,7 @@ class ActiveDirectory {
     static DsGetIcon(dwFlags, pszObjectClass, cxImage, cyImage) {
         pszObjectClass := pszObjectClass is String? StrPtr(pszObjectClass) : pszObjectClass
 
-        result := DllCall("dsuiext.dll\DsGetIcon", "uint", dwFlags, "ptr", pszObjectClass, "int", cxImage, "int", cyImage)
+        result := DllCall("dsuiext.dll\DsGetIcon", "uint", dwFlags, "ptr", pszObjectClass, "int", cxImage, "int", cyImage, "ptr")
         return result
     }
 

--- a/Windows/Win32/Networking/Clustering/Apis.ahk
+++ b/Windows/Win32/Networking/Clustering/Apis.ahk
@@ -6412,7 +6412,7 @@ class Clustering {
 
         A_LastError := 0
 
-        result := DllCall("CLUSAPI.dll\GetClusterResourceTypeKey", "ptr", hCluster, "ptr", lpszTypeName, "uint", samDesired)
+        result := DllCall("CLUSAPI.dll\GetClusterResourceTypeKey", "ptr", hCluster, "ptr", lpszTypeName, "uint", samDesired, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11628,7 +11628,7 @@ class Clustering {
     static GetClusterKey(hCluster, samDesired) {
         A_LastError := 0
 
-        result := DllCall("CLUSAPI.dll\GetClusterKey", "ptr", hCluster, "uint", samDesired)
+        result := DllCall("CLUSAPI.dll\GetClusterKey", "ptr", hCluster, "uint", samDesired, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11651,7 +11651,7 @@ class Clustering {
     static GetClusterGroupKey(hGroup, samDesired) {
         A_LastError := 0
 
-        result := DllCall("CLUSAPI.dll\GetClusterGroupKey", "ptr", hGroup, "uint", samDesired)
+        result := DllCall("CLUSAPI.dll\GetClusterGroupKey", "ptr", hGroup, "uint", samDesired, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11674,7 +11674,7 @@ class Clustering {
     static GetClusterResourceKey(hResource, samDesired) {
         A_LastError := 0
 
-        result := DllCall("CLUSAPI.dll\GetClusterResourceKey", "ptr", hResource, "uint", samDesired)
+        result := DllCall("CLUSAPI.dll\GetClusterResourceKey", "ptr", hResource, "uint", samDesired, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11697,7 +11697,7 @@ class Clustering {
     static GetClusterNodeKey(hNode, samDesired) {
         A_LastError := 0
 
-        result := DllCall("CLUSAPI.dll\GetClusterNodeKey", "ptr", hNode, "uint", samDesired)
+        result := DllCall("CLUSAPI.dll\GetClusterNodeKey", "ptr", hNode, "uint", samDesired, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11720,7 +11720,7 @@ class Clustering {
     static GetClusterNetworkKey(hNetwork, samDesired) {
         A_LastError := 0
 
-        result := DllCall("CLUSAPI.dll\GetClusterNetworkKey", "ptr", hNetwork, "uint", samDesired)
+        result := DllCall("CLUSAPI.dll\GetClusterNetworkKey", "ptr", hNetwork, "uint", samDesired, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11743,7 +11743,7 @@ class Clustering {
     static GetClusterNetInterfaceKey(hNetInterface, samDesired) {
         A_LastError := 0
 
-        result := DllCall("CLUSAPI.dll\GetClusterNetInterfaceKey", "ptr", hNetInterface, "uint", samDesired)
+        result := DllCall("CLUSAPI.dll\GetClusterNetInterfaceKey", "ptr", hNetInterface, "uint", samDesired, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -15782,7 +15782,7 @@ class Clustering {
     static ResUtilGetEnvironmentWithNetName(hResource) {
         A_LastError := 0
 
-        result := DllCall("RESUTILS.dll\ResUtilGetEnvironmentWithNetName", "ptr", hResource)
+        result := DllCall("RESUTILS.dll\ResUtilGetEnvironmentWithNetName", "ptr", hResource, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/Networking/WinHttp/Apis.ahk
+++ b/Windows/Win32/Networking/WinHttp/Apis.ahk
@@ -3787,7 +3787,7 @@ class WinHttp {
 
         A_LastError := 0
 
-        result := DllCall("WINHTTP.dll\WinHttpOpen", "ptr", pszAgentW, "uint", dwAccessType, "ptr", pszProxyW, "ptr", pszProxyBypassW, "uint", dwFlags)
+        result := DllCall("WINHTTP.dll\WinHttpOpen", "ptr", pszAgentW, "uint", dwAccessType, "ptr", pszProxyW, "ptr", pszProxyBypassW, "uint", dwFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4003,7 +4003,7 @@ class WinHttp {
 
         A_LastError := 0
 
-        result := DllCall("WINHTTP.dll\WinHttpConnect", "ptr", hSession, "ptr", pswzServerName, "ushort", nServerPort, "uint", dwReserved)
+        result := DllCall("WINHTTP.dll\WinHttpConnect", "ptr", hSession, "ptr", pswzServerName, "ushort", nServerPort, "uint", dwReserved, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5034,7 +5034,7 @@ class WinHttp {
 
         A_LastError := 0
 
-        result := DllCall("WINHTTP.dll\WinHttpOpenRequest", "ptr", hConnect, "ptr", pwszVerb, "ptr", pwszObjectName, "ptr", pwszVersion, "ptr", pwszReferrer, "ptr", ppwszAcceptTypes, "uint", dwFlags)
+        result := DllCall("WINHTTP.dll\WinHttpOpenRequest", "ptr", hConnect, "ptr", pwszVerb, "ptr", pwszObjectName, "ptr", pwszVersion, "ptr", pwszReferrer, "ptr", ppwszAcceptTypes, "uint", dwFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -7501,7 +7501,7 @@ class WinHttp {
     static WinHttpWebSocketCompleteUpgrade(hRequest, pContext) {
         A_LastError := 0
 
-        result := DllCall("WINHTTP.dll\WinHttpWebSocketCompleteUpgrade", "ptr", hRequest, "ptr", pContext)
+        result := DllCall("WINHTTP.dll\WinHttpWebSocketCompleteUpgrade", "ptr", hRequest, "ptr", pContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -7849,7 +7849,7 @@ class WinHttp {
      * @returns {Pointer<Void>} 
      */
     static WinHttpProtocolCompleteUpgrade(hRequest, dwContext) {
-        result := DllCall("WINHTTP.dll\WinHttpProtocolCompleteUpgrade", "ptr", hRequest, "ptr", dwContext)
+        result := DllCall("WINHTTP.dll\WinHttpProtocolCompleteUpgrade", "ptr", hRequest, "ptr", dwContext, "ptr")
         return result
     }
 

--- a/Windows/Win32/Networking/WinInet/Apis.ahk
+++ b/Windows/Win32/Networking/WinInet/Apis.ahk
@@ -5430,7 +5430,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\InternetOpenA", "ptr", lpszAgent, "uint", dwAccessType, "ptr", lpszProxy, "ptr", lpszProxyBypass, "uint", dwFlags)
+        result := DllCall("WININET.dll\InternetOpenA", "ptr", lpszAgent, "uint", dwAccessType, "ptr", lpszProxy, "ptr", lpszProxyBypass, "uint", dwFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5499,7 +5499,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\InternetOpenW", "ptr", lpszAgent, "uint", dwAccessType, "ptr", lpszProxy, "ptr", lpszProxyBypass, "uint", dwFlags)
+        result := DllCall("WININET.dll\InternetOpenW", "ptr", lpszAgent, "uint", dwAccessType, "ptr", lpszProxy, "ptr", lpszProxyBypass, "uint", dwFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5654,7 +5654,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\InternetConnectA", "ptr", hInternet, "ptr", lpszServerName, "ushort", nServerPort, "ptr", lpszUserName, "ptr", lpszPassword, "uint", dwService, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\InternetConnectA", "ptr", hInternet, "ptr", lpszServerName, "ushort", nServerPort, "ptr", lpszUserName, "ptr", lpszPassword, "uint", dwService, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5772,7 +5772,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\InternetConnectW", "ptr", hInternet, "ptr", lpszServerName, "ushort", nServerPort, "ptr", lpszUserName, "ptr", lpszPassword, "uint", dwService, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\InternetConnectW", "ptr", hInternet, "ptr", lpszServerName, "ushort", nServerPort, "ptr", lpszUserName, "ptr", lpszPassword, "uint", dwService, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5834,7 +5834,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\InternetOpenUrlA", "ptr", hInternet, "ptr", lpszUrl, "ptr", lpszHeaders, "uint", dwHeadersLength, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\InternetOpenUrlA", "ptr", hInternet, "ptr", lpszUrl, "ptr", lpszHeaders, "uint", dwHeadersLength, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5896,7 +5896,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\InternetOpenUrlW", "ptr", hInternet, "ptr", lpszUrl, "ptr", lpszHeaders, "uint", dwHeadersLength, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\InternetOpenUrlW", "ptr", hInternet, "ptr", lpszUrl, "ptr", lpszHeaders, "uint", dwHeadersLength, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -6790,7 +6790,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\FtpFindFirstFileA", "ptr", hConnect, "ptr", lpszSearchFile, "ptr", lpFindFileData, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\FtpFindFirstFileA", "ptr", hConnect, "ptr", lpszSearchFile, "ptr", lpFindFileData, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -6860,7 +6860,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\FtpFindFirstFileW", "ptr", hConnect, "ptr", lpszSearchFile, "ptr", lpFindFileData, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\FtpFindFirstFileW", "ptr", hConnect, "ptr", lpszSearchFile, "ptr", lpFindFileData, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -7529,7 +7529,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\FtpOpenFileA", "ptr", hConnect, "ptr", lpszFileName, "uint", dwAccess, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\FtpOpenFileA", "ptr", hConnect, "ptr", lpszFileName, "uint", dwAccess, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -7578,7 +7578,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\FtpOpenFileW", "ptr", hConnect, "ptr", lpszFileName, "uint", dwAccess, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\FtpOpenFileW", "ptr", hConnect, "ptr", lpszFileName, "uint", dwAccess, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -8233,7 +8233,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\GopherFindFirstFileA", "ptr", hConnect, "ptr", lpszLocator, "ptr", lpszSearchString, "ptr", lpFindData, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\GopherFindFirstFileA", "ptr", hConnect, "ptr", lpszLocator, "ptr", lpszSearchString, "ptr", lpFindData, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -8293,7 +8293,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\GopherFindFirstFileW", "ptr", hConnect, "ptr", lpszLocator, "ptr", lpszSearchString, "ptr", lpFindData, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\GopherFindFirstFileW", "ptr", hConnect, "ptr", lpszLocator, "ptr", lpszSearchString, "ptr", lpFindData, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -8343,7 +8343,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\GopherOpenFileA", "ptr", hConnect, "ptr", lpszLocator, "ptr", lpszView, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\GopherOpenFileA", "ptr", hConnect, "ptr", lpszLocator, "ptr", lpszView, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -8393,7 +8393,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\GopherOpenFileW", "ptr", hConnect, "ptr", lpszLocator, "ptr", lpszView, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\GopherOpenFileW", "ptr", hConnect, "ptr", lpszLocator, "ptr", lpszView, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -8602,7 +8602,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\HttpOpenRequestA", "ptr", hConnect, "ptr", lpszVerb, "ptr", lpszObjectName, "ptr", lpszVersion, "ptr", lpszReferrer, "ptr", lplpszAcceptTypes, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\HttpOpenRequestA", "ptr", hConnect, "ptr", lpszVerb, "ptr", lpszObjectName, "ptr", lpszVersion, "ptr", lpszReferrer, "ptr", lplpszAcceptTypes, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -8694,7 +8694,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\HttpOpenRequestW", "ptr", hConnect, "ptr", lpszVerb, "ptr", lpszObjectName, "ptr", lpszVersion, "ptr", lpszReferrer, "ptr", lplpszAcceptTypes, "uint", dwFlags, "ptr", dwContext)
+        result := DllCall("WININET.dll\HttpOpenRequestW", "ptr", hConnect, "ptr", lpszVerb, "ptr", lpszObjectName, "ptr", lpszVersion, "ptr", lpszReferrer, "ptr", lplpszAcceptTypes, "uint", dwFlags, "ptr", dwContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11183,7 +11183,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\RetrieveUrlCacheEntryStreamA", "ptr", lpszUrlName, "ptr", lpCacheEntryInfo, "uint*", lpcbCacheEntryInfo, "int", fRandomRead, "uint", dwReserved)
+        result := DllCall("WININET.dll\RetrieveUrlCacheEntryStreamA", "ptr", lpszUrlName, "ptr", lpCacheEntryInfo, "uint*", lpcbCacheEntryInfo, "int", fRandomRead, "uint", dwReserved, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11263,7 +11263,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\RetrieveUrlCacheEntryStreamW", "ptr", lpszUrlName, "ptr", lpCacheEntryInfo, "uint*", lpcbCacheEntryInfo, "int", fRandomRead, "uint", dwReserved)
+        result := DllCall("WININET.dll\RetrieveUrlCacheEntryStreamW", "ptr", lpszUrlName, "ptr", lpCacheEntryInfo, "uint*", lpcbCacheEntryInfo, "int", fRandomRead, "uint", dwReserved, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11507,7 +11507,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\FindFirstUrlCacheGroup", "uint", dwFlags, "uint", dwFilter, "ptr", lpSearchCondition, "uint", dwSearchCondition, "int64*", lpGroupId, "ptr", lpReserved)
+        result := DllCall("WININET.dll\FindFirstUrlCacheGroup", "uint", dwFlags, "uint", dwFilter, "ptr", lpSearchCondition, "uint", dwSearchCondition, "int64*", lpGroupId, "ptr", lpReserved, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12219,7 +12219,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\FindFirstUrlCacheEntryExA", "ptr", lpszUrlSearchPattern, "uint", dwFlags, "uint", dwFilter, "int64", GroupId, "ptr", lpFirstCacheEntryInfo, "uint*", lpcbCacheEntryInfo, "ptr", lpGroupAttributes, "uint*", lpcbGroupAttributes, "ptr", lpReserved)
+        result := DllCall("WININET.dll\FindFirstUrlCacheEntryExA", "ptr", lpszUrlSearchPattern, "uint", dwFlags, "uint", dwFilter, "int64", GroupId, "ptr", lpFirstCacheEntryInfo, "uint*", lpcbCacheEntryInfo, "ptr", lpGroupAttributes, "uint*", lpcbGroupAttributes, "ptr", lpReserved, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12360,7 +12360,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\FindFirstUrlCacheEntryExW", "ptr", lpszUrlSearchPattern, "uint", dwFlags, "uint", dwFilter, "int64", GroupId, "ptr", lpFirstCacheEntryInfo, "uint*", lpcbCacheEntryInfo, "ptr", lpGroupAttributes, "uint*", lpcbGroupAttributes, "ptr", lpReserved)
+        result := DllCall("WININET.dll\FindFirstUrlCacheEntryExW", "ptr", lpszUrlSearchPattern, "uint", dwFlags, "uint", dwFilter, "int64", GroupId, "ptr", lpFirstCacheEntryInfo, "uint*", lpcbCacheEntryInfo, "ptr", lpGroupAttributes, "uint*", lpcbGroupAttributes, "ptr", lpReserved, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12483,7 +12483,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\FindFirstUrlCacheEntryA", "ptr", lpszUrlSearchPattern, "ptr", lpFirstCacheEntryInfo, "uint*", lpcbCacheEntryInfo)
+        result := DllCall("WININET.dll\FindFirstUrlCacheEntryA", "ptr", lpszUrlSearchPattern, "ptr", lpFirstCacheEntryInfo, "uint*", lpcbCacheEntryInfo, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12532,7 +12532,7 @@ class WinInet {
 
         A_LastError := 0
 
-        result := DllCall("WININET.dll\FindFirstUrlCacheEntryW", "ptr", lpszUrlSearchPattern, "ptr", lpFirstCacheEntryInfo, "uint*", lpcbCacheEntryInfo)
+        result := DllCall("WININET.dll\FindFirstUrlCacheEntryW", "ptr", lpszUrlSearchPattern, "ptr", lpFirstCacheEntryInfo, "uint*", lpcbCacheEntryInfo, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14537,7 +14537,7 @@ class WinInet {
      * @returns {Pointer<Void>} 
      */
     static FindFirstUrlCacheContainerA(pdwModified, lpContainerInfo, lpcbContainerInfo, dwOptions) {
-        result := DllCall("WININET.dll\FindFirstUrlCacheContainerA", "uint*", pdwModified, "ptr", lpContainerInfo, "uint*", lpcbContainerInfo, "uint", dwOptions)
+        result := DllCall("WININET.dll\FindFirstUrlCacheContainerA", "uint*", pdwModified, "ptr", lpContainerInfo, "uint*", lpcbContainerInfo, "uint", dwOptions, "ptr")
         return result
     }
 
@@ -14550,7 +14550,7 @@ class WinInet {
      * @returns {Pointer<Void>} 
      */
     static FindFirstUrlCacheContainerW(pdwModified, lpContainerInfo, lpcbContainerInfo, dwOptions) {
-        result := DllCall("WININET.dll\FindFirstUrlCacheContainerW", "uint*", pdwModified, "ptr", lpContainerInfo, "uint*", lpcbContainerInfo, "uint", dwOptions)
+        result := DllCall("WININET.dll\FindFirstUrlCacheContainerW", "uint*", pdwModified, "ptr", lpContainerInfo, "uint*", lpcbContainerInfo, "uint", dwOptions, "ptr")
         return result
     }
 
@@ -15522,7 +15522,7 @@ class WinInet {
      * @returns {Pointer<Void>} 
      */
     static HttpWebSocketCompleteUpgrade(hRequest, dwContext) {
-        result := DllCall("WININET.dll\HttpWebSocketCompleteUpgrade", "ptr", hRequest, "ptr", dwContext)
+        result := DllCall("WININET.dll\HttpWebSocketCompleteUpgrade", "ptr", hRequest, "ptr", dwContext, "ptr")
         return result
     }
 

--- a/Windows/Win32/Networking/WinSock/Apis.ahk
+++ b/Windows/Win32/Networking/WinSock/Apis.ahk
@@ -13612,7 +13612,7 @@ class WinSock {
 
         A_LastError := 0
 
-        result := DllCall("WS2_32.dll\WSAAsyncGetServByName", "ptr", hWnd, "uint", wMsg, "ptr", name, "ptr", proto, "ptr", buf, "int", buflen)
+        result := DllCall("WS2_32.dll\WSAAsyncGetServByName", "ptr", hWnd, "uint", wMsg, "ptr", name, "ptr", proto, "ptr", buf, "int", buflen, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -13788,7 +13788,7 @@ class WinSock {
 
         A_LastError := 0
 
-        result := DllCall("WS2_32.dll\WSAAsyncGetServByPort", "ptr", hWnd, "uint", wMsg, "int", port, "ptr", proto, "ptr", buf, "int", buflen)
+        result := DllCall("WS2_32.dll\WSAAsyncGetServByPort", "ptr", hWnd, "uint", wMsg, "int", port, "ptr", proto, "ptr", buf, "int", buflen, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -13960,7 +13960,7 @@ class WinSock {
 
         A_LastError := 0
 
-        result := DllCall("WS2_32.dll\WSAAsyncGetProtoByName", "ptr", hWnd, "uint", wMsg, "ptr", name, "ptr", buf, "int", buflen)
+        result := DllCall("WS2_32.dll\WSAAsyncGetProtoByName", "ptr", hWnd, "uint", wMsg, "ptr", name, "ptr", buf, "int", buflen, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14130,7 +14130,7 @@ class WinSock {
     static WSAAsyncGetProtoByNumber(hWnd, wMsg, number, buf, buflen) {
         A_LastError := 0
 
-        result := DllCall("WS2_32.dll\WSAAsyncGetProtoByNumber", "ptr", hWnd, "uint", wMsg, "int", number, "ptr", buf, "int", buflen)
+        result := DllCall("WS2_32.dll\WSAAsyncGetProtoByNumber", "ptr", hWnd, "uint", wMsg, "int", number, "ptr", buf, "int", buflen, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14178,7 +14178,7 @@ class WinSock {
 
         A_LastError := 0
 
-        result := DllCall("WS2_32.dll\WSAAsyncGetHostByName", "ptr", hWnd, "uint", wMsg, "ptr", name, "ptr", buf, "int", buflen)
+        result := DllCall("WS2_32.dll\WSAAsyncGetHostByName", "ptr", hWnd, "uint", wMsg, "ptr", name, "ptr", buf, "int", buflen, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14225,7 +14225,7 @@ class WinSock {
     static WSAAsyncGetHostByAddr(hWnd, wMsg, addr, len, type, buf, buflen) {
         A_LastError := 0
 
-        result := DllCall("WS2_32.dll\WSAAsyncGetHostByAddr", "ptr", hWnd, "uint", wMsg, "ptr", addr, "int", len, "int", type, "ptr", buf, "int", buflen)
+        result := DllCall("WS2_32.dll\WSAAsyncGetHostByAddr", "ptr", hWnd, "uint", wMsg, "ptr", addr, "int", len, "int", type, "ptr", buf, "int", buflen, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/Security/Apis.ahk
+++ b/Windows/Win32/Security/Apis.ahk
@@ -3005,7 +3005,7 @@ class Security {
      * @since windows5.1.2600
      */
     static FreeSid(pSid) {
-        result := DllCall("ADVAPI32.dll\FreeSid", "ptr", pSid)
+        result := DllCall("ADVAPI32.dll\FreeSid", "ptr", pSid, "ptr")
         return result
     }
 

--- a/Windows/Win32/Security/Authorization/UI/Apis.ahk
+++ b/Windows/Win32/Security/Authorization/UI/Apis.ahk
@@ -172,7 +172,7 @@ class UI {
     static CreateSecurityPage(psi) {
         A_LastError := 0
 
-        result := DllCall("ACLUI.dll\CreateSecurityPage", "ptr", psi)
+        result := DllCall("ACLUI.dll\CreateSecurityPage", "ptr", psi, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/Security/Credentials/Apis.ahk
+++ b/Windows/Win32/Security/Credentials/Apis.ahk
@@ -7112,7 +7112,7 @@ class Credentials {
     static SCardAccessStartedEvent() {
         A_LastError := 0
 
-        result := DllCall("WinSCard.dll\SCardAccessStartedEvent")
+        result := DllCall("WinSCard.dll\SCardAccessStartedEvent", "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/Security/Cryptography/Apis.ahk
+++ b/Windows/Win32/Security/Cryptography/Apis.ahk
@@ -30815,7 +30815,7 @@ class Cryptography {
     static CryptInitOIDFunctionSet(pszFuncName, dwFlags) {
         pszFuncName := pszFuncName is String? StrPtr(pszFuncName) : pszFuncName
 
-        result := DllCall("CRYPT32.dll\CryptInitOIDFunctionSet", "ptr", pszFuncName, "uint", dwFlags)
+        result := DllCall("CRYPT32.dll\CryptInitOIDFunctionSet", "ptr", pszFuncName, "uint", dwFlags, "ptr")
         return result
     }
 
@@ -31717,7 +31717,7 @@ class Cryptography {
 
         A_LastError := 0
 
-        result := DllCall("CRYPT32.dll\CryptMsgOpenToEncode", "uint", dwMsgEncodingType, "uint", dwFlags, "uint", dwMsgType, "ptr", pvMsgEncodeInfo, "ptr", pszInnerContentObjID, "ptr", pStreamInfo)
+        result := DllCall("CRYPT32.dll\CryptMsgOpenToEncode", "uint", dwMsgEncodingType, "uint", dwFlags, "uint", dwMsgType, "ptr", pvMsgEncodeInfo, "ptr", pszInnerContentObjID, "ptr", pStreamInfo, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -32124,7 +32124,7 @@ class Cryptography {
 
         A_LastError := 0
 
-        result := DllCall("CRYPT32.dll\CryptMsgOpenToDecode", "uint", dwMsgEncodingType, "uint", dwFlags, "uint", dwMsgType, "ptr", hCryptProv, "ptr", pRecipientInfo, "ptr", pStreamInfo)
+        result := DllCall("CRYPT32.dll\CryptMsgOpenToDecode", "uint", dwMsgEncodingType, "uint", dwFlags, "uint", dwMsgType, "ptr", hCryptProv, "ptr", pRecipientInfo, "ptr", pStreamInfo, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -32142,7 +32142,7 @@ class Cryptography {
      * @since windows5.1.2600
      */
     static CryptMsgDuplicate(hCryptMsg) {
-        result := DllCall("CRYPT32.dll\CryptMsgDuplicate", "ptr", hCryptMsg)
+        result := DllCall("CRYPT32.dll\CryptMsgDuplicate", "ptr", hCryptMsg, "ptr")
         return result
     }
 
@@ -34345,7 +34345,7 @@ class Cryptography {
 
         A_LastError := 0
 
-        result := DllCall("CRYPT32.dll\CertOpenStore", "ptr", lpszStoreProvider, "uint", dwEncodingType, "ptr", hCryptProv, "uint", dwFlags, "ptr", pvPara)
+        result := DllCall("CRYPT32.dll\CertOpenStore", "ptr", lpszStoreProvider, "uint", dwEncodingType, "ptr", hCryptProv, "uint", dwFlags, "ptr", pvPara, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -34360,7 +34360,7 @@ class Cryptography {
      * @since windows5.1.2600
      */
     static CertDuplicateStore(hCertStore) {
-        result := DllCall("CRYPT32.dll\CertDuplicateStore", "ptr", hCertStore)
+        result := DllCall("CRYPT32.dll\CertDuplicateStore", "ptr", hCertStore, "ptr")
         return result
     }
 
@@ -39728,7 +39728,7 @@ class Cryptography {
     static CertCreateContext(dwContextType, dwEncodingType, pbEncoded, cbEncoded, dwFlags, pCreatePara) {
         A_LastError := 0
 
-        result := DllCall("CRYPT32.dll\CertCreateContext", "uint", dwContextType, "uint", dwEncodingType, "ptr", pbEncoded, "uint", cbEncoded, "uint", dwFlags, "ptr", pCreatePara)
+        result := DllCall("CRYPT32.dll\CertCreateContext", "uint", dwContextType, "uint", dwEncodingType, "ptr", pbEncoded, "uint", cbEncoded, "uint", dwFlags, "ptr", pCreatePara, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -44846,7 +44846,7 @@ class Cryptography {
     static CryptGetMessageCertificates(dwMsgAndCertEncodingType, hCryptProv, dwFlags, pbSignedBlob, cbSignedBlob) {
         A_LastError := 0
 
-        result := DllCall("CRYPT32.dll\CryptGetMessageCertificates", "uint", dwMsgAndCertEncodingType, "ptr", hCryptProv, "uint", dwFlags, "ptr", pbSignedBlob, "uint", cbSignedBlob)
+        result := DllCall("CRYPT32.dll\CryptGetMessageCertificates", "uint", dwMsgAndCertEncodingType, "ptr", hCryptProv, "uint", dwFlags, "ptr", pbSignedBlob, "uint", cbSignedBlob, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -45964,7 +45964,7 @@ class Cryptography {
 
         A_LastError := 0
 
-        result := DllCall("CRYPT32.dll\CertOpenSystemStoreA", "ptr", hProv, "ptr", szSubsystemProtocol)
+        result := DllCall("CRYPT32.dll\CertOpenSystemStoreA", "ptr", hProv, "ptr", szSubsystemProtocol, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -46046,7 +46046,7 @@ class Cryptography {
 
         A_LastError := 0
 
-        result := DllCall("CRYPT32.dll\CertOpenSystemStoreW", "ptr", hProv, "ptr", szSubsystemProtocol)
+        result := DllCall("CRYPT32.dll\CertOpenSystemStoreW", "ptr", hProv, "ptr", szSubsystemProtocol, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -46361,7 +46361,7 @@ class Cryptography {
      * @since windows5.1.2600
      */
     static CryptMemAlloc(cbSize) {
-        result := DllCall("CRYPT32.dll\CryptMemAlloc", "uint", cbSize)
+        result := DllCall("CRYPT32.dll\CryptMemAlloc", "uint", cbSize, "ptr")
         return result
     }
 
@@ -46374,7 +46374,7 @@ class Cryptography {
      * @since windows5.1.2600
      */
     static CryptMemRealloc(pv, cbSize) {
-        result := DllCall("CRYPT32.dll\CryptMemRealloc", "ptr", pv, "uint", cbSize)
+        result := DllCall("CRYPT32.dll\CryptMemRealloc", "ptr", pv, "uint", cbSize, "ptr")
         return result
     }
 
@@ -48164,7 +48164,7 @@ class Cryptography {
 
         A_LastError := 0
 
-        result := DllCall("CRYPT32.dll\PFXImportCertStore", "ptr", pPFX, "ptr", szPassword, "uint", dwFlags)
+        result := DllCall("CRYPT32.dll\PFXImportCertStore", "ptr", pPFX, "ptr", szPassword, "uint", dwFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -48547,7 +48547,7 @@ class Cryptography {
     static CertOpenServerOcspResponse(pChainContext, dwFlags, pOpenPara) {
         A_LastError := 0
 
-        result := DllCall("CRYPT32.dll\CertOpenServerOcspResponse", "ptr", pChainContext, "uint", dwFlags, "ptr", pOpenPara)
+        result := DllCall("CRYPT32.dll\CertOpenServerOcspResponse", "ptr", pChainContext, "uint", dwFlags, "ptr", pOpenPara, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/Security/Cryptography/Catalog/Apis.ahk
+++ b/Windows/Win32/Security/Cryptography/Catalog/Apis.ahk
@@ -124,7 +124,7 @@ class Catalog {
     static CryptCATOpen(pwszFileName, fdwOpenFlags, hProv, dwPublicVersion, dwEncodingType) {
         pwszFileName := pwszFileName is String? StrPtr(pwszFileName) : pwszFileName
 
-        result := DllCall("WINTRUST.dll\CryptCATOpen", "ptr", pwszFileName, "uint", fdwOpenFlags, "ptr", hProv, "uint", dwPublicVersion, "uint", dwEncodingType)
+        result := DllCall("WINTRUST.dll\CryptCATOpen", "ptr", pwszFileName, "uint", fdwOpenFlags, "ptr", hProv, "uint", dwPublicVersion, "uint", dwEncodingType, "ptr")
         return result
     }
 
@@ -160,7 +160,7 @@ class Catalog {
      * @since windows5.1.2600
      */
     static CryptCATHandleFromStore(pCatStore) {
-        result := DllCall("WINTRUST.dll\CryptCATHandleFromStore", "ptr", pCatStore)
+        result := DllCall("WINTRUST.dll\CryptCATHandleFromStore", "ptr", pCatStore, "ptr")
         return result
     }
 

--- a/Windows/Win32/Storage/CloudFilters/Apis.ahk
+++ b/Windows/Win32/Storage/CloudFilters/Apis.ahk
@@ -467,7 +467,7 @@ class CloudFilters {
      * @since windows10.0.16299
      */
     static CfGetWin32HandleFromProtectedHandle(ProtectedHandle) {
-        result := DllCall("cldapi.dll\CfGetWin32HandleFromProtectedHandle", "ptr", ProtectedHandle)
+        result := DllCall("cldapi.dll\CfGetWin32HandleFromProtectedHandle", "ptr", ProtectedHandle, "ptr")
         return result
     }
 

--- a/Windows/Win32/Storage/FileSystem/Apis.ahk
+++ b/Windows/Win32/Storage/FileSystem/Apis.ahk
@@ -3100,7 +3100,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateFileA", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwCreationDisposition, "uint", dwFlagsAndAttributes, "ptr", hTemplateFile)
+        result := DllCall("KERNEL32.dll\CreateFileA", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwCreationDisposition, "uint", dwFlagsAndAttributes, "ptr", hTemplateFile, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4125,7 +4125,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateFileW", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwCreationDisposition, "uint", dwFlagsAndAttributes, "ptr", hTemplateFile)
+        result := DllCall("KERNEL32.dll\CreateFileW", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwCreationDisposition, "uint", dwFlagsAndAttributes, "ptr", hTemplateFile, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4915,7 +4915,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstChangeNotificationA", "ptr", lpPathName, "int", bWatchSubtree, "uint", dwNotifyFilter)
+        result := DllCall("KERNEL32.dll\FindFirstChangeNotificationA", "ptr", lpPathName, "int", bWatchSubtree, "uint", dwNotifyFilter, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5021,7 +5021,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstChangeNotificationW", "ptr", lpPathName, "int", bWatchSubtree, "uint", dwNotifyFilter)
+        result := DllCall("KERNEL32.dll\FindFirstChangeNotificationW", "ptr", lpPathName, "int", bWatchSubtree, "uint", dwNotifyFilter, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5204,7 +5204,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstFileA", "ptr", lpFileName, "ptr", lpFindFileData)
+        result := DllCall("KERNEL32.dll\FindFirstFileA", "ptr", lpFileName, "ptr", lpFindFileData, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5387,7 +5387,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstFileW", "ptr", lpFileName, "ptr", lpFindFileData)
+        result := DllCall("KERNEL32.dll\FindFirstFileW", "ptr", lpFileName, "ptr", lpFindFileData, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5649,7 +5649,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstFileExA", "ptr", lpFileName, "int", fInfoLevelId, "ptr", lpFindFileData, "int", fSearchOp, "ptr", lpSearchFilter, "uint", dwAdditionalFlags)
+        result := DllCall("KERNEL32.dll\FindFirstFileExA", "ptr", lpFileName, "int", fInfoLevelId, "ptr", lpFindFileData, "int", fSearchOp, "ptr", lpSearchFilter, "uint", dwAdditionalFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5911,7 +5911,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstFileExW", "ptr", lpFileName, "int", fInfoLevelId, "ptr", lpFindFileData, "int", fSearchOp, "ptr", lpSearchFilter, "uint", dwAdditionalFlags)
+        result := DllCall("KERNEL32.dll\FindFirstFileExW", "ptr", lpFileName, "int", fInfoLevelId, "ptr", lpFindFileData, "int", fSearchOp, "ptr", lpSearchFilter, "uint", dwAdditionalFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -6011,7 +6011,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstVolumeW", "ptr", lpszVolumeName, "uint", cchBufferLength)
+        result := DllCall("KERNEL32.dll\FindFirstVolumeW", "ptr", lpszVolumeName, "uint", cchBufferLength, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14831,7 +14831,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateFile2", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "uint", dwCreationDisposition, "ptr", pCreateExParams)
+        result := DllCall("KERNEL32.dll\CreateFile2", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "uint", dwCreationDisposition, "ptr", pCreateExParams, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -15288,7 +15288,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstStreamW", "ptr", lpFileName, "int", InfoLevel, "ptr", lpFindStreamData, "uint", dwFlags)
+        result := DllCall("KERNEL32.dll\FindFirstStreamW", "ptr", lpFileName, "int", InfoLevel, "ptr", lpFindStreamData, "uint", dwFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -15667,7 +15667,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstFileNameW", "ptr", lpFileName, "uint", dwFlags, "uint*", StringLength, "ptr", LinkName)
+        result := DllCall("KERNEL32.dll\FindFirstFileNameW", "ptr", lpFileName, "uint", dwFlags, "uint*", StringLength, "ptr", LinkName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -17129,7 +17129,7 @@ class FileSystem {
     static CreateFileFromAppW(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile) {
         lpFileName := lpFileName is String? StrPtr(lpFileName) : lpFileName
 
-        result := DllCall("api-ms-win-core-file-fromapp-l1-1-0.dll\CreateFileFromAppW", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwCreationDisposition, "uint", dwFlagsAndAttributes, "ptr", hTemplateFile)
+        result := DllCall("api-ms-win-core-file-fromapp-l1-1-0.dll\CreateFileFromAppW", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwCreationDisposition, "uint", dwFlagsAndAttributes, "ptr", hTemplateFile, "ptr")
         return result
     }
 
@@ -17166,7 +17166,7 @@ class FileSystem {
     static CreateFile2FromAppW(lpFileName, dwDesiredAccess, dwShareMode, dwCreationDisposition, pCreateExParams) {
         lpFileName := lpFileName is String? StrPtr(lpFileName) : lpFileName
 
-        result := DllCall("api-ms-win-core-file-fromapp-l1-1-0.dll\CreateFile2FromAppW", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "uint", dwCreationDisposition, "ptr", pCreateExParams)
+        result := DllCall("api-ms-win-core-file-fromapp-l1-1-0.dll\CreateFile2FromAppW", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "uint", dwCreationDisposition, "ptr", pCreateExParams, "ptr")
         return result
     }
 
@@ -17251,7 +17251,7 @@ class FileSystem {
 
         lpFileName := lpFileName is String? StrPtr(lpFileName) : lpFileName
 
-        result := DllCall("api-ms-win-core-file-fromapp-l1-1-0.dll\FindFirstFileExFromAppW", "ptr", lpFileName, "int", fInfoLevelId, "ptr", lpFindFileData, "int", fSearchOp, "ptr", lpSearchFilter, "uint", dwAdditionalFlags)
+        result := DllCall("api-ms-win-core-file-fromapp-l1-1-0.dll\FindFirstFileExFromAppW", "ptr", lpFileName, "int", fInfoLevelId, "ptr", lpFindFileData, "int", fSearchOp, "ptr", lpSearchFilter, "uint", dwAdditionalFlags, "ptr")
         return result
     }
 
@@ -19338,7 +19338,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("clfsw32.dll\CreateLogFile", "ptr", pszLogFileName, "uint", fDesiredAccess, "uint", dwShareMode, "ptr", psaLogFile, "uint", fCreateDisposition, "uint", fFlagsAndAttributes)
+        result := DllCall("clfsw32.dll\CreateLogFile", "ptr", pszLogFileName, "uint", fDesiredAccess, "uint", dwShareMode, "ptr", psaLogFile, "uint", fCreateDisposition, "uint", fFlagsAndAttributes, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -23654,7 +23654,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("ktmw32.dll\CreateTransaction", "ptr", lpTransactionAttributes, "ptr", UOW, "uint", CreateOptions, "uint", IsolationLevel, "uint", IsolationFlags, "uint", Timeout, "ptr", Description)
+        result := DllCall("ktmw32.dll\CreateTransaction", "ptr", lpTransactionAttributes, "ptr", UOW, "uint", CreateOptions, "uint", IsolationLevel, "uint", IsolationFlags, "uint", Timeout, "ptr", Description, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -23678,7 +23678,7 @@ class FileSystem {
     static OpenTransaction(dwDesiredAccess, TransactionId) {
         A_LastError := 0
 
-        result := DllCall("ktmw32.dll\OpenTransaction", "uint", dwDesiredAccess, "ptr", TransactionId)
+        result := DllCall("ktmw32.dll\OpenTransaction", "uint", dwDesiredAccess, "ptr", TransactionId, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -23897,7 +23897,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("ktmw32.dll\CreateTransactionManager", "ptr", lpTransactionAttributes, "ptr", LogFileName, "uint", CreateOptions, "uint", CommitStrength)
+        result := DllCall("ktmw32.dll\CreateTransactionManager", "ptr", lpTransactionAttributes, "ptr", LogFileName, "uint", CreateOptions, "uint", CommitStrength, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -23926,7 +23926,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("ktmw32.dll\OpenTransactionManager", "ptr", LogFileName, "uint", DesiredAccess, "uint", OpenOptions)
+        result := DllCall("ktmw32.dll\OpenTransactionManager", "ptr", LogFileName, "uint", DesiredAccess, "uint", OpenOptions, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -23951,7 +23951,7 @@ class FileSystem {
     static OpenTransactionManagerById(TransactionManagerId, DesiredAccess, OpenOptions) {
         A_LastError := 0
 
-        result := DllCall("ktmw32.dll\OpenTransactionManagerById", "ptr", TransactionManagerId, "uint", DesiredAccess, "uint", OpenOptions)
+        result := DllCall("ktmw32.dll\OpenTransactionManagerById", "ptr", TransactionManagerId, "uint", DesiredAccess, "uint", OpenOptions, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -24126,7 +24126,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("ktmw32.dll\CreateResourceManager", "ptr", lpResourceManagerAttributes, "ptr", ResourceManagerId, "uint", CreateOptions, "ptr", TmHandle, "ptr", Description)
+        result := DllCall("ktmw32.dll\CreateResourceManager", "ptr", lpResourceManagerAttributes, "ptr", ResourceManagerId, "uint", CreateOptions, "ptr", TmHandle, "ptr", Description, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -24151,7 +24151,7 @@ class FileSystem {
     static OpenResourceManager(dwDesiredAccess, TmHandle, ResourceManagerId) {
         A_LastError := 0
 
-        result := DllCall("ktmw32.dll\OpenResourceManager", "uint", dwDesiredAccess, "ptr", TmHandle, "ptr", ResourceManagerId)
+        result := DllCall("ktmw32.dll\OpenResourceManager", "uint", dwDesiredAccess, "ptr", TmHandle, "ptr", ResourceManagerId, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -24357,7 +24357,7 @@ class FileSystem {
     static CreateEnlistment(lpEnlistmentAttributes, ResourceManagerHandle, TransactionHandle, NotificationMask, CreateOptions, EnlistmentKey) {
         A_LastError := 0
 
-        result := DllCall("ktmw32.dll\CreateEnlistment", "ptr", lpEnlistmentAttributes, "ptr", ResourceManagerHandle, "ptr", TransactionHandle, "uint", NotificationMask, "uint", CreateOptions, "ptr", EnlistmentKey)
+        result := DllCall("ktmw32.dll\CreateEnlistment", "ptr", lpEnlistmentAttributes, "ptr", ResourceManagerHandle, "ptr", TransactionHandle, "uint", NotificationMask, "uint", CreateOptions, "ptr", EnlistmentKey, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -24380,7 +24380,7 @@ class FileSystem {
     static OpenEnlistment(dwDesiredAccess, ResourceManagerHandle, EnlistmentId) {
         A_LastError := 0
 
-        result := DllCall("ktmw32.dll\OpenEnlistment", "uint", dwDesiredAccess, "ptr", ResourceManagerHandle, "ptr", EnlistmentId)
+        result := DllCall("ktmw32.dll\OpenEnlistment", "uint", dwDesiredAccess, "ptr", ResourceManagerHandle, "ptr", EnlistmentId, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -34156,7 +34156,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateFileTransactedA", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwCreationDisposition, "uint", dwFlagsAndAttributes, "ptr", hTemplateFile, "ptr", hTransaction, "uint*", pusMiniVersion, "ptr", lpExtendedParameter)
+        result := DllCall("KERNEL32.dll\CreateFileTransactedA", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwCreationDisposition, "uint", dwFlagsAndAttributes, "ptr", hTemplateFile, "ptr", hTransaction, "uint*", pusMiniVersion, "ptr", lpExtendedParameter, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -34833,7 +34833,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateFileTransactedW", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwCreationDisposition, "uint", dwFlagsAndAttributes, "ptr", hTemplateFile, "ptr", hTransaction, "uint*", pusMiniVersion, "ptr", lpExtendedParameter)
+        result := DllCall("KERNEL32.dll\CreateFileTransactedW", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwCreationDisposition, "uint", dwFlagsAndAttributes, "ptr", hTemplateFile, "ptr", hTransaction, "uint*", pusMiniVersion, "ptr", lpExtendedParameter, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -34932,7 +34932,7 @@ class FileSystem {
     static ReOpenFile(hOriginalFile, dwDesiredAccess, dwShareMode, dwFlagsAndAttributes) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\ReOpenFile", "ptr", hOriginalFile, "uint", dwDesiredAccess, "uint", dwShareMode, "uint", dwFlagsAndAttributes)
+        result := DllCall("KERNEL32.dll\ReOpenFile", "ptr", hOriginalFile, "uint", dwDesiredAccess, "uint", dwShareMode, "uint", dwFlagsAndAttributes, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -36569,7 +36569,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstFileTransactedA", "ptr", lpFileName, "int", fInfoLevelId, "ptr", lpFindFileData, "int", fSearchOp, "ptr", lpSearchFilter, "uint", dwAdditionalFlags, "ptr", hTransaction)
+        result := DllCall("KERNEL32.dll\FindFirstFileTransactedA", "ptr", lpFileName, "int", fInfoLevelId, "ptr", lpFindFileData, "int", fSearchOp, "ptr", lpSearchFilter, "uint", dwAdditionalFlags, "ptr", hTransaction, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -36774,7 +36774,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstFileTransactedW", "ptr", lpFileName, "int", fInfoLevelId, "ptr", lpFindFileData, "int", fSearchOp, "ptr", lpSearchFilter, "uint", dwAdditionalFlags, "ptr", hTransaction)
+        result := DllCall("KERNEL32.dll\FindFirstFileTransactedW", "ptr", lpFileName, "int", fInfoLevelId, "ptr", lpFindFileData, "int", fSearchOp, "ptr", lpSearchFilter, "uint", dwAdditionalFlags, "ptr", hTransaction, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -40562,7 +40562,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstStreamTransactedW", "ptr", lpFileName, "int", InfoLevel, "ptr", lpFindStreamData, "uint", dwFlags, "ptr", hTransaction)
+        result := DllCall("KERNEL32.dll\FindFirstStreamTransactedW", "ptr", lpFileName, "int", InfoLevel, "ptr", lpFindStreamData, "uint", dwFlags, "ptr", hTransaction, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -40661,7 +40661,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstFileNameTransactedW", "ptr", lpFileName, "uint", dwFlags, "uint*", StringLength, "ptr", LinkName, "ptr", hTransaction)
+        result := DllCall("KERNEL32.dll\FindFirstFileNameTransactedW", "ptr", lpFileName, "uint", dwFlags, "uint*", StringLength, "ptr", LinkName, "ptr", hTransaction, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -41472,7 +41472,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstVolumeA", "ptr", lpszVolumeName, "uint", cchBufferLength)
+        result := DllCall("KERNEL32.dll\FindFirstVolumeA", "ptr", lpszVolumeName, "uint", cchBufferLength, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -41688,7 +41688,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstVolumeMountPointA", "ptr", lpszRootPathName, "ptr", lpszVolumeMountPoint, "uint", cchBufferLength)
+        result := DllCall("KERNEL32.dll\FindFirstVolumeMountPointA", "ptr", lpszRootPathName, "ptr", lpszVolumeMountPoint, "uint", cchBufferLength, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -41805,7 +41805,7 @@ class FileSystem {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindFirstVolumeMountPointW", "ptr", lpszRootPathName, "ptr", lpszVolumeMountPoint, "uint", cchBufferLength)
+        result := DllCall("KERNEL32.dll\FindFirstVolumeMountPointW", "ptr", lpszRootPathName, "ptr", lpszVolumeMountPoint, "uint", cchBufferLength, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -43286,7 +43286,7 @@ class FileSystem {
     static OpenFileById(hVolumeHint, lpFileId, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwFlagsAndAttributes) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\OpenFileById", "ptr", hVolumeHint, "ptr", lpFileId, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwFlagsAndAttributes)
+        result := DllCall("KERNEL32.dll\OpenFileById", "ptr", hVolumeHint, "ptr", lpFileId, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwFlagsAndAttributes, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/Storage/Packaging/Appx/Apis.ahk
+++ b/Windows/Win32/Storage/Packaging/Appx/Apis.ahk
@@ -2610,7 +2610,7 @@ class Appx {
      * @returns {Pointer<Void>} 
      */
     static GetCurrentPackageVirtualizationContext() {
-        result := DllCall("KERNEL32.dll\GetCurrentPackageVirtualizationContext")
+        result := DllCall("KERNEL32.dll\GetCurrentPackageVirtualizationContext", "ptr")
         return result
     }
 

--- a/Windows/Win32/System/AddressBook/Apis.ahk
+++ b/Windows/Win32/System/AddressBook/Apis.ahk
@@ -1259,7 +1259,7 @@ class AddressBook {
      * @see https://learn.microsoft.com/office/client-developer/outlook/mapi/ftgregisteridleroutine
      */
     static FtgRegisterIdleRoutine(lpfnIdle, lpvIdleParam, priIdle, csecIdle, iroIdle) {
-        result := DllCall("MAPI32.dll\FtgRegisterIdleRoutine", "ptr", lpfnIdle, "ptr", lpvIdleParam, "short", priIdle, "uint", csecIdle, "ushort", iroIdle)
+        result := DllCall("MAPI32.dll\FtgRegisterIdleRoutine", "ptr", lpfnIdle, "ptr", lpvIdleParam, "short", priIdle, "uint", csecIdle, "ushort", iroIdle, "ptr")
         return result
     }
 

--- a/Windows/Win32/System/ApplicationInstallationAndServicing/Apis.ahk
+++ b/Windows/Win32/System/ApplicationInstallationAndServicing/Apis.ahk
@@ -33642,7 +33642,7 @@ class ApplicationInstallationAndServicing {
     static CreateActCtxA(pActCtx) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateActCtxA", "ptr", pActCtx)
+        result := DllCall("KERNEL32.dll\CreateActCtxA", "ptr", pActCtx, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -33678,7 +33678,7 @@ class ApplicationInstallationAndServicing {
     static CreateActCtxW(pActCtx) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateActCtxW", "ptr", pActCtx)
+        result := DllCall("KERNEL32.dll\CreateActCtxW", "ptr", pActCtx, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/Com/Apis.ahk
+++ b/Windows/Win32/System/Com/Apis.ahk
@@ -584,7 +584,7 @@ class Com {
     static CoLoadLibrary(lpszLibName, bAutoFree) {
         lpszLibName := lpszLibName is String? StrPtr(lpszLibName) : lpszLibName
 
-        result := DllCall("OLE32.dll\CoLoadLibrary", "ptr", lpszLibName, "int", bAutoFree)
+        result := DllCall("OLE32.dll\CoLoadLibrary", "ptr", lpszLibName, "int", bAutoFree, "ptr")
         return result
     }
 
@@ -4996,7 +4996,7 @@ class Com {
      * @since windows5.0
      */
     static CoTaskMemAlloc(cb) {
-        result := DllCall("OLE32.dll\CoTaskMemAlloc", "ptr", cb)
+        result := DllCall("OLE32.dll\CoTaskMemAlloc", "ptr", cb, "ptr")
         return result
     }
 
@@ -5019,7 +5019,7 @@ class Com {
      * @since windows5.0
      */
     static CoTaskMemRealloc(pv, cb) {
-        result := DllCall("OLE32.dll\CoTaskMemRealloc", "ptr", pv, "ptr", cb)
+        result := DllCall("OLE32.dll\CoTaskMemRealloc", "ptr", pv, "ptr", cb, "ptr")
         return result
     }
 

--- a/Windows/Win32/System/Console/Apis.ahk
+++ b/Windows/Win32/System/Console/Apis.ahk
@@ -1028,7 +1028,7 @@ class Console {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateConsoleScreenBuffer", "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwFlags, "ptr", lpScreenBufferData)
+        result := DllCall("KERNEL32.dll\CreateConsoleScreenBuffer", "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwFlags, "ptr", lpScreenBufferData, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2257,7 +2257,7 @@ class Console {
      * @see https://learn.microsoft.com/windows/console/getconsolewindow
      */
     static GetConsoleWindow() {
-        result := DllCall("KERNEL32.dll\GetConsoleWindow")
+        result := DllCall("KERNEL32.dll\GetConsoleWindow", "ptr")
         return result
     }
 
@@ -2730,7 +2730,7 @@ class Console {
     static GetStdHandle(nStdHandle) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\GetStdHandle", "uint", nStdHandle)
+        result := DllCall("KERNEL32.dll\GetStdHandle", "uint", nStdHandle, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/DataExchange/Apis.ahk
+++ b/Windows/Win32/System/DataExchange/Apis.ahk
@@ -754,7 +754,7 @@ class DataExchange {
      * @since windows5.0
      */
     static DdeConnectList(idInst, hszService, hszTopic, hConvList, pCC) {
-        result := DllCall("USER32.dll\DdeConnectList", "uint", idInst, "ptr", hszService, "ptr", hszTopic, "ptr", hConvList, "ptr", pCC)
+        result := DllCall("USER32.dll\DdeConnectList", "uint", idInst, "ptr", hszService, "ptr", hszTopic, "ptr", hConvList, "ptr", pCC, "ptr")
         return result
     }
 
@@ -773,7 +773,7 @@ class DataExchange {
      * @since windows5.0
      */
     static DdeQueryNextServer(hConvList, hConvPrev) {
-        result := DllCall("USER32.dll\DdeQueryNextServer", "ptr", hConvList, "ptr", hConvPrev)
+        result := DllCall("USER32.dll\DdeQueryNextServer", "ptr", hConvList, "ptr", hConvPrev, "ptr")
         return result
     }
 
@@ -833,7 +833,7 @@ class DataExchange {
      * @since windows5.0
      */
     static DdeConnect(idInst, hszService, hszTopic, pCC) {
-        result := DllCall("USER32.dll\DdeConnect", "uint", idInst, "ptr", hszService, "ptr", hszTopic, "ptr", pCC)
+        result := DllCall("USER32.dll\DdeConnect", "uint", idInst, "ptr", hszService, "ptr", hszTopic, "ptr", pCC, "ptr")
         return result
     }
 
@@ -875,7 +875,7 @@ class DataExchange {
      * @since windows5.0
      */
     static DdeReconnect(hConv) {
-        result := DllCall("USER32.dll\DdeReconnect", "ptr", hConv)
+        result := DllCall("USER32.dll\DdeReconnect", "ptr", hConv, "ptr")
         return result
     }
 
@@ -1095,7 +1095,7 @@ class DataExchange {
      * @since windows5.0
      */
     static DdeNameService(idInst, hsz1, hsz2, afCmd) {
-        result := DllCall("USER32.dll\DdeNameService", "uint", idInst, "ptr", hsz1, "ptr", hsz2, "uint", afCmd)
+        result := DllCall("USER32.dll\DdeNameService", "uint", idInst, "ptr", hsz1, "ptr", hsz2, "uint", afCmd, "ptr")
         return result
     }
 
@@ -1160,7 +1160,7 @@ class DataExchange {
      * @since windows5.0
      */
     static DdeClientTransaction(pData, cbData, hConv, hszItem, wFmt, wType, dwTimeout, pdwResult) {
-        result := DllCall("USER32.dll\DdeClientTransaction", "char*", pData, "uint", cbData, "ptr", hConv, "ptr", hszItem, "uint", wFmt, "uint", wType, "uint", dwTimeout, "uint*", pdwResult)
+        result := DllCall("USER32.dll\DdeClientTransaction", "char*", pData, "uint", cbData, "ptr", hConv, "ptr", hszItem, "uint", wFmt, "uint", wType, "uint", dwTimeout, "uint*", pdwResult, "ptr")
         return result
     }
 
@@ -1205,7 +1205,7 @@ class DataExchange {
      * @since windows5.0
      */
     static DdeCreateDataHandle(idInst, pSrc, cb, cbOff, hszItem, wFmt, afCmd) {
-        result := DllCall("USER32.dll\DdeCreateDataHandle", "uint", idInst, "ptr", pSrc, "uint", cb, "uint", cbOff, "ptr", hszItem, "uint", wFmt, "uint", afCmd)
+        result := DllCall("USER32.dll\DdeCreateDataHandle", "uint", idInst, "ptr", pSrc, "uint", cb, "uint", cbOff, "ptr", hszItem, "uint", wFmt, "uint", afCmd, "ptr")
         return result
     }
 
@@ -1238,7 +1238,7 @@ class DataExchange {
      * @since windows5.0
      */
     static DdeAddData(hData, pSrc, cb, cbOff) {
-        result := DllCall("USER32.dll\DdeAddData", "ptr", hData, "ptr", pSrc, "uint", cb, "uint", cbOff)
+        result := DllCall("USER32.dll\DdeAddData", "ptr", hData, "ptr", pSrc, "uint", cb, "uint", cbOff, "ptr")
         return result
     }
 
@@ -1653,7 +1653,7 @@ class DataExchange {
     static DdeCreateStringHandleA(idInst, psz, iCodePage) {
         psz := psz is String? StrPtr(psz) : psz
 
-        result := DllCall("USER32.dll\DdeCreateStringHandleA", "uint", idInst, "ptr", psz, "int", iCodePage)
+        result := DllCall("USER32.dll\DdeCreateStringHandleA", "uint", idInst, "ptr", psz, "int", iCodePage, "ptr")
         return result
     }
 
@@ -1707,7 +1707,7 @@ class DataExchange {
     static DdeCreateStringHandleW(idInst, psz, iCodePage) {
         psz := psz is String? StrPtr(psz) : psz
 
-        result := DllCall("USER32.dll\DdeCreateStringHandleW", "uint", idInst, "ptr", psz, "int", iCodePage)
+        result := DllCall("USER32.dll\DdeCreateStringHandleW", "uint", idInst, "ptr", psz, "int", iCodePage, "ptr")
         return result
     }
 
@@ -1943,7 +1943,7 @@ class DataExchange {
      * @since windows5.0
      */
     static SetWinMetaFileBits(nSize, lpMeta16Data, hdcRef, lpMFP) {
-        result := DllCall("GDI32.dll\SetWinMetaFileBits", "uint", nSize, "ptr", lpMeta16Data, "ptr", hdcRef, "ptr", lpMFP)
+        result := DllCall("GDI32.dll\SetWinMetaFileBits", "uint", nSize, "ptr", lpMeta16Data, "ptr", hdcRef, "ptr", lpMFP, "ptr")
         return result
     }
 
@@ -2035,7 +2035,7 @@ class DataExchange {
     static GetClipboardOwner() {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\GetClipboardOwner")
+        result := DllCall("USER32.dll\GetClipboardOwner", "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2062,7 +2062,7 @@ class DataExchange {
     static SetClipboardViewer(hWndNewViewer) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\SetClipboardViewer", "ptr", hWndNewViewer)
+        result := DllCall("USER32.dll\SetClipboardViewer", "ptr", hWndNewViewer, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2082,7 +2082,7 @@ class DataExchange {
     static GetClipboardViewer() {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\GetClipboardViewer")
+        result := DllCall("USER32.dll\GetClipboardViewer", "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2144,7 +2144,7 @@ class DataExchange {
     static SetClipboardData(uFormat, hMem) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\SetClipboardData", "uint", uFormat, "ptr", hMem)
+        result := DllCall("USER32.dll\SetClipboardData", "uint", uFormat, "ptr", hMem, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2175,7 +2175,7 @@ class DataExchange {
     static GetClipboardData(uFormat) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\GetClipboardData", "uint", uFormat)
+        result := DllCall("USER32.dll\GetClipboardData", "uint", uFormat, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2462,7 +2462,7 @@ class DataExchange {
     static GetOpenClipboardWindow() {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\GetOpenClipboardWindow")
+        result := DllCall("USER32.dll\GetOpenClipboardWindow", "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/DeploymentServices/Apis.ahk
+++ b/Windows/Win32/System/DeploymentServices/Apis.ahk
@@ -2340,7 +2340,7 @@ class DeploymentServices {
     static PxePacketAllocate(hProvider, hClientRequest, uSize) {
         A_LastError := 0
 
-        result := DllCall("WDSPXE.dll\PxePacketAllocate", "ptr", hProvider, "ptr", hClientRequest, "uint", uSize)
+        result := DllCall("WDSPXE.dll\PxePacketAllocate", "ptr", hProvider, "ptr", hClientRequest, "uint", uSize, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3204,7 +3204,7 @@ class DeploymentServices {
      * @since windowsserver2008
      */
     static WdsTransportServerAllocateBuffer(hProvider, ulBufferSize) {
-        result := DllCall("WDSMC.dll\WdsTransportServerAllocateBuffer", "ptr", hProvider, "uint", ulBufferSize)
+        result := DllCall("WDSMC.dll\WdsTransportServerAllocateBuffer", "ptr", hProvider, "uint", ulBufferSize, "ptr")
         return result
     }
 

--- a/Windows/Win32/System/Diagnostics/Debug/Apis.ahk
+++ b/Windows/Win32/System/Diagnostics/Debug/Apis.ahk
@@ -2337,7 +2337,7 @@ class Debug {
     static ImageRvaToVa(NtHeaders, Base, Rva, LastRvaSection) {
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\ImageRvaToVa", "ptr", NtHeaders, "ptr", Base, "uint", Rva, "ptr", LastRvaSection)
+        result := DllCall("dbghelp.dll\ImageRvaToVa", "ptr", NtHeaders, "ptr", Base, "uint", Rva, "ptr", LastRvaSection, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2428,7 +2428,7 @@ class Debug {
      * @see https://learn.microsoft.com/windows/win32/api/winnt/nf-winnt-rtlpctofileheader
      */
     static RtlPcToFileHeader(PcValue, BaseOfImage) {
-        result := DllCall("KERNEL32.dll\RtlPcToFileHeader", "ptr", PcValue, "ptr", BaseOfImage)
+        result := DllCall("KERNEL32.dll\RtlPcToFileHeader", "ptr", PcValue, "ptr", BaseOfImage, "ptr")
         return result
     }
 
@@ -2796,7 +2796,7 @@ class Debug {
      * @returns {Pointer<Void>} 
      */
     static EncodePointer(Ptr) {
-        result := DllCall("KERNEL32.dll\EncodePointer", "ptr", Ptr)
+        result := DllCall("KERNEL32.dll\EncodePointer", "ptr", Ptr, "ptr")
         return result
     }
 
@@ -2806,7 +2806,7 @@ class Debug {
      * @returns {Pointer<Void>} 
      */
     static DecodePointer(Ptr) {
-        result := DllCall("KERNEL32.dll\DecodePointer", "ptr", Ptr)
+        result := DllCall("KERNEL32.dll\DecodePointer", "ptr", Ptr, "ptr")
         return result
     }
 
@@ -2816,7 +2816,7 @@ class Debug {
      * @returns {Pointer<Void>} 
      */
     static EncodeSystemPointer(Ptr) {
-        result := DllCall("KERNEL32.dll\EncodeSystemPointer", "ptr", Ptr)
+        result := DllCall("KERNEL32.dll\EncodeSystemPointer", "ptr", Ptr, "ptr")
         return result
     }
 
@@ -2826,7 +2826,7 @@ class Debug {
      * @returns {Pointer<Void>} 
      */
     static DecodeSystemPointer(Ptr) {
-        result := DllCall("KERNEL32.dll\DecodeSystemPointer", "ptr", Ptr)
+        result := DllCall("KERNEL32.dll\DecodeSystemPointer", "ptr", Ptr, "ptr")
         return result
     }
 
@@ -3146,7 +3146,7 @@ class Debug {
      * @since windows5.1.2600
      */
     static AddVectoredExceptionHandler(First, Handler) {
-        result := DllCall("KERNEL32.dll\AddVectoredExceptionHandler", "uint", First, "ptr", Handler)
+        result := DllCall("KERNEL32.dll\AddVectoredExceptionHandler", "uint", First, "ptr", Handler, "ptr")
         return result
     }
 
@@ -3185,7 +3185,7 @@ class Debug {
      * @since windows6.0.6000
      */
     static AddVectoredContinueHandler(First, Handler) {
-        result := DllCall("KERNEL32.dll\AddVectoredContinueHandler", "uint", First, "ptr", Handler)
+        result := DllCall("KERNEL32.dll\AddVectoredContinueHandler", "uint", First, "ptr", Handler, "ptr")
         return result
     }
 
@@ -3399,7 +3399,7 @@ class Debug {
     static OpenThreadWaitChainSession(Flags, callback) {
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\OpenThreadWaitChainSession", "uint", Flags, "ptr", callback)
+        result := DllCall("ADVAPI32.dll\OpenThreadWaitChainSession", "uint", Flags, "ptr", callback, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4451,7 +4451,7 @@ class Debug {
 
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\SymFindDebugInfoFile", "ptr", hProcess, "ptr", FileName, "ptr", DebugFilePath, "ptr", Callback, "ptr", CallerData)
+        result := DllCall("dbghelp.dll\SymFindDebugInfoFile", "ptr", hProcess, "ptr", FileName, "ptr", DebugFilePath, "ptr", Callback, "ptr", CallerData, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4498,7 +4498,7 @@ class Debug {
 
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\SymFindDebugInfoFileW", "ptr", hProcess, "ptr", FileName, "ptr", DebugFilePath, "ptr", Callback, "ptr", CallerData)
+        result := DllCall("dbghelp.dll\SymFindDebugInfoFileW", "ptr", hProcess, "ptr", FileName, "ptr", DebugFilePath, "ptr", Callback, "ptr", CallerData, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4529,7 +4529,7 @@ class Debug {
 
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\FindDebugInfoFile", "ptr", FileName, "ptr", SymbolPath, "ptr", DebugFilePath)
+        result := DllCall("dbghelp.dll\FindDebugInfoFile", "ptr", FileName, "ptr", SymbolPath, "ptr", DebugFilePath, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4579,7 +4579,7 @@ class Debug {
 
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\FindDebugInfoFileEx", "ptr", FileName, "ptr", SymbolPath, "ptr", DebugFilePath, "ptr", Callback, "ptr", CallerData)
+        result := DllCall("dbghelp.dll\FindDebugInfoFileEx", "ptr", FileName, "ptr", SymbolPath, "ptr", DebugFilePath, "ptr", Callback, "ptr", CallerData, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4636,7 +4636,7 @@ class Debug {
 
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\FindDebugInfoFileExW", "ptr", FileName, "ptr", SymbolPath, "ptr", DebugFilePath, "ptr", Callback, "ptr", CallerData)
+        result := DllCall("dbghelp.dll\FindDebugInfoFileExW", "ptr", FileName, "ptr", SymbolPath, "ptr", DebugFilePath, "ptr", Callback, "ptr", CallerData, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4785,7 +4785,7 @@ class Debug {
 
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\SymFindExecutableImage", "ptr", hProcess, "ptr", FileName, "ptr", ImageFilePath, "ptr", Callback, "ptr", CallerData)
+        result := DllCall("dbghelp.dll\SymFindExecutableImage", "ptr", hProcess, "ptr", FileName, "ptr", ImageFilePath, "ptr", Callback, "ptr", CallerData, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4832,7 +4832,7 @@ class Debug {
 
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\SymFindExecutableImageW", "ptr", hProcess, "ptr", FileName, "ptr", ImageFilePath, "ptr", Callback, "ptr", CallerData)
+        result := DllCall("dbghelp.dll\SymFindExecutableImageW", "ptr", hProcess, "ptr", FileName, "ptr", ImageFilePath, "ptr", Callback, "ptr", CallerData, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4863,7 +4863,7 @@ class Debug {
 
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\FindExecutableImage", "ptr", FileName, "ptr", SymbolPath, "ptr", ImageFilePath)
+        result := DllCall("dbghelp.dll\FindExecutableImage", "ptr", FileName, "ptr", SymbolPath, "ptr", ImageFilePath, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4904,7 +4904,7 @@ class Debug {
 
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\FindExecutableImageEx", "ptr", FileName, "ptr", SymbolPath, "ptr", ImageFilePath, "ptr", Callback, "ptr", CallerData)
+        result := DllCall("dbghelp.dll\FindExecutableImageEx", "ptr", FileName, "ptr", SymbolPath, "ptr", ImageFilePath, "ptr", Callback, "ptr", CallerData, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4952,7 +4952,7 @@ class Debug {
 
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\FindExecutableImageExW", "ptr", FileName, "ptr", SymbolPath, "ptr", ImageFilePath, "ptr", Callback, "ptr", CallerData)
+        result := DllCall("dbghelp.dll\FindExecutableImageExW", "ptr", FileName, "ptr", SymbolPath, "ptr", ImageFilePath, "ptr", Callback, "ptr", CallerData, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4979,7 +4979,7 @@ class Debug {
     static ImageDirectoryEntryToDataEx(Base, MappedAsImage, DirectoryEntry, Size, FoundHeader) {
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\ImageDirectoryEntryToDataEx", "ptr", Base, "char", MappedAsImage, "ushort", DirectoryEntry, "uint*", Size, "ptr", FoundHeader)
+        result := DllCall("dbghelp.dll\ImageDirectoryEntryToDataEx", "ptr", Base, "char", MappedAsImage, "ushort", DirectoryEntry, "uint*", Size, "ptr", FoundHeader, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5007,7 +5007,7 @@ class Debug {
     static ImageDirectoryEntryToData(Base, MappedAsImage, DirectoryEntry, Size) {
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\ImageDirectoryEntryToData", "ptr", Base, "char", MappedAsImage, "ushort", DirectoryEntry, "uint*", Size)
+        result := DllCall("dbghelp.dll\ImageDirectoryEntryToData", "ptr", Base, "char", MappedAsImage, "ushort", DirectoryEntry, "uint*", Size, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -7197,7 +7197,7 @@ class Debug {
     static SymFunctionTableAccess64(hProcess, AddrBase) {
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\SymFunctionTableAccess64", "ptr", hProcess, "uint", AddrBase)
+        result := DllCall("dbghelp.dll\SymFunctionTableAccess64", "ptr", hProcess, "uint", AddrBase, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -7215,7 +7215,7 @@ class Debug {
      * @see https://learn.microsoft.com/windows/win32/api/dbghelp/nf-dbghelp-symfunctiontableaccess64accessroutines
      */
     static SymFunctionTableAccess64AccessRoutines(hProcess, AddrBase, ReadMemoryRoutine, GetModuleBaseRoutine) {
-        result := DllCall("dbghelp.dll\SymFunctionTableAccess64AccessRoutines", "ptr", hProcess, "uint", AddrBase, "ptr", ReadMemoryRoutine, "ptr", GetModuleBaseRoutine)
+        result := DllCall("dbghelp.dll\SymFunctionTableAccess64AccessRoutines", "ptr", hProcess, "uint", AddrBase, "ptr", ReadMemoryRoutine, "ptr", GetModuleBaseRoutine, "ptr")
         return result
     }
 
@@ -7248,7 +7248,7 @@ class Debug {
     static SymFunctionTableAccess(hProcess, AddrBase) {
         A_LastError := 0
 
-        result := DllCall("dbghelp.dll\SymFunctionTableAccess", "ptr", hProcess, "uint", AddrBase)
+        result := DllCall("dbghelp.dll\SymFunctionTableAccess", "ptr", hProcess, "uint", AddrBase, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -13084,7 +13084,7 @@ class Debug {
      * @returns {Pointer<Void>} 
      */
     static RangeMapCreate() {
-        result := DllCall("dbghelp.dll\RangeMapCreate")
+        result := DllCall("dbghelp.dll\RangeMapCreate", "ptr")
         return result
     }
 
@@ -14132,7 +14132,7 @@ class Debug {
      * @since windows6.1
      */
     static LocateXStateFeature(Context, FeatureId, Length) {
-        result := DllCall("KERNEL32.dll\LocateXStateFeature", "ptr", Context, "uint", FeatureId, "uint*", Length)
+        result := DllCall("KERNEL32.dll\LocateXStateFeature", "ptr", Context, "uint", FeatureId, "uint*", Length, "ptr")
         return result
     }
 

--- a/Windows/Win32/System/Diagnostics/ToolHelp/Apis.ahk
+++ b/Windows/Win32/System/Diagnostics/ToolHelp/Apis.ahk
@@ -57,7 +57,7 @@ class ToolHelp {
     static CreateToolhelp32Snapshot(dwFlags, th32ProcessID) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateToolhelp32Snapshot", "uint", dwFlags, "uint", th32ProcessID)
+        result := DllCall("KERNEL32.dll\CreateToolhelp32Snapshot", "uint", dwFlags, "uint", th32ProcessID, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/Environment/Apis.ahk
+++ b/Windows/Win32/System/Environment/Apis.ahk
@@ -1331,7 +1331,7 @@ class Environment {
     static CreateEnclave(hProcess, lpAddress, dwSize, dwInitialCommitment, flEnclaveType, lpEnclaveInformation, dwInfoLength, lpEnclaveError) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateEnclave", "ptr", hProcess, "ptr", lpAddress, "ptr", dwSize, "ptr", dwInitialCommitment, "uint", flEnclaveType, "ptr", lpEnclaveInformation, "uint", dwInfoLength, "uint*", lpEnclaveError)
+        result := DllCall("KERNEL32.dll\CreateEnclave", "ptr", hProcess, "ptr", lpAddress, "ptr", dwSize, "ptr", dwInitialCommitment, "uint", flEnclaveType, "ptr", lpEnclaveInformation, "uint", dwInfoLength, "uint*", lpEnclaveError, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/EventLog/Apis.ahk
+++ b/Windows/Win32/System/EventLog/Apis.ahk
@@ -1943,7 +1943,7 @@ class EventLog {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\OpenEventLogA", "ptr", lpUNCServerName, "ptr", lpSourceName)
+        result := DllCall("ADVAPI32.dll\OpenEventLogA", "ptr", lpUNCServerName, "ptr", lpSourceName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -1973,7 +1973,7 @@ class EventLog {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\OpenEventLogW", "ptr", lpUNCServerName, "ptr", lpSourceName)
+        result := DllCall("ADVAPI32.dll\OpenEventLogW", "ptr", lpUNCServerName, "ptr", lpSourceName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2009,7 +2009,7 @@ class EventLog {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\RegisterEventSourceA", "ptr", lpUNCServerName, "ptr", lpSourceName)
+        result := DllCall("ADVAPI32.dll\RegisterEventSourceA", "ptr", lpUNCServerName, "ptr", lpSourceName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2045,7 +2045,7 @@ class EventLog {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\RegisterEventSourceW", "ptr", lpUNCServerName, "ptr", lpSourceName)
+        result := DllCall("ADVAPI32.dll\RegisterEventSourceW", "ptr", lpUNCServerName, "ptr", lpSourceName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2081,7 +2081,7 @@ class EventLog {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\OpenBackupEventLogA", "ptr", lpUNCServerName, "ptr", lpFileName)
+        result := DllCall("ADVAPI32.dll\OpenBackupEventLogA", "ptr", lpUNCServerName, "ptr", lpFileName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2117,7 +2117,7 @@ class EventLog {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\OpenBackupEventLogW", "ptr", lpUNCServerName, "ptr", lpFileName)
+        result := DllCall("ADVAPI32.dll\OpenBackupEventLogW", "ptr", lpUNCServerName, "ptr", lpFileName, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/GroupPolicy/Apis.ahk
+++ b/Windows/Win32/System/GroupPolicy/Apis.ahk
@@ -583,7 +583,7 @@ class GroupPolicy {
     static EnterCriticalPolicySection(bMachine) {
         A_LastError := 0
 
-        result := DllCall("USERENV.dll\EnterCriticalPolicySection", "int", bMachine)
+        result := DllCall("USERENV.dll\EnterCriticalPolicySection", "int", bMachine, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/Hypervisor/Apis.ahk
+++ b/Windows/Win32/System/Hypervisor/Apis.ahk
@@ -2034,7 +2034,7 @@ class Hypervisor {
      * @returns {Pointer<Void>} 
      */
     static GetSavedStateSymbolProviderHandle(vmSavedStateDumpHandle) {
-        result := DllCall("VmSavedStateDumpProvider.dll\GetSavedStateSymbolProviderHandle", "ptr", vmSavedStateDumpHandle)
+        result := DllCall("VmSavedStateDumpProvider.dll\GetSavedStateSymbolProviderHandle", "ptr", vmSavedStateDumpHandle, "ptr")
         return result
     }
 

--- a/Windows/Win32/System/LibraryLoader/Apis.ahk
+++ b/Windows/Win32/System/LibraryLoader/Apis.ahk
@@ -199,7 +199,7 @@ class LibraryLoader {
         lpType := lpType is String? StrPtr(lpType) : lpType
         lpName := lpName is String? StrPtr(lpName) : lpName
 
-        result := DllCall("KERNEL32.dll\FindResourceExW", "ptr", hModule, "ptr", lpType, "ptr", lpName, "ushort", wLanguage)
+        result := DllCall("KERNEL32.dll\FindResourceExW", "ptr", hModule, "ptr", lpType, "ptr", lpName, "ushort", wLanguage, "ptr")
         return result
     }
 
@@ -399,7 +399,7 @@ class LibraryLoader {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\GetModuleHandleA", "ptr", lpModuleName)
+        result := DllCall("KERNEL32.dll\GetModuleHandleA", "ptr", lpModuleName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -439,7 +439,7 @@ class LibraryLoader {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\GetModuleHandleW", "ptr", lpModuleName)
+        result := DllCall("KERNEL32.dll\GetModuleHandleW", "ptr", lpModuleName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -743,7 +743,7 @@ class LibraryLoader {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\LoadLibraryExA", "ptr", lpLibFileName, "ptr", hFile, "uint", dwFlags)
+        result := DllCall("KERNEL32.dll\LoadLibraryExA", "ptr", lpLibFileName, "ptr", hFile, "uint", dwFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -876,7 +876,7 @@ class LibraryLoader {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\LoadLibraryExW", "ptr", lpLibFileName, "ptr", hFile, "uint", dwFlags)
+        result := DllCall("KERNEL32.dll\LoadLibraryExW", "ptr", lpLibFileName, "ptr", hFile, "uint", dwFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -978,7 +978,7 @@ class LibraryLoader {
     static LoadResource(hModule, hResInfo) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\LoadResource", "ptr", hModule, "ptr", hResInfo)
+        result := DllCall("KERNEL32.dll\LoadResource", "ptr", hModule, "ptr", hResInfo, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -1004,7 +1004,7 @@ class LibraryLoader {
      * @since windows5.0
      */
     static LockResource(hResData) {
-        result := DllCall("KERNEL32.dll\LockResource", "ptr", hResData)
+        result := DllCall("KERNEL32.dll\LockResource", "ptr", hResData, "ptr")
         return result
     }
 
@@ -1075,7 +1075,7 @@ class LibraryLoader {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\AddDllDirectory", "ptr", NewDirectory)
+        result := DllCall("KERNEL32.dll\AddDllDirectory", "ptr", NewDirectory, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -1882,7 +1882,7 @@ class LibraryLoader {
         lpName := lpName is String? StrPtr(lpName) : lpName
         lpType := lpType is String? StrPtr(lpType) : lpType
 
-        result := DllCall("KERNEL32.dll\FindResourceW", "ptr", hModule, "ptr", lpName, "ptr", lpType)
+        result := DllCall("KERNEL32.dll\FindResourceW", "ptr", hModule, "ptr", lpName, "ptr", lpType, "ptr")
         return result
     }
 
@@ -2029,7 +2029,7 @@ class LibraryLoader {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\LoadLibraryA", "ptr", lpLibFileName)
+        result := DllCall("KERNEL32.dll\LoadLibraryA", "ptr", lpLibFileName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2179,7 +2179,7 @@ class LibraryLoader {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\LoadLibraryW", "ptr", lpLibFileName)
+        result := DllCall("KERNEL32.dll\LoadLibraryW", "ptr", lpLibFileName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2321,7 +2321,7 @@ class LibraryLoader {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\LoadPackagedLibrary", "ptr", lpwLibFileName, "uint", Reserved)
+        result := DllCall("KERNEL32.dll\LoadPackagedLibrary", "ptr", lpwLibFileName, "uint", Reserved, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2639,7 +2639,7 @@ class LibraryLoader {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindResourceA", "ptr", hModule, "ptr", lpName, "ptr", lpType)
+        result := DllCall("KERNEL32.dll\FindResourceA", "ptr", hModule, "ptr", lpName, "ptr", lpType, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2742,7 +2742,7 @@ class LibraryLoader {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FindResourceExA", "ptr", hModule, "ptr", lpType, "ptr", lpName, "ushort", wLanguage)
+        result := DllCall("KERNEL32.dll\FindResourceExA", "ptr", hModule, "ptr", lpType, "ptr", lpName, "ushort", wLanguage, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2964,7 +2964,7 @@ class LibraryLoader {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\BeginUpdateResourceA", "ptr", pFileName, "int", bDeleteExistingResources)
+        result := DllCall("KERNEL32.dll\BeginUpdateResourceA", "ptr", pFileName, "int", bDeleteExistingResources, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2996,7 +2996,7 @@ class LibraryLoader {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\BeginUpdateResourceW", "ptr", pFileName, "int", bDeleteExistingResources)
+        result := DllCall("KERNEL32.dll\BeginUpdateResourceW", "ptr", pFileName, "int", bDeleteExistingResources, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/Memory/Apis.ahk
+++ b/Windows/Win32/System/Memory/Apis.ahk
@@ -115,7 +115,7 @@ class Memory {
     static HeapCreate(flOptions, dwInitialSize, dwMaximumSize) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\HeapCreate", "uint", flOptions, "ptr", dwInitialSize, "ptr", dwMaximumSize)
+        result := DllCall("KERNEL32.dll\HeapCreate", "uint", flOptions, "ptr", dwInitialSize, "ptr", dwMaximumSize, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -201,7 +201,7 @@ class Memory {
      * @since windows5.1.2600
      */
     static HeapAlloc(hHeap, dwFlags, dwBytes) {
-        result := DllCall("KERNEL32.dll\HeapAlloc", "ptr", hHeap, "uint", dwFlags, "ptr", dwBytes)
+        result := DllCall("KERNEL32.dll\HeapAlloc", "ptr", hHeap, "uint", dwFlags, "ptr", dwBytes, "ptr")
         return result
     }
 
@@ -266,7 +266,7 @@ class Memory {
      * @since windows5.1.2600
      */
     static HeapReAlloc(hHeap, dwFlags, lpMem, dwBytes) {
-        result := DllCall("KERNEL32.dll\HeapReAlloc", "ptr", hHeap, "uint", dwFlags, "ptr", lpMem, "ptr", dwBytes)
+        result := DllCall("KERNEL32.dll\HeapReAlloc", "ptr", hHeap, "uint", dwFlags, "ptr", lpMem, "ptr", dwBytes, "ptr")
         return result
     }
 
@@ -424,7 +424,7 @@ class Memory {
     static GetProcessHeap() {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\GetProcessHeap")
+        result := DllCall("KERNEL32.dll\GetProcessHeap", "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -906,7 +906,7 @@ class Memory {
     static VirtualAlloc(lpAddress, dwSize, flAllocationType, flProtect) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\VirtualAlloc", "ptr", lpAddress, "ptr", dwSize, "uint", flAllocationType, "uint", flProtect)
+        result := DllCall("KERNEL32.dll\VirtualAlloc", "ptr", lpAddress, "ptr", dwSize, "uint", flAllocationType, "uint", flProtect, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -1123,7 +1123,7 @@ class Memory {
     static VirtualAllocEx(hProcess, lpAddress, dwSize, flAllocationType, flProtect) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\VirtualAllocEx", "ptr", hProcess, "ptr", lpAddress, "ptr", dwSize, "uint", flAllocationType, "uint", flProtect)
+        result := DllCall("KERNEL32.dll\VirtualAllocEx", "ptr", hProcess, "ptr", lpAddress, "ptr", dwSize, "uint", flAllocationType, "uint", flProtect, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -1416,7 +1416,7 @@ class Memory {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateFileMappingW", "ptr", hFile, "ptr", lpFileMappingAttributes, "uint", flProtect, "uint", dwMaximumSizeHigh, "uint", dwMaximumSizeLow, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\CreateFileMappingW", "ptr", hFile, "ptr", lpFileMappingAttributes, "uint", flProtect, "uint", dwMaximumSizeHigh, "uint", dwMaximumSizeLow, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -1523,7 +1523,7 @@ class Memory {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\OpenFileMappingW", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\OpenFileMappingW", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -1682,7 +1682,7 @@ class Memory {
     static MapViewOfFile(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\MapViewOfFile", "ptr", hFileMappingObject, "uint", dwDesiredAccess, "uint", dwFileOffsetHigh, "uint", dwFileOffsetLow, "ptr", dwNumberOfBytesToMap)
+        result := DllCall("KERNEL32.dll\MapViewOfFile", "ptr", hFileMappingObject, "uint", dwDesiredAccess, "uint", dwFileOffsetHigh, "uint", dwFileOffsetLow, "ptr", dwNumberOfBytesToMap, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -1845,7 +1845,7 @@ class Memory {
     static MapViewOfFileEx(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap, lpBaseAddress) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\MapViewOfFileEx", "ptr", hFileMappingObject, "uint", dwDesiredAccess, "uint", dwFileOffsetHigh, "uint", dwFileOffsetLow, "ptr", dwNumberOfBytesToMap, "ptr", lpBaseAddress)
+        result := DllCall("KERNEL32.dll\MapViewOfFileEx", "ptr", hFileMappingObject, "uint", dwDesiredAccess, "uint", dwFileOffsetHigh, "uint", dwFileOffsetLow, "ptr", dwNumberOfBytesToMap, "ptr", lpBaseAddress, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2504,7 +2504,7 @@ class Memory {
     static CreateMemoryResourceNotification(NotificationType) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateMemoryResourceNotification", "int", NotificationType)
+        result := DllCall("KERNEL32.dll\CreateMemoryResourceNotification", "int", NotificationType, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2922,7 +2922,7 @@ class Memory {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateFileMappingNumaW", "ptr", hFile, "ptr", lpFileMappingAttributes, "uint", flProtect, "uint", dwMaximumSizeHigh, "uint", dwMaximumSizeLow, "ptr", lpName, "uint", nndPreferred)
+        result := DllCall("KERNEL32.dll\CreateFileMappingNumaW", "ptr", hFile, "ptr", lpFileMappingAttributes, "uint", flProtect, "uint", dwMaximumSizeHigh, "uint", dwMaximumSizeLow, "ptr", lpName, "uint", nndPreferred, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3122,7 +3122,7 @@ class Memory {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateFileMappingFromApp", "ptr", hFile, "ptr", SecurityAttributes, "uint", PageProtection, "uint", MaximumSize, "ptr", Name)
+        result := DllCall("KERNEL32.dll\CreateFileMappingFromApp", "ptr", hFile, "ptr", SecurityAttributes, "uint", PageProtection, "uint", MaximumSize, "ptr", Name, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3165,7 +3165,7 @@ class Memory {
     static MapViewOfFileFromApp(hFileMappingObject, DesiredAccess, FileOffset, NumberOfBytesToMap) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\MapViewOfFileFromApp", "ptr", hFileMappingObject, "uint", DesiredAccess, "uint", FileOffset, "ptr", NumberOfBytesToMap)
+        result := DllCall("KERNEL32.dll\MapViewOfFileFromApp", "ptr", hFileMappingObject, "uint", DesiredAccess, "uint", FileOffset, "ptr", NumberOfBytesToMap, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3530,7 +3530,7 @@ class Memory {
     static VirtualAllocExNuma(hProcess, lpAddress, dwSize, flAllocationType, flProtect, nndPreferred) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\VirtualAllocExNuma", "ptr", hProcess, "ptr", lpAddress, "ptr", dwSize, "uint", flAllocationType, "uint", flProtect, "uint", nndPreferred)
+        result := DllCall("KERNEL32.dll\VirtualAllocExNuma", "ptr", hProcess, "ptr", lpAddress, "ptr", dwSize, "uint", flAllocationType, "uint", flProtect, "uint", nndPreferred, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3595,7 +3595,7 @@ class Memory {
      * @since windows8.0
      */
     static RegisterBadMemoryNotification(Callback) {
-        result := DllCall("KERNEL32.dll\RegisterBadMemoryNotification", "ptr", Callback)
+        result := DllCall("KERNEL32.dll\RegisterBadMemoryNotification", "ptr", Callback, "ptr")
         return result
     }
 
@@ -3815,7 +3815,7 @@ class Memory {
     static VirtualAllocFromApp(BaseAddress, Size, AllocationType, Protection) {
         A_LastError := 0
 
-        result := DllCall("api-ms-win-core-memory-l1-1-3.dll\VirtualAllocFromApp", "ptr", BaseAddress, "ptr", Size, "uint", AllocationType, "uint", Protection)
+        result := DllCall("api-ms-win-core-memory-l1-1-3.dll\VirtualAllocFromApp", "ptr", BaseAddress, "ptr", Size, "uint", AllocationType, "uint", Protection, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3946,7 +3946,7 @@ class Memory {
 
         A_LastError := 0
 
-        result := DllCall("api-ms-win-core-memory-l1-1-3.dll\OpenFileMappingFromApp", "uint", DesiredAccess, "int", InheritHandle, "ptr", Name)
+        result := DllCall("api-ms-win-core-memory-l1-1-3.dll\OpenFileMappingFromApp", "uint", DesiredAccess, "int", InheritHandle, "ptr", Name, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4013,7 +4013,7 @@ class Memory {
     static MapViewOfFileNuma2(FileMappingHandle, ProcessHandle, Offset, BaseAddress, ViewSize, AllocationType, PageProtection, PreferredNode) {
         A_LastError := 0
 
-        result := DllCall("api-ms-win-core-memory-l1-1-5.dll\MapViewOfFileNuma2", "ptr", FileMappingHandle, "ptr", ProcessHandle, "uint", Offset, "ptr", BaseAddress, "ptr", ViewSize, "uint", AllocationType, "uint", PageProtection, "uint", PreferredNode)
+        result := DllCall("api-ms-win-core-memory-l1-1-5.dll\MapViewOfFileNuma2", "ptr", FileMappingHandle, "ptr", ProcessHandle, "uint", Offset, "ptr", BaseAddress, "ptr", ViewSize, "uint", AllocationType, "uint", PageProtection, "uint", PreferredNode, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4156,7 +4156,7 @@ class Memory {
     static VirtualAlloc2(Process, BaseAddress, Size, AllocationType, PageProtection, ExtendedParameters, ParameterCount) {
         A_LastError := 0
 
-        result := DllCall("api-ms-win-core-memory-l1-1-6.dll\VirtualAlloc2", "ptr", Process, "ptr", BaseAddress, "ptr", Size, "uint", AllocationType, "uint", PageProtection, "ptr", ExtendedParameters, "uint", ParameterCount)
+        result := DllCall("api-ms-win-core-memory-l1-1-6.dll\VirtualAlloc2", "ptr", Process, "ptr", BaseAddress, "ptr", Size, "uint", AllocationType, "uint", PageProtection, "ptr", ExtendedParameters, "uint", ParameterCount, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4197,7 +4197,7 @@ class Memory {
     static MapViewOfFile3(FileMapping, Process, BaseAddress, Offset, ViewSize, AllocationType, PageProtection, ExtendedParameters, ParameterCount) {
         A_LastError := 0
 
-        result := DllCall("api-ms-win-core-memory-l1-1-6.dll\MapViewOfFile3", "ptr", FileMapping, "ptr", Process, "ptr", BaseAddress, "uint", Offset, "ptr", ViewSize, "uint", AllocationType, "uint", PageProtection, "ptr", ExtendedParameters, "uint", ParameterCount)
+        result := DllCall("api-ms-win-core-memory-l1-1-6.dll\MapViewOfFile3", "ptr", FileMapping, "ptr", Process, "ptr", BaseAddress, "uint", Offset, "ptr", ViewSize, "uint", AllocationType, "uint", PageProtection, "ptr", ExtendedParameters, "uint", ParameterCount, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4299,7 +4299,7 @@ class Memory {
     static VirtualAlloc2FromApp(Process, BaseAddress, Size, AllocationType, PageProtection, ExtendedParameters, ParameterCount) {
         A_LastError := 0
 
-        result := DllCall("api-ms-win-core-memory-l1-1-6.dll\VirtualAlloc2FromApp", "ptr", Process, "ptr", BaseAddress, "ptr", Size, "uint", AllocationType, "uint", PageProtection, "ptr", ExtendedParameters, "uint", ParameterCount)
+        result := DllCall("api-ms-win-core-memory-l1-1-6.dll\VirtualAlloc2FromApp", "ptr", Process, "ptr", BaseAddress, "ptr", Size, "uint", AllocationType, "uint", PageProtection, "ptr", ExtendedParameters, "uint", ParameterCount, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4353,7 +4353,7 @@ class Memory {
     static MapViewOfFile3FromApp(FileMapping, Process, BaseAddress, Offset, ViewSize, AllocationType, PageProtection, ExtendedParameters, ParameterCount) {
         A_LastError := 0
 
-        result := DllCall("api-ms-win-core-memory-l1-1-6.dll\MapViewOfFile3FromApp", "ptr", FileMapping, "ptr", Process, "ptr", BaseAddress, "uint", Offset, "ptr", ViewSize, "uint", AllocationType, "uint", PageProtection, "ptr", ExtendedParameters, "uint", ParameterCount)
+        result := DllCall("api-ms-win-core-memory-l1-1-6.dll\MapViewOfFile3FromApp", "ptr", FileMapping, "ptr", Process, "ptr", BaseAddress, "uint", Offset, "ptr", ViewSize, "uint", AllocationType, "uint", PageProtection, "ptr", ExtendedParameters, "uint", ParameterCount, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4588,7 +4588,7 @@ class Memory {
 
         A_LastError := 0
 
-        result := DllCall("api-ms-win-core-memory-l1-1-7.dll\CreateFileMapping2", "ptr", File, "ptr", SecurityAttributes, "uint", DesiredAccess, "uint", PageProtection, "uint", AllocationAttributes, "uint", MaximumSize, "ptr", Name, "ptr", ExtendedParameters, "uint", ParameterCount)
+        result := DllCall("api-ms-win-core-memory-l1-1-7.dll\CreateFileMapping2", "ptr", File, "ptr", SecurityAttributes, "uint", DesiredAccess, "uint", PageProtection, "uint", AllocationAttributes, "uint", MaximumSize, "ptr", Name, "ptr", ExtendedParameters, "uint", ParameterCount, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4618,7 +4618,7 @@ class Memory {
      * @returns {Pointer<Void>} 
      */
     static OpenDedicatedMemoryPartition(Partition, DedicatedMemoryTypeId, DesiredAccess, InheritHandle) {
-        result := DllCall("api-ms-win-core-memory-l1-1-8.dll\OpenDedicatedMemoryPartition", "ptr", Partition, "uint", DedicatedMemoryTypeId, "uint", DesiredAccess, "int", InheritHandle)
+        result := DllCall("api-ms-win-core-memory-l1-1-8.dll\OpenDedicatedMemoryPartition", "ptr", Partition, "uint", DedicatedMemoryTypeId, "uint", DesiredAccess, "int", InheritHandle, "ptr")
         return result
     }
 
@@ -4737,7 +4737,7 @@ class Memory {
     static GlobalAlloc(uFlags, dwBytes) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\GlobalAlloc", "uint", uFlags, "ptr", dwBytes)
+        result := DllCall("KERNEL32.dll\GlobalAlloc", "uint", uFlags, "ptr", dwBytes, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4814,7 +4814,7 @@ class Memory {
     static GlobalReAlloc(hMem, dwBytes, uFlags) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\GlobalReAlloc", "ptr", hMem, "ptr", dwBytes, "uint", uFlags)
+        result := DllCall("KERNEL32.dll\GlobalReAlloc", "ptr", hMem, "ptr", dwBytes, "uint", uFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4915,7 +4915,7 @@ class Memory {
     static GlobalLock(hMem) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\GlobalLock", "ptr", hMem)
+        result := DllCall("KERNEL32.dll\GlobalLock", "ptr", hMem, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4969,7 +4969,7 @@ class Memory {
     static GlobalHandle(pMem) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\GlobalHandle", "ptr", pMem)
+        result := DllCall("KERNEL32.dll\GlobalHandle", "ptr", pMem, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5006,7 +5006,7 @@ class Memory {
     static LocalAlloc(uFlags, uBytes) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\LocalAlloc", "uint", uFlags, "ptr", uBytes)
+        result := DllCall("KERNEL32.dll\LocalAlloc", "uint", uFlags, "ptr", uBytes, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5081,7 +5081,7 @@ class Memory {
     static LocalReAlloc(hMem, uBytes, uFlags) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\LocalReAlloc", "ptr", hMem, "ptr", uBytes, "uint", uFlags)
+        result := DllCall("KERNEL32.dll\LocalReAlloc", "ptr", hMem, "ptr", uBytes, "uint", uFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5116,7 +5116,7 @@ class Memory {
     static LocalLock(hMem) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\LocalLock", "ptr", hMem)
+        result := DllCall("KERNEL32.dll\LocalLock", "ptr", hMem, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5142,7 +5142,7 @@ class Memory {
     static LocalHandle(pMem) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\LocalHandle", "ptr", pMem)
+        result := DllCall("KERNEL32.dll\LocalHandle", "ptr", pMem, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5450,7 +5450,7 @@ class Memory {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateFileMappingA", "ptr", hFile, "ptr", lpFileMappingAttributes, "uint", flProtect, "uint", dwMaximumSizeHigh, "uint", dwMaximumSizeLow, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\CreateFileMappingA", "ptr", hFile, "ptr", lpFileMappingAttributes, "uint", flProtect, "uint", dwMaximumSizeHigh, "uint", dwMaximumSizeLow, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5686,7 +5686,7 @@ class Memory {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateFileMappingNumaA", "ptr", hFile, "ptr", lpFileMappingAttributes, "uint", flProtect, "uint", dwMaximumSizeHigh, "uint", dwMaximumSizeLow, "ptr", lpName, "uint", nndPreferred)
+        result := DllCall("KERNEL32.dll\CreateFileMappingNumaA", "ptr", hFile, "ptr", lpFileMappingAttributes, "uint", flProtect, "uint", dwMaximumSizeHigh, "uint", dwMaximumSizeLow, "ptr", lpName, "uint", nndPreferred, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5793,7 +5793,7 @@ class Memory {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\OpenFileMappingA", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\OpenFileMappingA", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5979,7 +5979,7 @@ class Memory {
     static MapViewOfFileExNuma(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap, lpBaseAddress, nndPreferred) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\MapViewOfFileExNuma", "ptr", hFileMappingObject, "uint", dwDesiredAccess, "uint", dwFileOffsetHigh, "uint", dwFileOffsetLow, "ptr", dwNumberOfBytesToMap, "ptr", lpBaseAddress, "uint", nndPreferred)
+        result := DllCall("KERNEL32.dll\MapViewOfFileExNuma", "ptr", hFileMappingObject, "uint", dwDesiredAccess, "uint", dwFileOffsetHigh, "uint", dwFileOffsetLow, "ptr", dwNumberOfBytesToMap, "ptr", lpBaseAddress, "uint", nndPreferred, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/Ole/Apis.ahk
+++ b/Windows/Win32/System/Ole/Apis.ahk
@@ -32475,7 +32475,7 @@ class Ole {
      * @since windows5.0
      */
     static OleDuplicateData(hSrc, cfFormat, uiFlags) {
-        result := DllCall("OLE32.dll\OleDuplicateData", "ptr", hSrc, "ushort", cfFormat, "uint", uiFlags)
+        result := DllCall("OLE32.dll\OleDuplicateData", "ptr", hSrc, "ushort", cfFormat, "uint", uiFlags, "ptr")
         return result
     }
 
@@ -33037,7 +33037,7 @@ class Ole {
     static OleGetIconOfFile(lpszPath, fUseFileAsLabel) {
         lpszPath := lpszPath is String? StrPtr(lpszPath) : lpszPath
 
-        result := DllCall("ole32.dll\OleGetIconOfFile", "ptr", lpszPath, "int", fUseFileAsLabel)
+        result := DllCall("ole32.dll\OleGetIconOfFile", "ptr", lpszPath, "int", fUseFileAsLabel, "ptr")
         return result
     }
 
@@ -33053,7 +33053,7 @@ class Ole {
     static OleGetIconOfClass(rclsid, lpszLabel, fUseTypeAsLabel) {
         lpszLabel := lpszLabel is String? StrPtr(lpszLabel) : lpszLabel
 
-        result := DllCall("OLE32.dll\OleGetIconOfClass", "ptr", rclsid, "ptr", lpszLabel, "int", fUseTypeAsLabel)
+        result := DllCall("OLE32.dll\OleGetIconOfClass", "ptr", rclsid, "ptr", lpszLabel, "int", fUseTypeAsLabel, "ptr")
         return result
     }
 
@@ -33079,7 +33079,7 @@ class Ole {
 
         A_LastError := 0
 
-        result := DllCall("ole32.dll\OleMetafilePictFromIconAndLabel", "ptr", hIcon, "ptr", lpszLabel, "ptr", lpszSourceFile, "uint", iIconIndex)
+        result := DllCall("ole32.dll\OleMetafilePictFromIconAndLabel", "ptr", hIcon, "ptr", lpszLabel, "ptr", lpszSourceFile, "uint", iIconIndex, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -34524,7 +34524,7 @@ class Ole {
      * @since windows5.0
      */
     static OleIconToCursor(hinstExe, hIcon) {
-        result := DllCall("OLEAUT32.dll\OleIconToCursor", "ptr", hinstExe, "ptr", hIcon)
+        result := DllCall("OLEAUT32.dll\OleIconToCursor", "ptr", hinstExe, "ptr", hIcon, "ptr")
         return result
     }
 

--- a/Windows/Win32/System/Pipes/Apis.ahk
+++ b/Windows/Win32/System/Pipes/Apis.ahk
@@ -704,7 +704,7 @@ class Pipes {
     static CreateNamedPipeW(lpName, dwOpenMode, dwPipeMode, nMaxInstances, nOutBufferSize, nInBufferSize, nDefaultTimeOut, lpSecurityAttributes) {
         lpName := lpName is String? StrPtr(lpName) : lpName
 
-        result := DllCall("KERNEL32.dll\CreateNamedPipeW", "ptr", lpName, "uint", dwOpenMode, "uint", dwPipeMode, "uint", nMaxInstances, "uint", nOutBufferSize, "uint", nInBufferSize, "uint", nDefaultTimeOut, "ptr", lpSecurityAttributes)
+        result := DllCall("KERNEL32.dll\CreateNamedPipeW", "ptr", lpName, "uint", dwOpenMode, "uint", dwPipeMode, "uint", nMaxInstances, "uint", nOutBufferSize, "uint", nInBufferSize, "uint", nDefaultTimeOut, "ptr", lpSecurityAttributes, "ptr")
         return result
     }
 
@@ -1259,7 +1259,7 @@ class Pipes {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateNamedPipeA", "ptr", lpName, "uint", dwOpenMode, "uint", dwPipeMode, "uint", nMaxInstances, "uint", nOutBufferSize, "uint", nInBufferSize, "uint", nDefaultTimeOut, "ptr", lpSecurityAttributes)
+        result := DllCall("KERNEL32.dll\CreateNamedPipeA", "ptr", lpName, "uint", dwOpenMode, "uint", dwPipeMode, "uint", nMaxInstances, "uint", nOutBufferSize, "uint", nInBufferSize, "uint", nDefaultTimeOut, "ptr", lpSecurityAttributes, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/Power/Apis.ahk
+++ b/Windows/Win32/System/Power/Apis.ahk
@@ -4014,7 +4014,7 @@ class Power {
     static PowerCreateRequest(Context) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\PowerCreateRequest", "ptr", Context)
+        result := DllCall("KERNEL32.dll\PowerCreateRequest", "ptr", Context, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/RemoteDesktop/Apis.ahk
+++ b/Windows/Win32/System/RemoteDesktop/Apis.ahk
@@ -1528,7 +1528,7 @@ class RemoteDesktop {
     static WTSOpenServerW(pServerName) {
         pServerName := pServerName is String? StrPtr(pServerName) : pServerName
 
-        result := DllCall("WTSAPI32.dll\WTSOpenServerW", "ptr", pServerName)
+        result := DllCall("WTSAPI32.dll\WTSOpenServerW", "ptr", pServerName, "ptr")
         return result
     }
 
@@ -1556,7 +1556,7 @@ class RemoteDesktop {
     static WTSOpenServerA(pServerName) {
         pServerName := pServerName is String? StrPtr(pServerName) : pServerName
 
-        result := DllCall("WTSAPI32.dll\WTSOpenServerA", "ptr", pServerName)
+        result := DllCall("WTSAPI32.dll\WTSOpenServerA", "ptr", pServerName, "ptr")
         return result
     }
 
@@ -1585,7 +1585,7 @@ class RemoteDesktop {
     static WTSOpenServerExW(pServerName) {
         pServerName := pServerName is String? StrPtr(pServerName) : pServerName
 
-        result := DllCall("WTSAPI32.dll\WTSOpenServerExW", "ptr", pServerName)
+        result := DllCall("WTSAPI32.dll\WTSOpenServerExW", "ptr", pServerName, "ptr")
         return result
     }
 
@@ -1614,7 +1614,7 @@ class RemoteDesktop {
     static WTSOpenServerExA(pServerName) {
         pServerName := pServerName is String? StrPtr(pServerName) : pServerName
 
-        result := DllCall("WTSAPI32.dll\WTSOpenServerExA", "ptr", pServerName)
+        result := DllCall("WTSAPI32.dll\WTSOpenServerExA", "ptr", pServerName, "ptr")
         return result
     }
 
@@ -2539,7 +2539,7 @@ class RemoteDesktop {
 
         A_LastError := 0
 
-        result := DllCall("WTSAPI32.dll\WTSVirtualChannelOpen", "ptr", hServer, "uint", SessionId, "ptr", pVirtualName)
+        result := DllCall("WTSAPI32.dll\WTSVirtualChannelOpen", "ptr", hServer, "uint", SessionId, "ptr", pVirtualName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2579,7 +2579,7 @@ class RemoteDesktop {
 
         A_LastError := 0
 
-        result := DllCall("WTSAPI32.dll\WTSVirtualChannelOpenEx", "uint", SessionId, "ptr", pVirtualName, "uint", flags)
+        result := DllCall("WTSAPI32.dll\WTSVirtualChannelOpenEx", "uint", SessionId, "ptr", pVirtualName, "uint", flags, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/Rpc/Apis.ahk
+++ b/Windows/Win32/System/Rpc/Apis.ahk
@@ -12405,7 +12405,7 @@ class Rpc {
      * @returns {Pointer<Void>} 
      */
     static I_RpcAllocate(Size) {
-        result := DllCall("RPCRT4.dll\I_RpcAllocate", "uint", Size)
+        result := DllCall("RPCRT4.dll\I_RpcAllocate", "uint", Size, "ptr")
         return result
     }
 
@@ -12454,7 +12454,7 @@ class Rpc {
      * @returns {Pointer<Void>} 
      */
     static I_RpcGetCurrentCallHandle() {
-        result := DllCall("RPCRT4.dll\I_RpcGetCurrentCallHandle")
+        result := DllCall("RPCRT4.dll\I_RpcGetCurrentCallHandle", "ptr")
         return result
     }
 
@@ -21151,7 +21151,7 @@ class Rpc {
      * @returns {Pointer<Void>} 
      */
     static NDRCContextBinding(CContext) {
-        result := DllCall("RPCRT4.dll\NDRCContextBinding", "ptr", CContext)
+        result := DllCall("RPCRT4.dll\NDRCContextBinding", "ptr", CContext, "ptr")
         return result
     }
 
@@ -23229,7 +23229,7 @@ class Rpc {
      * @since windows5.0
      */
     static RpcSsAllocate(Size) {
-        result := DllCall("RPCRT4.dll\RpcSsAllocate", "ptr", Size)
+        result := DllCall("RPCRT4.dll\RpcSsAllocate", "ptr", Size, "ptr")
         return result
     }
 
@@ -23352,7 +23352,7 @@ class Rpc {
      * @since windows5.0
      */
     static RpcSsGetThreadHandle() {
-        result := DllCall("RPCRT4.dll\RpcSsGetThreadHandle")
+        result := DllCall("RPCRT4.dll\RpcSsGetThreadHandle", "ptr")
         return result
     }
 
@@ -23505,7 +23505,7 @@ class Rpc {
      * @since windows5.0
      */
     static RpcSmAllocate(Size, pStatus) {
-        result := DllCall("RPCRT4.dll\RpcSmAllocate", "ptr", Size, "int*", pStatus)
+        result := DllCall("RPCRT4.dll\RpcSmAllocate", "ptr", Size, "int*", pStatus, "ptr")
         return result
     }
 
@@ -23806,7 +23806,7 @@ class Rpc {
      * @since windows5.0
      */
     static RpcSmGetThreadHandle(pStatus) {
-        result := DllCall("RPCRT4.dll\RpcSmGetThreadHandle", "int*", pStatus)
+        result := DllCall("RPCRT4.dll\RpcSmGetThreadHandle", "int*", pStatus, "ptr")
         return result
     }
 
@@ -23994,7 +23994,7 @@ class Rpc {
      * @returns {Pointer<Void>} 
      */
     static NdrRpcSmClientAllocate(Size) {
-        result := DllCall("RPCRT4.dll\NdrRpcSmClientAllocate", "ptr", Size)
+        result := DllCall("RPCRT4.dll\NdrRpcSmClientAllocate", "ptr", Size, "ptr")
         return result
     }
 
@@ -24013,7 +24013,7 @@ class Rpc {
      * @returns {Pointer<Void>} 
      */
     static NdrRpcSsDefaultAllocate(Size) {
-        result := DllCall("RPCRT4.dll\NdrRpcSsDefaultAllocate", "ptr", Size)
+        result := DllCall("RPCRT4.dll\NdrRpcSsDefaultAllocate", "ptr", Size, "ptr")
         return result
     }
 
@@ -24053,7 +24053,7 @@ class Rpc {
      * @returns {Pointer<Void>} 
      */
     static NdrAllocate(pStubMsg, Len) {
-        result := DllCall("RPCRT4.dll\NdrAllocate", "ptr", pStubMsg, "ptr", Len)
+        result := DllCall("RPCRT4.dll\NdrAllocate", "ptr", pStubMsg, "ptr", Len, "ptr")
         return result
     }
 
@@ -24080,7 +24080,7 @@ class Rpc {
      * @since windows5.0
      */
     static NdrOleAllocate(Size) {
-        result := DllCall("RPCRT4.dll\NdrOleAllocate", "ptr", Size)
+        result := DllCall("RPCRT4.dll\NdrOleAllocate", "ptr", Size, "ptr")
         return result
     }
 

--- a/Windows/Win32/System/Search/Apis.ahk
+++ b/Windows/Win32/System/Search/Apis.ahk
@@ -20270,7 +20270,7 @@ class Search {
         pwchServerName := pwchServerName is String? StrPtr(pwchServerName) : pwchServerName
         pwchInstanceName := pwchInstanceName is String? StrPtr(pwchInstanceName) : pwchInstanceName
 
-        result := DllCall("odbcbcp.dll\SQLInitEnumServers", "ptr", pwchServerName, "ptr", pwchInstanceName)
+        result := DllCall("odbcbcp.dll\SQLInitEnumServers", "ptr", pwchServerName, "ptr", pwchInstanceName, "ptr")
         return result
     }
 

--- a/Windows/Win32/System/Services/Apis.ahk
+++ b/Windows/Win32/System/Services/Apis.ahk
@@ -2095,7 +2095,7 @@ class Services {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\CreateServiceA", "ptr", hSCManager, "ptr", lpServiceName, "ptr", lpDisplayName, "uint", dwDesiredAccess, "uint", dwServiceType, "uint", dwStartType, "uint", dwErrorControl, "ptr", lpBinaryPathName, "ptr", lpLoadOrderGroup, "uint*", lpdwTagId, "ptr", lpDependencies, "ptr", lpServiceStartName, "ptr", lpPassword)
+        result := DllCall("ADVAPI32.dll\CreateServiceA", "ptr", hSCManager, "ptr", lpServiceName, "ptr", lpDisplayName, "uint", dwDesiredAccess, "uint", dwServiceType, "uint", dwStartType, "uint", dwErrorControl, "ptr", lpBinaryPathName, "ptr", lpLoadOrderGroup, "uint*", lpdwTagId, "ptr", lpDependencies, "ptr", lpServiceStartName, "ptr", lpPassword, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2378,7 +2378,7 @@ class Services {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\CreateServiceW", "ptr", hSCManager, "ptr", lpServiceName, "ptr", lpDisplayName, "uint", dwDesiredAccess, "uint", dwServiceType, "uint", dwStartType, "uint", dwErrorControl, "ptr", lpBinaryPathName, "ptr", lpLoadOrderGroup, "uint*", lpdwTagId, "ptr", lpDependencies, "ptr", lpServiceStartName, "ptr", lpPassword)
+        result := DllCall("ADVAPI32.dll\CreateServiceW", "ptr", hSCManager, "ptr", lpServiceName, "ptr", lpDisplayName, "uint", dwDesiredAccess, "uint", dwServiceType, "uint", dwStartType, "uint", dwErrorControl, "ptr", lpBinaryPathName, "ptr", lpLoadOrderGroup, "uint*", lpdwTagId, "ptr", lpDependencies, "ptr", lpServiceStartName, "ptr", lpPassword, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3330,7 +3330,7 @@ class Services {
     static LockServiceDatabase(hSCManager) {
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\LockServiceDatabase", "ptr", hSCManager)
+        result := DllCall("ADVAPI32.dll\LockServiceDatabase", "ptr", hSCManager, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3454,7 +3454,7 @@ class Services {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\OpenSCManagerA", "ptr", lpMachineName, "ptr", lpDatabaseName, "uint", dwDesiredAccess)
+        result := DllCall("ADVAPI32.dll\OpenSCManagerA", "ptr", lpMachineName, "ptr", lpDatabaseName, "uint", dwDesiredAccess, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3531,7 +3531,7 @@ class Services {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\OpenSCManagerW", "ptr", lpMachineName, "ptr", lpDatabaseName, "uint", dwDesiredAccess)
+        result := DllCall("ADVAPI32.dll\OpenSCManagerW", "ptr", lpMachineName, "ptr", lpDatabaseName, "uint", dwDesiredAccess, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3623,7 +3623,7 @@ class Services {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\OpenServiceA", "ptr", hSCManager, "ptr", lpServiceName, "uint", dwDesiredAccess)
+        result := DllCall("ADVAPI32.dll\OpenServiceA", "ptr", hSCManager, "ptr", lpServiceName, "uint", dwDesiredAccess, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3715,7 +3715,7 @@ class Services {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\OpenServiceW", "ptr", hSCManager, "ptr", lpServiceName, "uint", dwDesiredAccess)
+        result := DllCall("ADVAPI32.dll\OpenServiceW", "ptr", hSCManager, "ptr", lpServiceName, "uint", dwDesiredAccess, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4542,7 +4542,7 @@ class Services {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\RegisterServiceCtrlHandlerA", "ptr", lpServiceName, "ptr", lpHandlerProc)
+        result := DllCall("ADVAPI32.dll\RegisterServiceCtrlHandlerA", "ptr", lpServiceName, "ptr", lpHandlerProc, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4619,7 +4619,7 @@ class Services {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\RegisterServiceCtrlHandlerW", "ptr", lpServiceName, "ptr", lpHandlerProc)
+        result := DllCall("ADVAPI32.dll\RegisterServiceCtrlHandlerW", "ptr", lpServiceName, "ptr", lpHandlerProc, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4699,7 +4699,7 @@ class Services {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\RegisterServiceCtrlHandlerExA", "ptr", lpServiceName, "ptr", lpHandlerProc, "ptr", lpContext)
+        result := DllCall("ADVAPI32.dll\RegisterServiceCtrlHandlerExA", "ptr", lpServiceName, "ptr", lpHandlerProc, "ptr", lpContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4779,7 +4779,7 @@ class Services {
 
         A_LastError := 0
 
-        result := DllCall("ADVAPI32.dll\RegisterServiceCtrlHandlerExW", "ptr", lpServiceName, "ptr", lpHandlerProc, "ptr", lpContext)
+        result := DllCall("ADVAPI32.dll\RegisterServiceCtrlHandlerExW", "ptr", lpServiceName, "ptr", lpHandlerProc, "ptr", lpContext, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/Threading/Apis.ahk
+++ b/Windows/Win32/System/Threading/Apis.ahk
@@ -1164,7 +1164,7 @@ class Threading {
      * @see https://learn.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocesstoken
      */
     static GetCurrentProcessToken() {
-        result := DllCall("FORCEINLINE\GetCurrentProcessToken")
+        result := DllCall("FORCEINLINE\GetCurrentProcessToken", "ptr")
         return result
     }
 
@@ -1182,7 +1182,7 @@ class Threading {
      * @see https://learn.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentthreadtoken
      */
     static GetCurrentThreadToken() {
-        result := DllCall("FORCEINLINE\GetCurrentThreadToken")
+        result := DllCall("FORCEINLINE\GetCurrentThreadToken", "ptr")
         return result
     }
 
@@ -1200,7 +1200,7 @@ class Threading {
      * @see https://learn.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentthreadeffectivetoken
      */
     static GetCurrentThreadEffectiveToken() {
-        result := DllCall("FORCEINLINE\GetCurrentThreadEffectiveToken")
+        result := DllCall("FORCEINLINE\GetCurrentThreadEffectiveToken", "ptr")
         return result
     }
 
@@ -1334,7 +1334,7 @@ class Threading {
     static FlsGetValue(dwFlsIndex) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\FlsGetValue", "uint", dwFlsIndex)
+        result := DllCall("KERNEL32.dll\FlsGetValue", "uint", dwFlsIndex, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -1444,7 +1444,7 @@ class Threading {
      * @returns {Pointer<Void>} 
      */
     static FlsGetValue2(dwTlsIndex) {
-        result := DllCall("KERNEL32.dll\FlsGetValue2", "uint", dwTlsIndex)
+        result := DllCall("KERNEL32.dll\FlsGetValue2", "uint", dwTlsIndex, "ptr")
         return result
     }
 
@@ -2752,7 +2752,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateMutexA", "ptr", lpMutexAttributes, "int", bInitialOwner, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\CreateMutexA", "ptr", lpMutexAttributes, "int", bInitialOwner, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2830,7 +2830,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateMutexW", "ptr", lpMutexAttributes, "int", bInitialOwner, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\CreateMutexW", "ptr", lpMutexAttributes, "int", bInitialOwner, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2876,7 +2876,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\OpenMutexW", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\OpenMutexW", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -2980,7 +2980,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateEventA", "ptr", lpEventAttributes, "int", bManualReset, "int", bInitialState, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\CreateEventA", "ptr", lpEventAttributes, "int", bManualReset, "int", bInitialState, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3084,7 +3084,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateEventW", "ptr", lpEventAttributes, "int", bManualReset, "int", bInitialState, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\CreateEventW", "ptr", lpEventAttributes, "int", bManualReset, "int", bInitialState, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3129,7 +3129,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\OpenEventA", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\OpenEventA", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3174,7 +3174,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\OpenEventW", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\OpenEventW", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3216,7 +3216,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\OpenSemaphoreW", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\OpenSemaphoreW", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3259,7 +3259,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\OpenWaitableTimerW", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpTimerName)
+        result := DllCall("KERNEL32.dll\OpenWaitableTimerW", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpTimerName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3505,7 +3505,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateMutexExA", "ptr", lpMutexAttributes, "ptr", lpName, "uint", dwFlags, "uint", dwDesiredAccess)
+        result := DllCall("KERNEL32.dll\CreateMutexExA", "ptr", lpMutexAttributes, "ptr", lpName, "uint", dwFlags, "uint", dwDesiredAccess, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3604,7 +3604,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateMutexExW", "ptr", lpMutexAttributes, "ptr", lpName, "uint", dwFlags, "uint", dwDesiredAccess)
+        result := DllCall("KERNEL32.dll\CreateMutexExW", "ptr", lpMutexAttributes, "ptr", lpName, "uint", dwFlags, "uint", dwDesiredAccess, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3703,7 +3703,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateEventExA", "ptr", lpEventAttributes, "ptr", lpName, "uint", dwFlags, "uint", dwDesiredAccess)
+        result := DllCall("KERNEL32.dll\CreateEventExA", "ptr", lpEventAttributes, "ptr", lpName, "uint", dwFlags, "uint", dwDesiredAccess, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3802,7 +3802,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateEventExW", "ptr", lpEventAttributes, "ptr", lpName, "uint", dwFlags, "uint", dwDesiredAccess)
+        result := DllCall("KERNEL32.dll\CreateEventExW", "ptr", lpEventAttributes, "ptr", lpName, "uint", dwFlags, "uint", dwDesiredAccess, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3869,7 +3869,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateSemaphoreExW", "ptr", lpSemaphoreAttributes, "int", lInitialCount, "int", lMaximumCount, "ptr", lpName, "uint", dwFlags, "uint", dwDesiredAccess)
+        result := DllCall("KERNEL32.dll\CreateSemaphoreExW", "ptr", lpSemaphoreAttributes, "int", lInitialCount, "int", lMaximumCount, "ptr", lpName, "uint", dwFlags, "uint", dwDesiredAccess, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -3950,7 +3950,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateWaitableTimerExW", "ptr", lpTimerAttributes, "ptr", lpTimerName, "uint", dwFlags, "uint", dwDesiredAccess)
+        result := DllCall("KERNEL32.dll\CreateWaitableTimerExW", "ptr", lpTimerAttributes, "ptr", lpTimerName, "uint", dwFlags, "uint", dwDesiredAccess, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4373,7 +4373,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateSemaphoreW", "ptr", lpSemaphoreAttributes, "int", lInitialCount, "int", lMaximumCount, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\CreateSemaphoreW", "ptr", lpSemaphoreAttributes, "int", lInitialCount, "int", lMaximumCount, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4436,7 +4436,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateWaitableTimerW", "ptr", lpTimerAttributes, "int", bManualReset, "ptr", lpTimerName)
+        result := DllCall("KERNEL32.dll\CreateWaitableTimerW", "ptr", lpTimerAttributes, "int", bManualReset, "ptr", lpTimerName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -4671,7 +4671,7 @@ class Threading {
      * @since windows5.1.2600
      */
     static GetCurrentProcess() {
-        result := DllCall("KERNEL32.dll\GetCurrentProcess")
+        result := DllCall("KERNEL32.dll\GetCurrentProcess", "ptr")
         return result
     }
 
@@ -4949,7 +4949,7 @@ class Threading {
     static CreateThread(lpThreadAttributes, dwStackSize, lpStartAddress, lpParameter, dwCreationFlags, lpThreadId) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateThread", "ptr", lpThreadAttributes, "ptr", dwStackSize, "ptr", lpStartAddress, "ptr", lpParameter, "uint", dwCreationFlags, "uint*", lpThreadId)
+        result := DllCall("KERNEL32.dll\CreateThread", "ptr", lpThreadAttributes, "ptr", dwStackSize, "ptr", lpStartAddress, "ptr", lpParameter, "uint", dwCreationFlags, "uint*", lpThreadId, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5072,7 +5072,7 @@ class Threading {
     static CreateRemoteThread(hProcess, lpThreadAttributes, dwStackSize, lpStartAddress, lpParameter, dwCreationFlags, lpThreadId) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateRemoteThread", "ptr", hProcess, "ptr", lpThreadAttributes, "ptr", dwStackSize, "ptr", lpStartAddress, "ptr", lpParameter, "uint", dwCreationFlags, "uint*", lpThreadId)
+        result := DllCall("KERNEL32.dll\CreateRemoteThread", "ptr", hProcess, "ptr", lpThreadAttributes, "ptr", dwStackSize, "ptr", lpStartAddress, "ptr", lpParameter, "uint", dwCreationFlags, "uint*", lpThreadId, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5101,7 +5101,7 @@ class Threading {
      * @since windows5.1.2600
      */
     static GetCurrentThread() {
-        result := DllCall("KERNEL32.dll\GetCurrentThread")
+        result := DllCall("KERNEL32.dll\GetCurrentThread", "ptr")
         return result
     }
 
@@ -5143,7 +5143,7 @@ class Threading {
     static OpenThread(dwDesiredAccess, bInheritHandle, dwThreadId) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\OpenThread", "uint", dwDesiredAccess, "int", bInheritHandle, "uint", dwThreadId)
+        result := DllCall("KERNEL32.dll\OpenThread", "uint", dwDesiredAccess, "int", bInheritHandle, "uint", dwThreadId, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -5670,7 +5670,7 @@ class Threading {
     static TlsGetValue(dwTlsIndex) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\TlsGetValue", "uint", dwTlsIndex)
+        result := DllCall("KERNEL32.dll\TlsGetValue", "uint", dwTlsIndex, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -7564,7 +7564,7 @@ class Threading {
     static CreateRemoteThreadEx(hProcess, lpThreadAttributes, dwStackSize, lpStartAddress, lpParameter, dwCreationFlags, lpAttributeList, lpThreadId) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateRemoteThreadEx", "ptr", hProcess, "ptr", lpThreadAttributes, "ptr", dwStackSize, "ptr", lpStartAddress, "ptr", lpParameter, "uint", dwCreationFlags, "ptr", lpAttributeList, "uint*", lpThreadId)
+        result := DllCall("KERNEL32.dll\CreateRemoteThreadEx", "ptr", hProcess, "ptr", lpThreadAttributes, "ptr", dwStackSize, "ptr", lpStartAddress, "ptr", lpParameter, "uint", dwCreationFlags, "ptr", lpAttributeList, "uint*", lpThreadId, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -7757,7 +7757,7 @@ class Threading {
     static OpenProcess(dwDesiredAccess, bInheritHandle, dwProcessId) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\OpenProcess", "uint", dwDesiredAccess, "int", bInheritHandle, "uint", dwProcessId)
+        result := DllCall("KERNEL32.dll\OpenProcess", "uint", dwDesiredAccess, "int", bInheritHandle, "uint", dwProcessId, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -8800,7 +8800,7 @@ class Threading {
      * @returns {Pointer<Void>} 
      */
     static TlsGetValue2(dwTlsIndex) {
-        result := DllCall("KERNEL32.dll\TlsGetValue2", "uint", dwTlsIndex)
+        result := DllCall("KERNEL32.dll\TlsGetValue2", "uint", dwTlsIndex, "ptr")
         return result
     }
 
@@ -8901,7 +8901,7 @@ class Threading {
     static CreateTimerQueue() {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateTimerQueue")
+        result := DllCall("KERNEL32.dll\CreateTimerQueue", "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -10055,7 +10055,7 @@ class Threading {
     static CreatePrivateNamespaceW(lpPrivateNamespaceAttributes, lpBoundaryDescriptor, lpAliasPrefix) {
         lpAliasPrefix := lpAliasPrefix is String? StrPtr(lpAliasPrefix) : lpAliasPrefix
 
-        result := DllCall("KERNEL32.dll\CreatePrivateNamespaceW", "ptr", lpPrivateNamespaceAttributes, "ptr", lpBoundaryDescriptor, "ptr", lpAliasPrefix)
+        result := DllCall("KERNEL32.dll\CreatePrivateNamespaceW", "ptr", lpPrivateNamespaceAttributes, "ptr", lpBoundaryDescriptor, "ptr", lpAliasPrefix, "ptr")
         return result
     }
 
@@ -10071,7 +10071,7 @@ class Threading {
     static OpenPrivateNamespaceW(lpBoundaryDescriptor, lpAliasPrefix) {
         lpAliasPrefix := lpAliasPrefix is String? StrPtr(lpAliasPrefix) : lpAliasPrefix
 
-        result := DllCall("KERNEL32.dll\OpenPrivateNamespaceW", "ptr", lpBoundaryDescriptor, "ptr", lpAliasPrefix)
+        result := DllCall("KERNEL32.dll\OpenPrivateNamespaceW", "ptr", lpBoundaryDescriptor, "ptr", lpAliasPrefix, "ptr")
         return result
     }
 
@@ -10118,7 +10118,7 @@ class Threading {
     static CreateBoundaryDescriptorW(Name, Flags) {
         Name := Name is String? StrPtr(Name) : Name
 
-        result := DllCall("KERNEL32.dll\CreateBoundaryDescriptorW", "ptr", Name, "uint", Flags)
+        result := DllCall("KERNEL32.dll\CreateBoundaryDescriptorW", "ptr", Name, "uint", Flags, "ptr")
         return result
     }
 
@@ -10407,7 +10407,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("AVRT.dll\AvSetMmThreadCharacteristicsA", "ptr", TaskName, "uint*", TaskIndex)
+        result := DllCall("AVRT.dll\AvSetMmThreadCharacteristicsA", "ptr", TaskName, "uint*", TaskIndex, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -10483,7 +10483,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("AVRT.dll\AvSetMmThreadCharacteristicsW", "ptr", TaskName, "uint*", TaskIndex)
+        result := DllCall("AVRT.dll\AvSetMmThreadCharacteristicsW", "ptr", TaskName, "uint*", TaskIndex, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -10563,7 +10563,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("AVRT.dll\AvSetMmMaxThreadCharacteristicsA", "ptr", FirstTask, "ptr", SecondTask, "uint*", TaskIndex)
+        result := DllCall("AVRT.dll\AvSetMmMaxThreadCharacteristicsA", "ptr", FirstTask, "ptr", SecondTask, "uint*", TaskIndex, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -10643,7 +10643,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("AVRT.dll\AvSetMmMaxThreadCharacteristicsW", "ptr", FirstTask, "ptr", SecondTask, "uint*", TaskIndex)
+        result := DllCall("AVRT.dll\AvSetMmMaxThreadCharacteristicsW", "ptr", FirstTask, "ptr", SecondTask, "uint*", TaskIndex, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11632,7 +11632,7 @@ class Threading {
      * @see https://learn.microsoft.com/windows/win32/WinAuto/getprocesshandlefromhwnd
      */
     static GetProcessHandleFromHwnd(hwnd) {
-        result := DllCall("OLEACC.dll\GetProcessHandleFromHwnd", "ptr", hwnd)
+        result := DllCall("OLEACC.dll\GetProcessHandleFromHwnd", "ptr", hwnd, "ptr")
         return result
     }
 
@@ -12015,7 +12015,7 @@ class Threading {
     static CreateFiberEx(dwStackCommitSize, dwStackReserveSize, dwFlags, lpStartAddress, lpParameter) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateFiberEx", "ptr", dwStackCommitSize, "ptr", dwStackReserveSize, "uint", dwFlags, "ptr", lpStartAddress, "ptr", lpParameter)
+        result := DllCall("KERNEL32.dll\CreateFiberEx", "ptr", dwStackCommitSize, "ptr", dwStackReserveSize, "uint", dwFlags, "ptr", lpStartAddress, "ptr", lpParameter, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12044,7 +12044,7 @@ class Threading {
     static ConvertThreadToFiberEx(lpParameter, dwFlags) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\ConvertThreadToFiberEx", "ptr", lpParameter, "uint", dwFlags)
+        result := DllCall("KERNEL32.dll\ConvertThreadToFiberEx", "ptr", lpParameter, "uint", dwFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12079,7 +12079,7 @@ class Threading {
     static CreateFiber(dwStackSize, lpStartAddress, lpParameter) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateFiber", "ptr", dwStackSize, "ptr", lpStartAddress, "ptr", lpParameter)
+        result := DllCall("KERNEL32.dll\CreateFiber", "ptr", dwStackSize, "ptr", lpStartAddress, "ptr", lpParameter, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12107,7 +12107,7 @@ class Threading {
     static ConvertThreadToFiber(lpParameter) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\ConvertThreadToFiber", "ptr", lpParameter)
+        result := DllCall("KERNEL32.dll\ConvertThreadToFiber", "ptr", lpParameter, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12375,7 +12375,7 @@ class Threading {
     static GetCurrentUmsThread() {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\GetCurrentUmsThread")
+        result := DllCall("KERNEL32.dll\GetCurrentUmsThread", "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12394,7 +12394,7 @@ class Threading {
     static GetNextUmsListItem(UmsContext) {
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\GetNextUmsListItem", "ptr", UmsContext)
+        result := DllCall("KERNEL32.dll\GetNextUmsListItem", "ptr", UmsContext, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -13246,7 +13246,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateSemaphoreA", "ptr", lpSemaphoreAttributes, "int", lInitialCount, "int", lMaximumCount, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\CreateSemaphoreA", "ptr", lpSemaphoreAttributes, "int", lInitialCount, "int", lMaximumCount, "ptr", lpName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -13306,7 +13306,7 @@ class Threading {
     static CreateWaitableTimerA(lpTimerAttributes, bManualReset, lpTimerName) {
         lpTimerName := lpTimerName is String? StrPtr(lpTimerName) : lpTimerName
 
-        result := DllCall("KERNEL32.dll\CreateWaitableTimerA", "ptr", lpTimerAttributes, "int", bManualReset, "ptr", lpTimerName)
+        result := DllCall("KERNEL32.dll\CreateWaitableTimerA", "ptr", lpTimerAttributes, "int", bManualReset, "ptr", lpTimerName, "ptr")
         return result
     }
 
@@ -13343,7 +13343,7 @@ class Threading {
     static OpenWaitableTimerA(dwDesiredAccess, bInheritHandle, lpTimerName) {
         lpTimerName := lpTimerName is String? StrPtr(lpTimerName) : lpTimerName
 
-        result := DllCall("KERNEL32.dll\OpenWaitableTimerA", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpTimerName)
+        result := DllCall("KERNEL32.dll\OpenWaitableTimerA", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpTimerName, "ptr")
         return result
     }
 
@@ -13407,7 +13407,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateSemaphoreExA", "ptr", lpSemaphoreAttributes, "int", lInitialCount, "int", lMaximumCount, "ptr", lpName, "uint", dwFlags, "uint", dwDesiredAccess)
+        result := DllCall("KERNEL32.dll\CreateSemaphoreExA", "ptr", lpSemaphoreAttributes, "int", lInitialCount, "int", lMaximumCount, "ptr", lpName, "uint", dwFlags, "uint", dwDesiredAccess, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -13485,7 +13485,7 @@ class Threading {
     static CreateWaitableTimerExA(lpTimerAttributes, lpTimerName, dwFlags, dwDesiredAccess) {
         lpTimerName := lpTimerName is String? StrPtr(lpTimerName) : lpTimerName
 
-        result := DllCall("KERNEL32.dll\CreateWaitableTimerExA", "ptr", lpTimerAttributes, "ptr", lpTimerName, "uint", dwFlags, "uint", dwDesiredAccess)
+        result := DllCall("KERNEL32.dll\CreateWaitableTimerExA", "ptr", lpTimerAttributes, "ptr", lpTimerName, "uint", dwFlags, "uint", dwDesiredAccess, "ptr")
         return result
     }
 
@@ -14050,7 +14050,7 @@ class Threading {
      * @returns {Pointer<Void>} 
      */
     static SetTimerQueueTimer(TimerQueue, Callback, Parameter, DueTime, Period, PreferIo) {
-        result := DllCall("KERNEL32.dll\SetTimerQueueTimer", "ptr", TimerQueue, "ptr", Callback, "ptr", Parameter, "uint", DueTime, "uint", Period, "int", PreferIo)
+        result := DllCall("KERNEL32.dll\SetTimerQueueTimer", "ptr", TimerQueue, "ptr", Callback, "ptr", Parameter, "uint", DueTime, "uint", Period, "int", PreferIo, "ptr")
         return result
     }
 
@@ -14090,7 +14090,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreatePrivateNamespaceA", "ptr", lpPrivateNamespaceAttributes, "ptr", lpBoundaryDescriptor, "ptr", lpAliasPrefix)
+        result := DllCall("KERNEL32.dll\CreatePrivateNamespaceA", "ptr", lpPrivateNamespaceAttributes, "ptr", lpBoundaryDescriptor, "ptr", lpAliasPrefix, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14110,7 +14110,7 @@ class Threading {
     static OpenPrivateNamespaceA(lpBoundaryDescriptor, lpAliasPrefix) {
         lpAliasPrefix := lpAliasPrefix is String? StrPtr(lpAliasPrefix) : lpAliasPrefix
 
-        result := DllCall("KERNEL32.dll\OpenPrivateNamespaceA", "ptr", lpBoundaryDescriptor, "ptr", lpAliasPrefix)
+        result := DllCall("KERNEL32.dll\OpenPrivateNamespaceA", "ptr", lpBoundaryDescriptor, "ptr", lpAliasPrefix, "ptr")
         return result
     }
 
@@ -14138,7 +14138,7 @@ class Threading {
 
         A_LastError := 0
 
-        result := DllCall("KERNEL32.dll\CreateBoundaryDescriptorA", "ptr", Name, "uint", Flags)
+        result := DllCall("KERNEL32.dll\CreateBoundaryDescriptorA", "ptr", Name, "uint", Flags, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/System/WindowsProgramming/Apis.ahk
+++ b/Windows/Win32/System/WindowsProgramming/Apis.ahk
@@ -3383,7 +3383,7 @@ class WindowsProgramming {
      * @returns {Pointer<Void>} 
      */
     static GlobalWire(hMem) {
-        result := DllCall("KERNEL32.dll\GlobalWire", "ptr", hMem)
+        result := DllCall("KERNEL32.dll\GlobalWire", "ptr", hMem, "ptr")
         return result
     }
 
@@ -3803,7 +3803,7 @@ class WindowsProgramming {
     static OpenMutexA(dwDesiredAccess, bInheritHandle, lpName) {
         lpName := lpName is String? StrPtr(lpName) : lpName
 
-        result := DllCall("KERNEL32.dll\OpenMutexA", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\OpenMutexA", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName, "ptr")
         return result
     }
 
@@ -3839,7 +3839,7 @@ class WindowsProgramming {
     static OpenSemaphoreA(dwDesiredAccess, bInheritHandle, lpName) {
         lpName := lpName is String? StrPtr(lpName) : lpName
 
-        result := DllCall("KERNEL32.dll\OpenSemaphoreA", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName)
+        result := DllCall("KERNEL32.dll\OpenSemaphoreA", "uint", dwDesiredAccess, "int", bInheritHandle, "ptr", lpName, "ptr")
         return result
     }
 
@@ -7210,7 +7210,7 @@ class WindowsProgramming {
      * @since windows5.0
      */
     static DCIOpenProvider() {
-        result := DllCall("DCIMAN32.dll\DCIOpenProvider")
+        result := DllCall("DCIMAN32.dll\DCIOpenProvider", "ptr")
         return result
     }
 
@@ -7302,7 +7302,7 @@ class WindowsProgramming {
      * @returns {Pointer<Void>} 
      */
     static WinWatchOpen(hwnd) {
-        result := DllCall("DCIMAN32.dll\WinWatchOpen", "ptr", hwnd)
+        result := DllCall("DCIMAN32.dll\WinWatchOpen", "ptr", hwnd, "ptr")
         return result
     }
 

--- a/Windows/Win32/UI/Accessibility/Apis.ahk
+++ b/Windows/Win32/UI/Accessibility/Apis.ahk
@@ -6232,7 +6232,7 @@ class Accessibility {
      * @since windows5.0
      */
     static SetWinEventHook(eventMin, eventMax, hmodWinEventProc, pfnWinEventProc, idProcess, idThread, dwFlags) {
-        result := DllCall("USER32.dll\SetWinEventHook", "uint", eventMin, "uint", eventMax, "ptr", hmodWinEventProc, "ptr", pfnWinEventProc, "uint", idProcess, "uint", idThread, "uint", dwFlags)
+        result := DllCall("USER32.dll\SetWinEventHook", "uint", eventMin, "uint", eventMax, "ptr", hmodWinEventProc, "ptr", pfnWinEventProc, "uint", idProcess, "uint", idThread, "uint", dwFlags, "ptr")
         return result
     }
 

--- a/Windows/Win32/UI/ColorSystem/Apis.ahk
+++ b/Windows/Win32/UI/ColorSystem/Apis.ahk
@@ -534,7 +534,7 @@ class ColorSystem {
      * @since windows5.0
      */
     static GetColorSpace(hdc) {
-        result := DllCall("GDI32.dll\GetColorSpace", "ptr", hdc)
+        result := DllCall("GDI32.dll\GetColorSpace", "ptr", hdc, "ptr")
         return result
     }
 
@@ -605,7 +605,7 @@ class ColorSystem {
      * @since windows5.0
      */
     static CreateColorSpaceA(lplcs) {
-        result := DllCall("GDI32.dll\CreateColorSpaceA", "ptr", lplcs)
+        result := DllCall("GDI32.dll\CreateColorSpaceA", "ptr", lplcs, "ptr")
         return result
     }
 
@@ -630,7 +630,7 @@ class ColorSystem {
      * @since windows5.0
      */
     static CreateColorSpaceW(lplcs) {
-        result := DllCall("GDI32.dll\CreateColorSpaceW", "ptr", lplcs)
+        result := DllCall("GDI32.dll\CreateColorSpaceW", "ptr", lplcs, "ptr")
         return result
     }
 
@@ -645,7 +645,7 @@ class ColorSystem {
      * @since windows5.0
      */
     static SetColorSpace(hdc, hcs) {
-        result := DllCall("GDI32.dll\SetColorSpace", "ptr", hdc, "ptr", hcs)
+        result := DllCall("GDI32.dll\SetColorSpace", "ptr", hdc, "ptr", hcs, "ptr")
         return result
     }
 

--- a/Windows/Win32/UI/Controls/Apis.ahk
+++ b/Windows/Win32/UI/Controls/Apis.ahk
@@ -10819,7 +10819,7 @@ class Controls {
      * @since windows6.0.6000
      */
     static CreatePropertySheetPageA(constPropSheetPagePointer) {
-        result := DllCall("COMCTL32.dll\CreatePropertySheetPageA", "ptr", constPropSheetPagePointer)
+        result := DllCall("COMCTL32.dll\CreatePropertySheetPageA", "ptr", constPropSheetPagePointer, "ptr")
         return result
     }
 
@@ -10847,7 +10847,7 @@ class Controls {
      * @since windows6.0.6000
      */
     static CreatePropertySheetPageW(constPropSheetPagePointer) {
-        result := DllCall("COMCTL32.dll\CreatePropertySheetPageW", "ptr", constPropSheetPagePointer)
+        result := DllCall("COMCTL32.dll\CreatePropertySheetPageW", "ptr", constPropSheetPagePointer, "ptr")
         return result
     }
 
@@ -11457,7 +11457,7 @@ class Controls {
      * @since windows6.0.6000
      */
     static ImageList_GetIcon(himl, i, flags) {
-        result := DllCall("COMCTL32.dll\ImageList_GetIcon", "ptr", himl, "int", i, "uint", flags)
+        result := DllCall("COMCTL32.dll\ImageList_GetIcon", "ptr", himl, "int", i, "uint", flags, "ptr")
         return result
     }
 
@@ -12199,7 +12199,7 @@ class Controls {
     static CreateToolbarEx(hwnd, ws, wID, nBitmaps, hBMInst, wBMID, lpButtons, iNumButtons, dxButton, dyButton, dxBitmap, dyBitmap, uStructSize) {
         A_LastError := 0
 
-        result := DllCall("COMCTL32.dll\CreateToolbarEx", "ptr", hwnd, "uint", ws, "uint", wID, "int", nBitmaps, "ptr", hBMInst, "ptr", wBMID, "ptr", lpButtons, "int", iNumButtons, "int", dxButton, "int", dyButton, "int", dxBitmap, "int", dyBitmap, "uint", uStructSize)
+        result := DllCall("COMCTL32.dll\CreateToolbarEx", "ptr", hwnd, "uint", ws, "uint", wID, "int", nBitmaps, "ptr", hBMInst, "ptr", wBMID, "ptr", lpButtons, "int", iNumButtons, "int", dxButton, "int", dyButton, "int", dxBitmap, "int", dyBitmap, "uint", uStructSize, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12254,7 +12254,7 @@ class Controls {
     static CreateMappedBitmap(hInstance, idBitmap, wFlags, lpColorMap, iNumMaps) {
         A_LastError := 0
 
-        result := DllCall("COMCTL32.dll\CreateMappedBitmap", "ptr", hInstance, "ptr", idBitmap, "uint", wFlags, "ptr", lpColorMap, "int", iNumMaps)
+        result := DllCall("COMCTL32.dll\CreateMappedBitmap", "ptr", hInstance, "ptr", idBitmap, "uint", wFlags, "ptr", lpColorMap, "int", iNumMaps, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12434,7 +12434,7 @@ class Controls {
 
         A_LastError := 0
 
-        result := DllCall("COMCTL32.dll\CreateStatusWindowA", "int", style, "ptr", lpszText, "ptr", hwndParent, "uint", wID)
+        result := DllCall("COMCTL32.dll\CreateStatusWindowA", "int", style, "ptr", lpszText, "ptr", hwndParent, "uint", wID, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12474,7 +12474,7 @@ class Controls {
 
         A_LastError := 0
 
-        result := DllCall("COMCTL32.dll\CreateStatusWindowW", "int", style, "ptr", lpszText, "ptr", hwndParent, "uint", wID)
+        result := DllCall("COMCTL32.dll\CreateStatusWindowW", "int", style, "ptr", lpszText, "ptr", hwndParent, "uint", wID, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12666,7 +12666,7 @@ class Controls {
      * @since windows6.0.6000
      */
     static CreateUpDownControl(dwStyle, x, y, cx, cy, hParent, nID, hInst, hBuddy, nUpper, nLower, nPos) {
-        result := DllCall("COMCTL32.dll\CreateUpDownControl", "uint", dwStyle, "int", x, "int", y, "int", cx, "int", cy, "ptr", hParent, "int", nID, "ptr", hInst, "ptr", hBuddy, "int", nUpper, "int", nLower, "int", nPos)
+        result := DllCall("COMCTL32.dll\CreateUpDownControl", "uint", dwStyle, "int", x, "int", y, "int", cx, "int", cy, "ptr", hParent, "int", nID, "ptr", hInst, "ptr", hBuddy, "int", nUpper, "int", nLower, "int", nPos, "ptr")
         return result
     }
 
@@ -13209,7 +13209,7 @@ class Controls {
      * @since windows6.0.6000
      */
     static DSA_GetItemPtr(hdsa, i) {
-        result := DllCall("COMCTL32.dll\DSA_GetItemPtr", "ptr", hdsa, "int", i)
+        result := DllCall("COMCTL32.dll\DSA_GetItemPtr", "ptr", hdsa, "int", i, "ptr")
         return result
     }
 
@@ -13429,7 +13429,7 @@ class Controls {
      * @since windows6.0.6000
      */
     static DPA_DeletePtr(hdpa, i) {
-        result := DllCall("COMCTL32.dll\DPA_DeletePtr", "ptr", hdpa, "int", i)
+        result := DllCall("COMCTL32.dll\DPA_DeletePtr", "ptr", hdpa, "int", i, "ptr")
         return result
     }
 
@@ -13549,7 +13549,7 @@ class Controls {
      * @since windows6.0.6000
      */
     static DPA_GetPtr(hdpa, i) {
-        result := DllCall("COMCTL32.dll\DPA_GetPtr", "ptr", hdpa, "ptr", i)
+        result := DllCall("COMCTL32.dll\DPA_GetPtr", "ptr", hdpa, "ptr", i, "ptr")
         return result
     }
 
@@ -15971,7 +15971,7 @@ class Controls {
      * @since windows6.0.6000
      */
     static GetThemeSysColorBrush(hTheme, iColorId) {
-        result := DllCall("UxTheme.dll\GetThemeSysColorBrush", "ptr", hTheme, "int", iColorId)
+        result := DllCall("UxTheme.dll\GetThemeSysColorBrush", "ptr", hTheme, "int", iColorId, "ptr")
         return result
     }
 
@@ -17042,7 +17042,7 @@ class Controls {
      * @since windows6.0.6000
      */
     static GetBufferedPaintTargetDC(hBufferedPaint) {
-        result := DllCall("UxTheme.dll\GetBufferedPaintTargetDC", "ptr", hBufferedPaint)
+        result := DllCall("UxTheme.dll\GetBufferedPaintTargetDC", "ptr", hBufferedPaint, "ptr")
         return result
     }
 
@@ -17058,7 +17058,7 @@ class Controls {
      * @since windows6.0.6000
      */
     static GetBufferedPaintDC(hBufferedPaint) {
-        result := DllCall("UxTheme.dll\GetBufferedPaintDC", "ptr", hBufferedPaint)
+        result := DllCall("UxTheme.dll\GetBufferedPaintDC", "ptr", hBufferedPaint, "ptr")
         return result
     }
 
@@ -17489,7 +17489,7 @@ class Controls {
     static CreateSyntheticPointerDevice(pointerType, maxCount, mode) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateSyntheticPointerDevice", "int", pointerType, "uint", maxCount, "int", mode)
+        result := DllCall("USER32.dll\CreateSyntheticPointerDevice", "int", pointerType, "uint", maxCount, "int", mode, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/UI/Controls/Dialogs/Apis.ahk
+++ b/Windows/Win32/UI/Controls/Dialogs/Apis.ahk
@@ -741,7 +741,7 @@ class Dialogs {
      * @since windows5.0
      */
     static FindTextA(param0) {
-        result := DllCall("COMDLG32.dll\FindTextA", "ptr", param0)
+        result := DllCall("COMDLG32.dll\FindTextA", "ptr", param0, "ptr")
         return result
     }
 
@@ -765,7 +765,7 @@ class Dialogs {
      * @since windows5.0
      */
     static FindTextW(param0) {
-        result := DllCall("COMDLG32.dll\FindTextW", "ptr", param0)
+        result := DllCall("COMDLG32.dll\FindTextW", "ptr", param0, "ptr")
         return result
     }
 
@@ -796,7 +796,7 @@ class Dialogs {
      * @since windows5.0
      */
     static ReplaceTextA(param0) {
-        result := DllCall("COMDLG32.dll\ReplaceTextA", "ptr", param0)
+        result := DllCall("COMDLG32.dll\ReplaceTextA", "ptr", param0, "ptr")
         return result
     }
 
@@ -827,7 +827,7 @@ class Dialogs {
      * @since windows5.0
      */
     static ReplaceTextW(param0) {
-        result := DllCall("COMDLG32.dll\ReplaceTextW", "ptr", param0)
+        result := DllCall("COMDLG32.dll\ReplaceTextW", "ptr", param0, "ptr")
         return result
     }
 

--- a/Windows/Win32/UI/HiDpi/Apis.ahk
+++ b/Windows/Win32/UI/HiDpi/Apis.ahk
@@ -274,7 +274,7 @@ class HiDpi {
      * @since windows10.0.14393
      */
     static SetThreadDpiAwarenessContext(dpiContext) {
-        result := DllCall("USER32.dll\SetThreadDpiAwarenessContext", "ptr", dpiContext)
+        result := DllCall("USER32.dll\SetThreadDpiAwarenessContext", "ptr", dpiContext, "ptr")
         return result
     }
 
@@ -287,7 +287,7 @@ class HiDpi {
      * @since windows10.0.14393
      */
     static GetThreadDpiAwarenessContext() {
-        result := DllCall("USER32.dll\GetThreadDpiAwarenessContext")
+        result := DllCall("USER32.dll\GetThreadDpiAwarenessContext", "ptr")
         return result
     }
 
@@ -304,7 +304,7 @@ class HiDpi {
      * @since windows10.0.14393
      */
     static GetWindowDpiAwarenessContext(hwnd) {
-        result := DllCall("USER32.dll\GetWindowDpiAwarenessContext", "ptr", hwnd)
+        result := DllCall("USER32.dll\GetWindowDpiAwarenessContext", "ptr", hwnd, "ptr")
         return result
     }
 
@@ -502,7 +502,7 @@ class HiDpi {
      * @returns {Pointer<Void>} 
      */
     static GetDpiAwarenessContextForProcess(hProcess) {
-        result := DllCall("USER32.dll\GetDpiAwarenessContextForProcess", "ptr", hProcess)
+        result := DllCall("USER32.dll\GetDpiAwarenessContextForProcess", "ptr", hProcess, "ptr")
         return result
     }
 

--- a/Windows/Win32/UI/Input/Ime/Apis.ahk
+++ b/Windows/Win32/UI/Input/Ime/Apis.ahk
@@ -3026,7 +3026,7 @@ class Ime {
         lpszIMEFileName := lpszIMEFileName is String? StrPtr(lpszIMEFileName) : lpszIMEFileName
         lpszLayoutText := lpszLayoutText is String? StrPtr(lpszLayoutText) : lpszLayoutText
 
-        result := DllCall("IMM32.dll\ImmInstallIMEA", "ptr", lpszIMEFileName, "ptr", lpszLayoutText)
+        result := DllCall("IMM32.dll\ImmInstallIMEA", "ptr", lpszIMEFileName, "ptr", lpszLayoutText, "ptr")
         return result
     }
 
@@ -3051,7 +3051,7 @@ class Ime {
         lpszIMEFileName := lpszIMEFileName is String? StrPtr(lpszIMEFileName) : lpszIMEFileName
         lpszLayoutText := lpszLayoutText is String? StrPtr(lpszLayoutText) : lpszLayoutText
 
-        result := DllCall("IMM32.dll\ImmInstallIMEW", "ptr", lpszIMEFileName, "ptr", lpszLayoutText)
+        result := DllCall("IMM32.dll\ImmInstallIMEW", "ptr", lpszIMEFileName, "ptr", lpszLayoutText, "ptr")
         return result
     }
 
@@ -3065,7 +3065,7 @@ class Ime {
      * @since windows5.1.2600
      */
     static ImmGetDefaultIMEWnd(param0) {
-        result := DllCall("IMM32.dll\ImmGetDefaultIMEWnd", "ptr", param0)
+        result := DllCall("IMM32.dll\ImmGetDefaultIMEWnd", "ptr", param0, "ptr")
         return result
     }
 
@@ -3323,7 +3323,7 @@ class Ime {
      * @since windows5.1.2600
      */
     static ImmCreateContext() {
-        result := DllCall("IMM32.dll\ImmCreateContext")
+        result := DllCall("IMM32.dll\ImmCreateContext", "ptr")
         return result
     }
 
@@ -3353,7 +3353,7 @@ class Ime {
      * @since windows5.1.2600
      */
     static ImmGetContext(param0) {
-        result := DllCall("IMM32.dll\ImmGetContext", "ptr", param0)
+        result := DllCall("IMM32.dll\ImmGetContext", "ptr", param0, "ptr")
         return result
     }
 
@@ -3381,7 +3381,7 @@ class Ime {
      * @since windows5.1.2600
      */
     static ImmAssociateContext(param0, param1) {
-        result := DllCall("IMM32.dll\ImmAssociateContext", "ptr", param0, "ptr", param1)
+        result := DllCall("IMM32.dll\ImmAssociateContext", "ptr", param0, "ptr", param1, "ptr")
         return result
     }
 
@@ -4704,7 +4704,7 @@ class Ime {
      * @returns {Pointer<Void>} 
      */
     static ImmCreateSoftKeyboard(param0, param1, param2, param3) {
-        result := DllCall("IMM32.dll\ImmCreateSoftKeyboard", "uint", param0, "ptr", param1, "int", param2, "int", param3)
+        result := DllCall("IMM32.dll\ImmCreateSoftKeyboard", "uint", param0, "ptr", param1, "int", param2, "int", param3, "ptr")
         return result
     }
 
@@ -4765,7 +4765,7 @@ class Ime {
      * @returns {Pointer<Void>} 
      */
     static ImmCreateIMCC(param0) {
-        result := DllCall("IMM32.dll\ImmCreateIMCC", "uint", param0)
+        result := DllCall("IMM32.dll\ImmCreateIMCC", "uint", param0, "ptr")
         return result
     }
 
@@ -4775,7 +4775,7 @@ class Ime {
      * @returns {Pointer<Void>} 
      */
     static ImmDestroyIMCC(param0) {
-        result := DllCall("IMM32.dll\ImmDestroyIMCC", "ptr", param0)
+        result := DllCall("IMM32.dll\ImmDestroyIMCC", "ptr", param0, "ptr")
         return result
     }
 
@@ -4785,7 +4785,7 @@ class Ime {
      * @returns {Pointer<Void>} 
      */
     static ImmLockIMCC(param0) {
-        result := DllCall("IMM32.dll\ImmLockIMCC", "ptr", param0)
+        result := DllCall("IMM32.dll\ImmLockIMCC", "ptr", param0, "ptr")
         return result
     }
 
@@ -4816,7 +4816,7 @@ class Ime {
      * @returns {Pointer<Void>} 
      */
     static ImmReSizeIMCC(param0, param1) {
-        result := DllCall("IMM32.dll\ImmReSizeIMCC", "ptr", param0, "uint", param1)
+        result := DllCall("IMM32.dll\ImmReSizeIMCC", "ptr", param0, "uint", param1, "ptr")
         return result
     }
 

--- a/Windows/Win32/UI/Input/KeyboardAndMouse/Apis.ahk
+++ b/Windows/Win32/UI/Input/KeyboardAndMouse/Apis.ahk
@@ -727,7 +727,7 @@ class KeyboardAndMouse {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadKeyboardLayoutA", "ptr", pwszKLID, "uint", Flags)
+        result := DllCall("USER32.dll\LoadKeyboardLayoutA", "ptr", pwszKLID, "uint", Flags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -768,7 +768,7 @@ class KeyboardAndMouse {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadKeyboardLayoutW", "ptr", pwszKLID, "uint", Flags)
+        result := DllCall("USER32.dll\LoadKeyboardLayoutW", "ptr", pwszKLID, "uint", Flags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -802,7 +802,7 @@ class KeyboardAndMouse {
     static ActivateKeyboardLayout(hkl, Flags) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\ActivateKeyboardLayout", "ptr", hkl, "uint", Flags)
+        result := DllCall("USER32.dll\ActivateKeyboardLayout", "ptr", hkl, "uint", Flags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -1066,7 +1066,7 @@ class KeyboardAndMouse {
      * @since windows5.0
      */
     static GetKeyboardLayout(idThread) {
-        result := DllCall("USER32.dll\GetKeyboardLayout", "uint", idThread)
+        result := DllCall("USER32.dll\GetKeyboardLayout", "uint", idThread, "ptr")
         return result
     }
 
@@ -1369,7 +1369,7 @@ class KeyboardAndMouse {
     static SetFocus(hWnd) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\SetFocus", "ptr", hWnd)
+        result := DllCall("USER32.dll\SetFocus", "ptr", hWnd, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -1389,7 +1389,7 @@ class KeyboardAndMouse {
      * @since windows5.0
      */
     static GetActiveWindow() {
-        result := DllCall("USER32.dll\GetActiveWindow")
+        result := DllCall("USER32.dll\GetActiveWindow", "ptr")
         return result
     }
 
@@ -1409,7 +1409,7 @@ class KeyboardAndMouse {
      * @since windows5.0
      */
     static GetFocus() {
-        result := DllCall("USER32.dll\GetFocus")
+        result := DllCall("USER32.dll\GetFocus", "ptr")
         return result
     }
 
@@ -2944,7 +2944,7 @@ class KeyboardAndMouse {
      * @since windows5.0
      */
     static GetCapture() {
-        result := DllCall("USER32.dll\GetCapture")
+        result := DllCall("USER32.dll\GetCapture", "ptr")
         return result
     }
 
@@ -2968,7 +2968,7 @@ class KeyboardAndMouse {
      * @since windows5.0
      */
     static SetCapture(hWnd) {
-        result := DllCall("USER32.dll\SetCapture", "ptr", hWnd)
+        result := DllCall("USER32.dll\SetCapture", "ptr", hWnd, "ptr")
         return result
     }
 
@@ -3088,7 +3088,7 @@ class KeyboardAndMouse {
     static SetActiveWindow(hWnd) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\SetActiveWindow", "ptr", hWnd)
+        result := DllCall("USER32.dll\SetActiveWindow", "ptr", hWnd, "ptr")
         if(A_LastError)
             throw OSError()
 

--- a/Windows/Win32/UI/Shell/Apis.ahk
+++ b/Windows/Win32/UI/Shell/Apis.ahk
@@ -1,5 +1,7 @@
 #Requires AutoHotkey v2.0.0 64-bit
 
+#Include ..\..\Foundation\Apis.ahk
+#Include ..\..\System\LibraryLoader\Apis.ahk
 /**
  * @namespace Windows.Win32.UI.Shell
  * @version v4.0.30319
@@ -8047,20 +8049,12 @@ class Shell {
      */
     static FileIconInit(fRestoreCache) {
         ; This method's EntryPoint is an ordinal, so we need to load the dll manually
-        hModule := DllCall("GetModuleHandleW", "str", "SHELL32.dll", "ptr")
-        if(!(wasLoaded := hModule != 0))
-            hModule := DllCall("LoadLibraryW","str", "SHELL32.dll", "ptr")
-        if(hModule == 0)
-            throw OSError()
-
-        procAddr := DllCall("GetProcAddress", "ptr", hModule, "uint64", 660, "ptr")
-        if(procAddr == 0)
-            throw OSError()
+        hModule := LibraryLoader.LoadLibraryW("SHELL32.dll")
+        procAddr := LibraryLoader.GetProcAddress(hModule, 660)
 
         result := DllCall(procAddr, "int", fRestoreCache, "int")
 
-        if(!wasLoaded)
-            DllCall("FreeLibraryW", "ptr", hModule)
+        Foundation.FreeLibrary(hModule)
 
         return result
     }

--- a/Windows/Win32/UI/Shell/Apis.ahk
+++ b/Windows/Win32/UI/Shell/Apis.ahk
@@ -10329,7 +10329,7 @@ class Shell {
      * @since windows5.0
      */
     static SHAlloc(cb) {
-        result := DllCall("SHELL32.dll\SHAlloc", "ptr", cb)
+        result := DllCall("SHELL32.dll\SHAlloc", "ptr", cb, "ptr")
         return result
     }
 
@@ -12693,7 +12693,7 @@ class Shell {
      * @since windows5.0
      */
     static SHChangeNotification_Lock(hChange, dwProcId, pppidl, plEvent) {
-        result := DllCall("SHELL32.dll\SHChangeNotification_Lock", "ptr", hChange, "uint", dwProcId, "ptr", pppidl, "int*", plEvent)
+        result := DllCall("SHELL32.dll\SHChangeNotification_Lock", "ptr", hChange, "uint", dwProcId, "ptr", pppidl, "int*", plEvent, "ptr")
         return result
     }
 
@@ -15437,7 +15437,7 @@ class Shell {
     static SHCreatePropSheetExtArray(hKey, pszSubKey, max_iface) {
         pszSubKey := pszSubKey is String? StrPtr(pszSubKey) : pszSubKey
 
-        result := DllCall("SHELL32.dll\SHCreatePropSheetExtArray", "ptr", hKey, "ptr", pszSubKey, "uint", max_iface)
+        result := DllCall("SHELL32.dll\SHCreatePropSheetExtArray", "ptr", hKey, "ptr", pszSubKey, "uint", max_iface, "ptr")
         return result
     }
 
@@ -16250,7 +16250,7 @@ class Shell {
         lpParameters := lpParameters is String? StrPtr(lpParameters) : lpParameters
         lpDirectory := lpDirectory is String? StrPtr(lpDirectory) : lpDirectory
 
-        result := DllCall("SHELL32.dll\ShellExecuteA", "ptr", hwnd, "ptr", lpOperation, "ptr", lpFile, "ptr", lpParameters, "ptr", lpDirectory, "int", nShowCmd)
+        result := DllCall("SHELL32.dll\ShellExecuteA", "ptr", hwnd, "ptr", lpOperation, "ptr", lpFile, "ptr", lpParameters, "ptr", lpDirectory, "int", nShowCmd, "ptr")
         return result
     }
 
@@ -16523,7 +16523,7 @@ class Shell {
         lpParameters := lpParameters is String? StrPtr(lpParameters) : lpParameters
         lpDirectory := lpDirectory is String? StrPtr(lpDirectory) : lpDirectory
 
-        result := DllCall("SHELL32.dll\ShellExecuteW", "ptr", hwnd, "ptr", lpOperation, "ptr", lpFile, "ptr", lpParameters, "ptr", lpDirectory, "int", nShowCmd)
+        result := DllCall("SHELL32.dll\ShellExecuteW", "ptr", hwnd, "ptr", lpOperation, "ptr", lpFile, "ptr", lpParameters, "ptr", lpDirectory, "int", nShowCmd, "ptr")
         return result
     }
 
@@ -16646,7 +16646,7 @@ class Shell {
         lpDirectory := lpDirectory is String? StrPtr(lpDirectory) : lpDirectory
         lpResult := lpResult is String? StrPtr(lpResult) : lpResult
 
-        result := DllCall("SHELL32.dll\FindExecutableA", "ptr", lpFile, "ptr", lpDirectory, "ptr", lpResult)
+        result := DllCall("SHELL32.dll\FindExecutableA", "ptr", lpFile, "ptr", lpDirectory, "ptr", lpResult, "ptr")
         return result
     }
 
@@ -16769,7 +16769,7 @@ class Shell {
         lpDirectory := lpDirectory is String? StrPtr(lpDirectory) : lpDirectory
         lpResult := lpResult is String? StrPtr(lpResult) : lpResult
 
-        result := DllCall("SHELL32.dll\FindExecutableW", "ptr", lpFile, "ptr", lpDirectory, "ptr", lpResult)
+        result := DllCall("SHELL32.dll\FindExecutableW", "ptr", lpFile, "ptr", lpDirectory, "ptr", lpResult, "ptr")
         return result
     }
 
@@ -16877,7 +16877,7 @@ class Shell {
     static DuplicateIcon(hIcon) {
         static hInst := 0 ;Reserved parameters must always be NULL
 
-        result := DllCall("SHELL32.dll\DuplicateIcon", "ptr", hInst, "ptr", hIcon)
+        result := DllCall("SHELL32.dll\DuplicateIcon", "ptr", hInst, "ptr", hIcon, "ptr")
         return result
     }
 
@@ -16923,7 +16923,7 @@ class Shell {
 
         pszIconPath := pszIconPath is String? StrPtr(pszIconPath) : pszIconPath
 
-        result := DllCall("SHELL32.dll\ExtractAssociatedIconA", "ptr", hInst, "ptr", pszIconPath, "ushort*", piIcon)
+        result := DllCall("SHELL32.dll\ExtractAssociatedIconA", "ptr", hInst, "ptr", pszIconPath, "ushort*", piIcon, "ptr")
         return result
     }
 
@@ -16969,7 +16969,7 @@ class Shell {
 
         pszIconPath := pszIconPath is String? StrPtr(pszIconPath) : pszIconPath
 
-        result := DllCall("SHELL32.dll\ExtractAssociatedIconW", "ptr", hInst, "ptr", pszIconPath, "ushort*", piIcon)
+        result := DllCall("SHELL32.dll\ExtractAssociatedIconW", "ptr", hInst, "ptr", pszIconPath, "ushort*", piIcon, "ptr")
         return result
     }
 
@@ -17016,7 +17016,7 @@ class Shell {
 
         pszIconPath := pszIconPath is String? StrPtr(pszIconPath) : pszIconPath
 
-        result := DllCall("SHELL32.dll\ExtractAssociatedIconExA", "ptr", hInst, "ptr", pszIconPath, "ushort*", piIconIndex, "ushort*", piIconId)
+        result := DllCall("SHELL32.dll\ExtractAssociatedIconExA", "ptr", hInst, "ptr", pszIconPath, "ushort*", piIconIndex, "ushort*", piIconId, "ptr")
         return result
     }
 
@@ -17063,7 +17063,7 @@ class Shell {
 
         pszIconPath := pszIconPath is String? StrPtr(pszIconPath) : pszIconPath
 
-        result := DllCall("SHELL32.dll\ExtractAssociatedIconExW", "ptr", hInst, "ptr", pszIconPath, "ushort*", piIconIndex, "ushort*", piIconId)
+        result := DllCall("SHELL32.dll\ExtractAssociatedIconExW", "ptr", hInst, "ptr", pszIconPath, "ushort*", piIconIndex, "ushort*", piIconId, "ptr")
         return result
     }
 
@@ -17101,7 +17101,7 @@ class Shell {
 
         pszExeFileName := pszExeFileName is String? StrPtr(pszExeFileName) : pszExeFileName
 
-        result := DllCall("SHELL32.dll\ExtractIconA", "ptr", hInst, "ptr", pszExeFileName, "uint", nIconIndex)
+        result := DllCall("SHELL32.dll\ExtractIconA", "ptr", hInst, "ptr", pszExeFileName, "uint", nIconIndex, "ptr")
         return result
     }
 
@@ -17139,7 +17139,7 @@ class Shell {
 
         pszExeFileName := pszExeFileName is String? StrPtr(pszExeFileName) : pszExeFileName
 
-        result := DllCall("SHELL32.dll\ExtractIconW", "ptr", hInst, "ptr", pszExeFileName, "uint", nIconIndex)
+        result := DllCall("SHELL32.dll\ExtractIconW", "ptr", hInst, "ptr", pszExeFileName, "uint", nIconIndex, "ptr")
         return result
     }
 
@@ -27049,7 +27049,7 @@ class Shell {
      * @since windows5.0
      */
     static SHRegDuplicateHKey(hkey) {
-        result := DllCall("SHLWAPI.dll\SHRegDuplicateHKey", "ptr", hkey)
+        result := DllCall("SHLWAPI.dll\SHRegDuplicateHKey", "ptr", hkey, "ptr")
         return result
     }
 
@@ -31066,7 +31066,7 @@ class Shell {
      * @since windows5.1.2600
      */
     static SHAllocShared(pvData, dwSize, dwProcessId) {
-        result := DllCall("SHLWAPI.dll\SHAllocShared", "ptr", pvData, "uint", dwSize, "uint", dwProcessId)
+        result := DllCall("SHLWAPI.dll\SHAllocShared", "ptr", pvData, "uint", dwSize, "uint", dwProcessId, "ptr")
         return result
     }
 
@@ -31109,7 +31109,7 @@ class Shell {
      * @since windows5.1.2600
      */
     static SHLockShared(hData, dwProcessId) {
-        result := DllCall("SHLWAPI.dll\SHLockShared", "ptr", hData, "uint", dwProcessId)
+        result := DllCall("SHLWAPI.dll\SHLockShared", "ptr", hData, "uint", dwProcessId, "ptr")
         return result
     }
 
@@ -31597,7 +31597,7 @@ class Shell {
      * @since windows5.0
      */
     static SHCreateShellPalette(hdc) {
-        result := DllCall("SHLWAPI.dll\SHCreateShellPalette", "ptr", hdc)
+        result := DllCall("SHLWAPI.dll\SHCreateShellPalette", "ptr", hdc, "ptr")
         return result
     }
 

--- a/Windows/Win32/UI/Shell/PropertiesSystem/Apis.ahk
+++ b/Windows/Win32/UI/Shell/PropertiesSystem/Apis.ahk
@@ -3727,7 +3727,7 @@ class PropertiesSystem {
         pszApp := pszApp is String? StrPtr(pszApp) : pszApp
         pszPIF := pszPIF is String? StrPtr(pszPIF) : pszPIF
 
-        result := DllCall("SHELL32.dll\PifMgr_OpenProperties", "ptr", pszApp, "ptr", pszPIF, "uint", hInf, "uint", flOpt)
+        result := DllCall("SHELL32.dll\PifMgr_OpenProperties", "ptr", pszApp, "ptr", pszPIF, "uint", hInf, "uint", flOpt, "ptr")
         return result
     }
 
@@ -3814,7 +3814,7 @@ class PropertiesSystem {
      * @since windows5.0
      */
     static PifMgr_CloseProperties(hProps, flOpt) {
-        result := DllCall("SHELL32.dll\PifMgr_CloseProperties", "ptr", hProps, "uint", flOpt)
+        result := DllCall("SHELL32.dll\PifMgr_CloseProperties", "ptr", hProps, "uint", flOpt, "ptr")
         return result
     }
 

--- a/Windows/Win32/UI/WindowsAndMessaging/Apis.ahk
+++ b/Windows/Win32/UI/WindowsAndMessaging/Apis.ahk
@@ -9019,7 +9019,7 @@ class WindowsAndMessaging {
     static RegisterDeviceNotificationA(hRecipient, NotificationFilter, Flags) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\RegisterDeviceNotificationA", "ptr", hRecipient, "ptr", NotificationFilter, "uint", Flags)
+        result := DllCall("USER32.dll\RegisterDeviceNotificationA", "ptr", hRecipient, "ptr", NotificationFilter, "uint", Flags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -9086,7 +9086,7 @@ class WindowsAndMessaging {
     static RegisterDeviceNotificationW(hRecipient, NotificationFilter, Flags) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\RegisterDeviceNotificationW", "ptr", hRecipient, "ptr", NotificationFilter, "uint", Flags)
+        result := DllCall("USER32.dll\RegisterDeviceNotificationW", "ptr", hRecipient, "ptr", NotificationFilter, "uint", Flags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -10329,7 +10329,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateWindowExA", "uint", dwExStyle, "ptr", lpClassName, "ptr", lpWindowName, "uint", dwStyle, "int", X, "int", Y, "int", nWidth, "int", nHeight, "ptr", hWndParent, "ptr", hMenu, "ptr", hInstance, "ptr", lpParam)
+        result := DllCall("USER32.dll\CreateWindowExA", "uint", dwExStyle, "ptr", lpClassName, "ptr", lpWindowName, "uint", dwStyle, "int", X, "int", Y, "int", nWidth, "int", nHeight, "ptr", hWndParent, "ptr", hMenu, "ptr", hInstance, "ptr", lpParam, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -10503,7 +10503,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateWindowExW", "uint", dwExStyle, "ptr", lpClassName, "ptr", lpWindowName, "uint", dwStyle, "int", X, "int", Y, "int", nWidth, "int", nHeight, "ptr", hWndParent, "ptr", hMenu, "ptr", hInstance, "ptr", lpParam)
+        result := DllCall("USER32.dll\CreateWindowExW", "uint", dwExStyle, "ptr", lpClassName, "ptr", lpWindowName, "uint", dwStyle, "int", X, "int", Y, "int", nWidth, "int", nHeight, "ptr", hWndParent, "ptr", hMenu, "ptr", hInstance, "ptr", lpParam, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11211,7 +11211,7 @@ class WindowsAndMessaging {
     static BeginDeferWindowPos(nNumWindows) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\BeginDeferWindowPos", "int", nNumWindows)
+        result := DllCall("USER32.dll\BeginDeferWindowPos", "int", nNumWindows, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11274,7 +11274,7 @@ class WindowsAndMessaging {
     static DeferWindowPos(hWinPosInfo, hWnd, hWndInsertAfter, x, y, cx, cy, uFlags) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\DeferWindowPos", "ptr", hWinPosInfo, "ptr", hWnd, "ptr", hWndInsertAfter, "int", x, "int", y, "int", cx, "int", cy, "uint", uFlags)
+        result := DllCall("USER32.dll\DeferWindowPos", "ptr", hWinPosInfo, "ptr", hWnd, "ptr", hWndInsertAfter, "int", x, "int", y, "int", cx, "int", cy, "uint", uFlags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11450,7 +11450,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateDialogParamA", "ptr", hInstance, "ptr", lpTemplateName, "ptr", hWndParent, "ptr", lpDialogFunc, "ptr", dwInitParam)
+        result := DllCall("USER32.dll\CreateDialogParamA", "ptr", hInstance, "ptr", lpTemplateName, "ptr", hWndParent, "ptr", lpDialogFunc, "ptr", dwInitParam, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11498,7 +11498,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateDialogParamW", "ptr", hInstance, "ptr", lpTemplateName, "ptr", hWndParent, "ptr", lpDialogFunc, "ptr", dwInitParam)
+        result := DllCall("USER32.dll\CreateDialogParamW", "ptr", hInstance, "ptr", lpTemplateName, "ptr", hWndParent, "ptr", lpDialogFunc, "ptr", dwInitParam, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11557,7 +11557,7 @@ class WindowsAndMessaging {
     static CreateDialogIndirectParamA(hInstance, lpTemplate, hWndParent, lpDialogFunc, dwInitParam) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateDialogIndirectParamA", "ptr", hInstance, "ptr", lpTemplate, "ptr", hWndParent, "ptr", lpDialogFunc, "ptr", dwInitParam)
+        result := DllCall("USER32.dll\CreateDialogIndirectParamA", "ptr", hInstance, "ptr", lpTemplate, "ptr", hWndParent, "ptr", lpDialogFunc, "ptr", dwInitParam, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11616,7 +11616,7 @@ class WindowsAndMessaging {
     static CreateDialogIndirectParamW(hInstance, lpTemplate, hWndParent, lpDialogFunc, dwInitParam) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateDialogIndirectParamW", "ptr", hInstance, "ptr", lpTemplate, "ptr", hWndParent, "ptr", lpDialogFunc, "ptr", dwInitParam)
+        result := DllCall("USER32.dll\CreateDialogIndirectParamW", "ptr", hInstance, "ptr", lpTemplate, "ptr", hWndParent, "ptr", lpDialogFunc, "ptr", dwInitParam, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -11886,7 +11886,7 @@ class WindowsAndMessaging {
     static GetDlgItem(hDlg, nIDDlgItem) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\GetDlgItem", "ptr", hDlg, "int", nIDDlgItem)
+        result := DllCall("USER32.dll\GetDlgItem", "ptr", hDlg, "int", nIDDlgItem, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12211,7 +12211,7 @@ class WindowsAndMessaging {
     static GetNextDlgGroupItem(hDlg, hCtl, bPrevious) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\GetNextDlgGroupItem", "ptr", hDlg, "ptr", hCtl, "int", bPrevious)
+        result := DllCall("USER32.dll\GetNextDlgGroupItem", "ptr", hDlg, "ptr", hCtl, "int", bPrevious, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -12251,7 +12251,7 @@ class WindowsAndMessaging {
     static GetNextDlgTabItem(hDlg, hCtl, bPrevious) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\GetNextDlgTabItem", "ptr", hDlg, "ptr", hCtl, "int", bPrevious)
+        result := DllCall("USER32.dll\GetNextDlgTabItem", "ptr", hDlg, "ptr", hCtl, "int", bPrevious, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14051,7 +14051,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadAcceleratorsA", "ptr", hInstance, "ptr", lpTableName)
+        result := DllCall("USER32.dll\LoadAcceleratorsA", "ptr", hInstance, "ptr", lpTableName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14083,7 +14083,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadAcceleratorsW", "ptr", hInstance, "ptr", lpTableName)
+        result := DllCall("USER32.dll\LoadAcceleratorsW", "ptr", hInstance, "ptr", lpTableName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14109,7 +14109,7 @@ class WindowsAndMessaging {
     static CreateAcceleratorTableA(paccel, cAccel) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateAcceleratorTableA", "ptr", paccel, "int", cAccel)
+        result := DllCall("USER32.dll\CreateAcceleratorTableA", "ptr", paccel, "int", cAccel, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14135,7 +14135,7 @@ class WindowsAndMessaging {
     static CreateAcceleratorTableW(paccel, cAccel) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateAcceleratorTableW", "ptr", paccel, "int", cAccel)
+        result := DllCall("USER32.dll\CreateAcceleratorTableW", "ptr", paccel, "int", cAccel, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14509,7 +14509,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadMenuA", "ptr", hInstance, "ptr", lpMenuName)
+        result := DllCall("USER32.dll\LoadMenuA", "ptr", hInstance, "ptr", lpMenuName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14539,7 +14539,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadMenuW", "ptr", hInstance, "ptr", lpMenuName)
+        result := DllCall("USER32.dll\LoadMenuW", "ptr", hInstance, "ptr", lpMenuName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14571,7 +14571,7 @@ class WindowsAndMessaging {
     static LoadMenuIndirectA(lpMenuTemplate) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadMenuIndirectA", "ptr", lpMenuTemplate)
+        result := DllCall("USER32.dll\LoadMenuIndirectA", "ptr", lpMenuTemplate, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14603,7 +14603,7 @@ class WindowsAndMessaging {
     static LoadMenuIndirectW(lpMenuTemplate) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadMenuIndirectW", "ptr", lpMenuTemplate)
+        result := DllCall("USER32.dll\LoadMenuIndirectW", "ptr", lpMenuTemplate, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -14624,7 +14624,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static GetMenu(hWnd) {
-        result := DllCall("USER32.dll\GetMenu", "ptr", hWnd)
+        result := DllCall("USER32.dll\GetMenu", "ptr", hWnd, "ptr")
         return result
     }
 
@@ -15062,7 +15062,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static GetSystemMenu(hWnd, bRevert) {
-        result := DllCall("USER32.dll\GetSystemMenu", "ptr", hWnd, "int", bRevert)
+        result := DllCall("USER32.dll\GetSystemMenu", "ptr", hWnd, "int", bRevert, "ptr")
         return result
     }
 
@@ -15081,7 +15081,7 @@ class WindowsAndMessaging {
     static CreateMenu() {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateMenu")
+        result := DllCall("USER32.dll\CreateMenu", "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -15105,7 +15105,7 @@ class WindowsAndMessaging {
     static CreatePopupMenu() {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreatePopupMenu")
+        result := DllCall("USER32.dll\CreatePopupMenu", "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -15259,7 +15259,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static GetSubMenu(hMenu, nPos) {
-        result := DllCall("USER32.dll\GetSubMenu", "ptr", hMenu, "int", nPos)
+        result := DllCall("USER32.dll\GetSubMenu", "ptr", hMenu, "int", nPos, "ptr")
         return result
     }
 
@@ -17372,7 +17372,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static GetForegroundWindow() {
-        result := DllCall("USER32.dll\GetForegroundWindow")
+        result := DllCall("USER32.dll\GetForegroundWindow", "ptr")
         return result
     }
 
@@ -17834,7 +17834,7 @@ class WindowsAndMessaging {
     static GetPropA(hWnd, lpString) {
         lpString := lpString is String? StrPtr(lpString) : lpString
 
-        result := DllCall("USER32.dll\GetPropA", "ptr", hWnd, "ptr", lpString)
+        result := DllCall("USER32.dll\GetPropA", "ptr", hWnd, "ptr", lpString, "ptr")
         return result
     }
 
@@ -17858,7 +17858,7 @@ class WindowsAndMessaging {
     static GetPropW(hWnd, lpString) {
         lpString := lpString is String? StrPtr(lpString) : lpString
 
-        result := DllCall("USER32.dll\GetPropW", "ptr", hWnd, "ptr", lpString)
+        result := DllCall("USER32.dll\GetPropW", "ptr", hWnd, "ptr", lpString, "ptr")
         return result
     }
 
@@ -17887,7 +17887,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\RemovePropA", "ptr", hWnd, "ptr", lpString)
+        result := DllCall("USER32.dll\RemovePropA", "ptr", hWnd, "ptr", lpString, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -17919,7 +17919,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\RemovePropW", "ptr", hWnd, "ptr", lpString)
+        result := DllCall("USER32.dll\RemovePropW", "ptr", hWnd, "ptr", lpString, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -19493,7 +19493,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static SetCursor(hCursor) {
-        result := DllCall("USER32.dll\SetCursor", "ptr", hCursor)
+        result := DllCall("USER32.dll\SetCursor", "ptr", hCursor, "ptr")
         return result
     }
 
@@ -19586,7 +19586,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static GetCursor() {
-        result := DllCall("USER32.dll\GetCursor")
+        result := DllCall("USER32.dll\GetCursor", "ptr")
         return result
     }
 
@@ -19903,7 +19903,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static WindowFromPoint(Point) {
-        result := DllCall("USER32.dll\WindowFromPoint", "ptr", Point)
+        result := DllCall("USER32.dll\WindowFromPoint", "ptr", Point, "ptr")
         return result
     }
 
@@ -19921,7 +19921,7 @@ class WindowsAndMessaging {
      * @since windows6.0.6000
      */
     static WindowFromPhysicalPoint(Point) {
-        result := DllCall("USER32.dll\WindowFromPhysicalPoint", "ptr", Point)
+        result := DllCall("USER32.dll\WindowFromPhysicalPoint", "ptr", Point, "ptr")
         return result
     }
 
@@ -19960,7 +19960,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static ChildWindowFromPoint(hWndParent, Point) {
-        result := DllCall("USER32.dll\ChildWindowFromPoint", "ptr", hWndParent, "ptr", Point)
+        result := DllCall("USER32.dll\ChildWindowFromPoint", "ptr", hWndParent, "ptr", Point, "ptr")
         return result
     }
 
@@ -20075,7 +20075,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static ChildWindowFromPointEx(hwnd, pt, flags) {
-        result := DllCall("USER32.dll\ChildWindowFromPointEx", "ptr", hwnd, "ptr", pt, "uint", flags)
+        result := DllCall("USER32.dll\ChildWindowFromPointEx", "ptr", hwnd, "ptr", pt, "uint", flags, "ptr")
         return result
     }
 
@@ -20591,7 +20591,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static GetDesktopWindow() {
-        result := DllCall("USER32.dll\GetDesktopWindow")
+        result := DllCall("USER32.dll\GetDesktopWindow", "ptr")
         return result
     }
 
@@ -20621,7 +20621,7 @@ class WindowsAndMessaging {
     static GetParent(hWnd) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\GetParent", "ptr", hWnd)
+        result := DllCall("USER32.dll\GetParent", "ptr", hWnd, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -20687,7 +20687,7 @@ class WindowsAndMessaging {
     static SetParent(hWndChild, hWndNewParent) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\SetParent", "ptr", hWndChild, "ptr", hWndNewParent)
+        result := DllCall("USER32.dll\SetParent", "ptr", hWndChild, "ptr", hWndNewParent, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -20748,7 +20748,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\FindWindowA", "ptr", lpClassName, "ptr", lpWindowName)
+        result := DllCall("USER32.dll\FindWindowA", "ptr", lpClassName, "ptr", lpWindowName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -20783,7 +20783,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\FindWindowW", "ptr", lpClassName, "ptr", lpWindowName)
+        result := DllCall("USER32.dll\FindWindowW", "ptr", lpClassName, "ptr", lpWindowName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -20845,7 +20845,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\FindWindowExA", "ptr", hWndParent, "ptr", hWndChildAfter, "ptr", lpszClass, "ptr", lpszWindow)
+        result := DllCall("USER32.dll\FindWindowExA", "ptr", hWndParent, "ptr", hWndChildAfter, "ptr", lpszClass, "ptr", lpszWindow, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -20907,7 +20907,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\FindWindowExW", "ptr", hWndParent, "ptr", hWndChildAfter, "ptr", lpszClass, "ptr", lpszWindow)
+        result := DllCall("USER32.dll\FindWindowExW", "ptr", hWndParent, "ptr", hWndChildAfter, "ptr", lpszClass, "ptr", lpszWindow, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -20923,7 +20923,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static GetShellWindow() {
-        result := DllCall("USER32.dll\GetShellWindow")
+        result := DllCall("USER32.dll\GetShellWindow", "ptr")
         return result
     }
 
@@ -21181,7 +21181,7 @@ class WindowsAndMessaging {
     static GetTopWindow(hWnd) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\GetTopWindow", "ptr", hWnd)
+        result := DllCall("USER32.dll\GetTopWindow", "ptr", hWnd, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -21249,7 +21249,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static GetLastActivePopup(hWnd) {
-        result := DllCall("USER32.dll\GetLastActivePopup", "ptr", hWnd)
+        result := DllCall("USER32.dll\GetLastActivePopup", "ptr", hWnd, "ptr")
         return result
     }
 
@@ -21270,7 +21270,7 @@ class WindowsAndMessaging {
     static GetWindow(hWnd, uCmd) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\GetWindow", "ptr", hWnd, "uint", uCmd)
+        result := DllCall("USER32.dll\GetWindow", "ptr", hWnd, "uint", uCmd, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -21284,7 +21284,7 @@ class WindowsAndMessaging {
      * @returns {Pointer<Void>} 
      */
     static SetWindowsHookA(nFilterType, pfnFilterProc) {
-        result := DllCall("USER32.dll\SetWindowsHookA", "int", nFilterType, "ptr", pfnFilterProc)
+        result := DllCall("USER32.dll\SetWindowsHookA", "int", nFilterType, "ptr", pfnFilterProc, "ptr")
         return result
     }
 
@@ -21295,7 +21295,7 @@ class WindowsAndMessaging {
      * @returns {Pointer<Void>} 
      */
     static SetWindowsHookW(nFilterType, pfnFilterProc) {
-        result := DllCall("USER32.dll\SetWindowsHookW", "int", nFilterType, "ptr", pfnFilterProc)
+        result := DllCall("USER32.dll\SetWindowsHookW", "int", nFilterType, "ptr", pfnFilterProc, "ptr")
         return result
     }
 
@@ -21449,7 +21449,7 @@ class WindowsAndMessaging {
     static SetWindowsHookExA(idHook, lpfn, hmod, dwThreadId) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\SetWindowsHookExA", "int", idHook, "ptr", lpfn, "ptr", hmod, "uint", dwThreadId)
+        result := DllCall("USER32.dll\SetWindowsHookExA", "int", idHook, "ptr", lpfn, "ptr", hmod, "uint", dwThreadId, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -21595,7 +21595,7 @@ class WindowsAndMessaging {
     static SetWindowsHookExW(idHook, lpfn, hmod, dwThreadId) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\SetWindowsHookExW", "int", idHook, "ptr", lpfn, "ptr", hmod, "uint", dwThreadId)
+        result := DllCall("USER32.dll\SetWindowsHookExW", "int", idHook, "ptr", lpfn, "ptr", hmod, "uint", dwThreadId, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -21906,7 +21906,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadCursorA", "ptr", hInstance, "ptr", lpCursorName)
+        result := DllCall("USER32.dll\LoadCursorA", "ptr", hInstance, "ptr", lpCursorName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -22124,7 +22124,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadCursorW", "ptr", hInstance, "ptr", lpCursorName)
+        result := DllCall("USER32.dll\LoadCursorW", "ptr", hInstance, "ptr", lpCursorName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -22180,7 +22180,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadCursorFromFileA", "ptr", lpFileName)
+        result := DllCall("USER32.dll\LoadCursorFromFileA", "ptr", lpFileName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -22236,7 +22236,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadCursorFromFileW", "ptr", lpFileName)
+        result := DllCall("USER32.dll\LoadCursorFromFileW", "ptr", lpFileName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -22284,7 +22284,7 @@ class WindowsAndMessaging {
     static CreateCursor(hInst, xHotSpot, yHotSpot, nWidth, nHeight, pvANDPlane, pvXORPlane) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateCursor", "ptr", hInst, "int", xHotSpot, "int", yHotSpot, "int", nWidth, "int", nHeight, "ptr", pvANDPlane, "ptr", pvXORPlane)
+        result := DllCall("USER32.dll\CreateCursor", "ptr", hInst, "int", xHotSpot, "int", yHotSpot, "int", nWidth, "int", nHeight, "ptr", pvANDPlane, "ptr", pvXORPlane, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -22389,7 +22389,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadIconA", "ptr", hInstance, "ptr", lpIconName)
+        result := DllCall("USER32.dll\LoadIconA", "ptr", hInstance, "ptr", lpIconName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -22428,7 +22428,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadIconW", "ptr", hInstance, "ptr", lpIconName)
+        result := DllCall("USER32.dll\LoadIconW", "ptr", hInstance, "ptr", lpIconName, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -22657,7 +22657,7 @@ class WindowsAndMessaging {
     static CreateIcon(hInstance, nWidth, nHeight, cPlanes, cBitsPixel, lpbANDbits, lpbXORbits) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateIcon", "ptr", hInstance, "int", nWidth, "int", nHeight, "char", cPlanes, "char", cBitsPixel, "char*", lpbANDbits, "char*", lpbXORbits)
+        result := DllCall("USER32.dll\CreateIcon", "ptr", hInstance, "int", nWidth, "int", nHeight, "char", cPlanes, "char", cBitsPixel, "char*", lpbANDbits, "char*", lpbXORbits, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -22807,7 +22807,7 @@ class WindowsAndMessaging {
     static CreateIconFromResource(presbits, dwResSize, fIcon, dwVer) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateIconFromResource", "ptr", presbits, "uint", dwResSize, "int", fIcon, "uint", dwVer)
+        result := DllCall("USER32.dll\CreateIconFromResource", "ptr", presbits, "uint", dwResSize, "int", fIcon, "uint", dwVer, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -22850,7 +22850,7 @@ class WindowsAndMessaging {
     static CreateIconFromResourceEx(presbits, dwResSize, fIcon, dwVer, cxDesired, cyDesired, Flags) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateIconFromResourceEx", "ptr", presbits, "uint", dwResSize, "int", fIcon, "uint", dwVer, "int", cxDesired, "int", cyDesired, "uint", Flags)
+        result := DllCall("USER32.dll\CreateIconFromResourceEx", "ptr", presbits, "uint", dwResSize, "int", fIcon, "uint", dwVer, "int", cxDesired, "int", cyDesired, "uint", Flags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -22956,7 +22956,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadImageA", "ptr", hInst, "ptr", name, "uint", type, "int", cx, "int", cy, "uint", fuLoad)
+        result := DllCall("USER32.dll\LoadImageA", "ptr", hInst, "ptr", name, "uint", type, "int", cx, "int", cy, "uint", fuLoad, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -23064,7 +23064,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\LoadImageW", "ptr", hInst, "ptr", name, "uint", type, "int", cx, "int", cy, "uint", fuLoad)
+        result := DllCall("USER32.dll\LoadImageW", "ptr", hInst, "ptr", name, "uint", type, "int", cx, "int", cy, "uint", fuLoad, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -23125,7 +23125,7 @@ class WindowsAndMessaging {
     static CopyImage(h, type, cx, cy, flags) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CopyImage", "ptr", h, "uint", type, "int", cx, "int", cy, "uint", flags)
+        result := DllCall("USER32.dll\CopyImage", "ptr", h, "uint", type, "int", cx, "int", cy, "uint", flags, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -23211,7 +23211,7 @@ class WindowsAndMessaging {
     static CreateIconIndirect(piconinfo) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateIconIndirect", "ptr", piconinfo)
+        result := DllCall("USER32.dll\CreateIconIndirect", "ptr", piconinfo, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -23238,7 +23238,7 @@ class WindowsAndMessaging {
     static CopyIcon(hIcon) {
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CopyIcon", "ptr", hIcon)
+        result := DllCall("USER32.dll\CopyIcon", "ptr", hIcon, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -23920,7 +23920,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateMDIWindowA", "ptr", lpClassName, "ptr", lpWindowName, "uint", dwStyle, "int", X, "int", Y, "int", nWidth, "int", nHeight, "ptr", hWndParent, "ptr", hInstance, "ptr", lParam)
+        result := DllCall("USER32.dll\CreateMDIWindowA", "ptr", lpClassName, "ptr", lpWindowName, "uint", dwStyle, "int", X, "int", Y, "int", nWidth, "int", nHeight, "ptr", hWndParent, "ptr", hInstance, "ptr", lParam, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -23974,7 +23974,7 @@ class WindowsAndMessaging {
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\CreateMDIWindowW", "ptr", lpClassName, "ptr", lpWindowName, "uint", dwStyle, "int", X, "int", Y, "int", nWidth, "int", nHeight, "ptr", hWndParent, "ptr", hInstance, "ptr", lParam)
+        result := DllCall("USER32.dll\CreateMDIWindowW", "ptr", lpClassName, "ptr", lpWindowName, "uint", dwStyle, "int", X, "int", Y, "int", nWidth, "int", nHeight, "ptr", hWndParent, "ptr", hInstance, "ptr", lParam, "ptr")
         if(A_LastError)
             throw OSError()
 
@@ -30203,7 +30203,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static GetAncestor(hwnd, gaFlags) {
-        result := DllCall("USER32.dll\GetAncestor", "ptr", hwnd, "uint", gaFlags)
+        result := DllCall("USER32.dll\GetAncestor", "ptr", hwnd, "uint", gaFlags, "ptr")
         return result
     }
 
@@ -30224,7 +30224,7 @@ class WindowsAndMessaging {
      * @since windows5.0
      */
     static RealChildWindowFromPoint(hwndParent, ptParentClientCoords) {
-        result := DllCall("USER32.dll\RealChildWindowFromPoint", "ptr", hwndParent, "ptr", ptParentClientCoords)
+        result := DllCall("USER32.dll\RealChildWindowFromPoint", "ptr", hwndParent, "ptr", ptParentClientCoords, "ptr")
         return result
     }
 

--- a/Windows/Win32/Web/InternetExplorer/Apis.ahk
+++ b/Windows/Win32/Web/InternetExplorer/Apis.ahk
@@ -2625,7 +2625,7 @@ class InternetExplorer {
     static IECreateFile(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile) {
         lpFileName := lpFileName is String? StrPtr(lpFileName) : lpFileName
 
-        result := DllCall("Ieframe.dll\IECreateFile", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwCreationDisposition, "uint", dwFlagsAndAttributes, "ptr", hTemplateFile)
+        result := DllCall("Ieframe.dll\IECreateFile", "ptr", lpFileName, "uint", dwDesiredAccess, "uint", dwShareMode, "ptr", lpSecurityAttributes, "uint", dwCreationDisposition, "uint", dwFlagsAndAttributes, "ptr", hTemplateFile, "ptr")
         return result
     }
 
@@ -2704,7 +2704,7 @@ class InternetExplorer {
     static IEFindFirstFile(lpFileName, lpFindFileData) {
         lpFileName := lpFileName is String? StrPtr(lpFileName) : lpFileName
 
-        result := DllCall("Ieframe.dll\IEFindFirstFile", "ptr", lpFileName, "ptr", lpFindFileData)
+        result := DllCall("Ieframe.dll\IEFindFirstFile", "ptr", lpFileName, "ptr", lpFindFileData, "ptr")
         return result
     }
 


### PR DESCRIPTION
Use the bindings to load DLLs when calling DLL methods by ordinal.

Related: #30 