### PR TITLE
Add conditional to update-parent job for 'ahk' label

### DIFF
--- a/.github/workflows/Update-Parent.yml
+++ b/.github/workflows/Update-Parent.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   update-parent:
+    if: contains(github.event.pull_request.labels.*.name, 'ahk')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout parent repository


### PR DESCRIPTION
It's excessive to bump the parent repo pointer for non-ahk changes. So don't.