### PR TITLE
Fix: Use cwd for ahk installation

### DIFF
--- a/.github/workflows/Run-Unit-Tests.yml
+++ b/.github/workflows/Run-Unit-Tests.yml
@@ -22,7 +22,6 @@ jobs:
         uses: holy-tao/install-autohotkey@v1
         with:
           version: v2.0.19
-          destination: "$cwd\autohotkey"
           
       - name: Enable AHK validator problem matcher
         run: echo "::add-matcher::.github/problem-matchers/ahk.json"
@@ -74,7 +73,6 @@ jobs:
         uses: holy-tao/install-autohotkey@v1
         with:
           version: v2.0.19
-          destination: "$cwd\autohotkey"
       
       - name: Run Unit Tests
         working-directory: Tests


### PR DESCRIPTION
The action didn't properly pass output destinations so the incorrect directory in the  `.yml` file didn't have any effect. I fixed the action, so now the workflow also needs to be updated