### PR TITLE
Simplify AutoHotkey installation in CI workflow

### DIFF
--- a/.github/workflows/Run-Unit-Tests.yml
+++ b/.github/workflows/Run-Unit-Tests.yml
@@ -19,16 +19,10 @@ jobs:
           submodules: recursive
 
       - name: Install AutoHotkey V2
-        shell: pwsh
-        env:
-            url: https://github.com/AutoHotkey/AutoHotkey/releases/download/v2.0.19/AutoHotkey_2.0.19.zip
-        run: |
-          $cwd = (Get-Item .).FullName
-          Invoke-WebRequest "$env:url" -OutFile "$cwd\autohotkey.zip"
-          Expand-Archive -Path "$cwd\autohotkey.zip" -DestinationPath "$cwd\autohotkey" -Force
-          Remove-Item -Path "$cwd\autohotkey.zip" -Force -ErrorAction SilentlyContinue
-
-          Write-Output ("$cwd\autohotkey;" + "$cwd\autohotkey\Compiler") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        uses: holy-tao/install-autohotkey@v1
+        with:
+          version: v2.0.19
+          destination: "$cwd\autohotkey"
           
       - name: Enable AHK validator problem matcher
         run: echo "::add-matcher::.github/problem-matchers/ahk.json"
@@ -77,16 +71,10 @@ jobs:
           submodules: recursive
 
       - name: Install AutoHotkey V2
-        shell: pwsh
-        env:
-            url: https://github.com/AutoHotkey/AutoHotkey/releases/download/v2.0.19/AutoHotkey_2.0.19.zip
-        run: |
-          $cwd = (Get-Item .).FullName
-          Invoke-WebRequest "$env:url" -OutFile "$cwd\autohotkey.zip"
-          Expand-Archive -Path "$cwd\autohotkey.zip" -DestinationPath "$cwd\autohotkey" -Force
-          Remove-Item -Path "$cwd\autohotkey.zip" -Force -ErrorAction SilentlyContinue
-
-          Write-Output ("$cwd\autohotkey;" + "$cwd\autohotkey\Compiler") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        uses: holy-tao/install-autohotkey@v1
+        with:
+          version: v2.0.19
+          destination: "$cwd\autohotkey"
       
       - name: Run Unit Tests
         working-directory: Tests


### PR DESCRIPTION
Use a [GitHub Action](https://github.com/holy-tao/install-autohotkey) to install AHK instead of duplicating the same code all over the place.