### PR TITLE
Add `ObsoleteAttribute` messages

### DIFF
--- a/Windows/Win32/Graphics/Direct2D/ID2D1Factory.ahk
+++ b/Windows/Win32/Graphics/Direct2D/ID2D1Factory.ahk
@@ -86,7 +86,7 @@ class ID2D1Factory extends IUnknown{
      * @param {Pointer<Float>} dpiY 
      * @returns {String} Nothing - always returns an empty string
      * @see https://learn.microsoft.com/windows/win32/api/d2d1/nf-d2d1-id2d1factory-getdesktopdpi
-     * @deprecated
+     * @deprecated Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps.
      */
     GetDesktopDpi(dpiX, dpiY) {
         dpiXMarshal := dpiX is VarRef ? "float*" : "ptr"

--- a/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/Apis.ahk
@@ -176,7 +176,7 @@ class NetworkDiagnosticsFramework {
      * 
      * A handle to the Network Diagnostics Framework incident.
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfcreateincident
-     * @deprecated
+     * @deprecated NdfCreateIncident is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.0.6000
      */
     static NdfCreateIncident(helperClassName, celt, attributes) {
@@ -210,7 +210,7 @@ class NetworkDiagnosticsFramework {
      * 
      * Handle to the Network Diagnostics Framework incident.
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfcreatewinsockincident
-     * @deprecated
+     * @deprecated NdfCreateWinSockIncident is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.0.6000
      */
     static NdfCreateWinSockIncident(sock, host, port, appId, userId) {
@@ -234,7 +234,7 @@ class NetworkDiagnosticsFramework {
      * 
      * Handle to the Network Diagnostics Framework incident.
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfcreatewebincident
-     * @deprecated
+     * @deprecated NdfCreateWebIncident is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.0.6000
      */
     static NdfCreateWebIncident(url) {
@@ -262,7 +262,7 @@ class NetworkDiagnosticsFramework {
      * 
      * Handle to the Network Diagnostics Framework incident.
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfcreatewebincidentex
-     * @deprecated
+     * @deprecated NdfCreateWebIncidentEx is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.0.6000
      */
     static NdfCreateWebIncidentEx(url, useWinHTTP, moduleName) {
@@ -285,7 +285,7 @@ class NetworkDiagnosticsFramework {
      * 
      * Handle to the Network Diagnostics Framework incident.
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfcreatesharingincident
-     * @deprecated
+     * @deprecated NdfCreateSharingIncident is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.0.6000
      */
     static NdfCreateSharingIncident(UNCPath) {
@@ -312,7 +312,7 @@ class NetworkDiagnosticsFramework {
      * 
      * Handle to the Network Diagnostics Framework incident.
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfcreatednsincident
-     * @deprecated
+     * @deprecated NdfCreateDNSIncident is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.0.6000
      */
     static NdfCreateDNSIncident(hostname, queryType) {
@@ -331,7 +331,7 @@ class NetworkDiagnosticsFramework {
      * 
      * Handle to the Network Diagnostics Framework incident.
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfcreateconnectivityincident
-     * @deprecated
+     * @deprecated NdfCreateConnectivityIncident is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.0.6000
      */
     static NdfCreateConnectivityIncident() {
@@ -353,7 +353,7 @@ class NetworkDiagnosticsFramework {
      * 
      * Handle to the Network Diagnostics Framework incident.
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfcreatenetconnectionincident
-     * @deprecated
+     * @deprecated NdfCreateNetConnectionIncident is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows8.0
      */
     static NdfCreateNetConnectionIncident(id) {
@@ -382,7 +382,7 @@ class NetworkDiagnosticsFramework {
      * 
      * Handle to the Network Diagnostics Framework incident.
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfcreatepnrpincident
-     * @deprecated
+     * @deprecated NdfCreatePnrpIncident is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.1
      */
     static NdfCreatePnrpIncident(cloudname, peername, diagnosePublish, appId) {
@@ -421,7 +421,7 @@ class NetworkDiagnosticsFramework {
      * 
      * Handle to the Network Diagnostics Framework incident.
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfcreategroupingincident
-     * @deprecated
+     * @deprecated NdfCreateGroupingIncident is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.1
      */
     static NdfCreateGroupingIncident(CloudName, GroupName, Identity, Invitation, Addresses, appId) {
@@ -479,7 +479,7 @@ class NetworkDiagnosticsFramework {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfexecutediagnosis
-     * @deprecated
+     * @deprecated NdfExecuteDiagnosis is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.0.6000
      */
     static NdfExecuteDiagnosis(handle, hwnd) {
@@ -521,7 +521,7 @@ class NetworkDiagnosticsFramework {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfcloseincident
-     * @deprecated
+     * @deprecated NdfCloseIncident is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.0.6000
      */
     static NdfCloseIncident(handle) {
@@ -628,7 +628,7 @@ class NetworkDiagnosticsFramework {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfdiagnoseincident
-     * @deprecated
+     * @deprecated NdfDiagnoseIncident is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.1
      */
     static NdfDiagnoseIncident(Handle, RootCauseCount, RootCauses, dwWait, dwFlags) {
@@ -712,7 +712,7 @@ class NetworkDiagnosticsFramework {
      * 
      * Other failure codes are returned if the repair failed to execute. In that case, the client can call <b>NdfRepairIncident</b> again with a different repair.
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfrepairincident
-     * @deprecated
+     * @deprecated NdfRepairIncident is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.1
      */
     static NdfRepairIncident(Handle, RepairEx, dwWait) {
@@ -755,7 +755,7 @@ class NetworkDiagnosticsFramework {
      * 
      *  Any result other than S_OK should be interpreted as an error.
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfcancelincident
-     * @deprecated
+     * @deprecated NdfCancelIncident is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.1
      */
     static NdfCancelIncident(Handle) {
@@ -777,7 +777,7 @@ class NetworkDiagnosticsFramework {
      * 
      * The location of the trace file.
      * @see https://docs.microsoft.com/windows/win32/api//ndfapi/nf-ndfapi-ndfgettracefile
-     * @deprecated
+     * @deprecated NdfGetTraceFile is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows6.1
      */
     static NdfGetTraceFile(Handle) {

--- a/Windows/Win32/NetworkManagement/P2P/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/Apis.ahk
@@ -509,7 +509,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphstartup
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphStartup(wVersionRequested, pVersionData) {
@@ -542,7 +542,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphshutdown
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphShutdown() {
@@ -558,7 +558,7 @@ class P2P {
      * @param {Pointer<Void>} pvData Pointer to an item to free.
      * @returns {String} Nothing - always returns an empty string
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphfreedata
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphFreeData(pvData) {
@@ -572,7 +572,7 @@ class P2P {
      * @param {Pointer<Void>} hPeerEnum Handle to a peer graph.
      * @returns {Integer} Receives a pointer to the number of records in an enumeration.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphgetitemcount
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphGetItemCount(hPeerEnum) {
@@ -596,7 +596,7 @@ class P2P {
      * <div> </div>
      * @returns {Pointer<Pointer<Void>>} Receives an array of pointers to  the requested items.  The number  of pointers contained in an array is specified by the output value of  <i>pCount</i>.  The actual data returned depends on the type of enumeration. The  types of structures that are returned are the following:  <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_connection_info">PEER_CONNECTION_INFO</a>, <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_node_info">PEER_NODE_INFO</a>, and <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_record">PEER_RECORD</a>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphgetnextitem
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphGetNextItem(hPeerEnum, pCount) {
@@ -644,7 +644,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphendenumeration
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphEndEnumeration(hPeerEnum) {
@@ -664,7 +664,7 @@ class P2P {
      * @param {Pointer<PEER_SECURITY_INTERFACE>} pSecurityInterface The information about a security provider for a peer graph in the <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_security_interface">PEER_SECURITY_INTERFACE</a> structure.
      * @returns {Pointer<Void>} Receives a handle to the peer graph that is created. When this handle is not required anymore, free it by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphclose">PeerGraphClose</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphcreate
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphCreate(pGraphProperties, pwzDatabaseName, pSecurityInterface) {
@@ -696,7 +696,7 @@ class P2P {
      * Specify <b>NULL</b> to use the default order. This parameter must be <b>NULL</b> if <i>cRecordTypeSyncPrecedence</i> is zero (0).
      * @returns {Pointer<Void>} Receives a handle to the peer graph that is opened. When this handle is not required or needed, free it by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphclose">PeerGraphClose</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphopen
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphOpen(pwzGraphId, pwzPeerId, pwzDatabaseName, pSecurityInterface, cRecordTypeSyncPrecedence, pRecordTypeSyncPrecedence) {
@@ -821,7 +821,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphlisten
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphListen(hGraph, dwScope, dwScopeId, wPort) {
@@ -841,7 +841,7 @@ class P2P {
      * @param {Pointer<PEER_ADDRESS>} pAddress Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_address">PEER_ADDRESS</a> structure that identifies a node to connect to.
      * @returns {Integer} Receives the pointer to an <b>ULONGLONG</b> that contains  the connection ID. This ID can be used with the direct communication functions.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphconnect
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphConnect(hGraph, pwzPeerId, pAddress) {
@@ -912,7 +912,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphclose
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphClose(hGraph) {
@@ -972,7 +972,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphdelete
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphDelete(pwzGraphId, pwzPeerId, pwzDatabaseName) {
@@ -992,7 +992,7 @@ class P2P {
      * @param {Pointer<Void>} hGraph Handle to the peer graph.
      * @returns {Integer} Receives the current status of the peer graph.  Returns one or more of the <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_graph_status_flags">PEER_GRAPH_STATUS_FLAGS</a> values.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphgetstatus
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphGetStatus(hGraph) {
@@ -1010,7 +1010,7 @@ class P2P {
      * @param {Pointer<Void>} hGraph Handle to a peer graph.
      * @returns {Pointer<PEER_GRAPH_PROPERTIES>} Receives a pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_graph_properties">PEER_GRAPH_PROPERTIES</a> structure.  When the structure is not needed, free it by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphfreedata">PeerGraphFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphgetproperties
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphGetProperties(hGraph) {
@@ -1089,7 +1089,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphsetproperties
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphSetProperties(hGraph, pGraphProperties) {
@@ -1110,7 +1110,7 @@ class P2P {
      * @param {Pointer<PEER_GRAPH_EVENT_REGISTRATION>} pEventRegistrations Points to an array of <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_graph_event_registration">PEER_GRAPH_EVENT_REGISTRATION</a> structures that specify what events the application requests notifications for.
      * @returns {Pointer<Void>} Receives a <b>HPEEREVENT</b> handle. This handle must be used when calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphunregisterevent">PeerGraphUnregisterEvent</a> to stop receiving  notifications.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphregisterevent
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphRegisterEvent(hGraph, hEvent, cEventRegistrations, pEventRegistrations) {
@@ -1159,7 +1159,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphunregisterevent
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphUnregisterEvent(hPeerEvent) {
@@ -1177,7 +1177,7 @@ class P2P {
      * @param {Pointer<Void>} hPeerEvent Peer event handle obtained by a call to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphregisterevent">PeerGraphRegisterEvent</a>.
      * @returns {Pointer<PEER_GRAPH_EVENT_DATA>} Receives a pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_graph_event_data">PEER_GRAPH_EVENT_DATA</a> structure that contains the data about an event notification.   When this structure is not needed, free it by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphfreedata">PeerGraphFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphgeteventdata
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphGetEventData(hPeerEvent) {
@@ -1196,7 +1196,7 @@ class P2P {
      * @param {Pointer<Guid>} pRecordId Pointer to record ID to retrieve.
      * @returns {Pointer<PEER_RECORD>} Receives the requested record. When this structure is no longer required, free it by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphfreedata">PeerGraphFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphgetrecord
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphGetRecord(hGraph, pRecordId) {
@@ -1323,7 +1323,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphaddrecord
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphAddRecord(hGraph, pRecord, pRecordId) {
@@ -1404,7 +1404,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphupdaterecord
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphUpdateRecord(hGraph, pRecord) {
@@ -1489,7 +1489,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphdeleterecord
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphDeleteRecord(hGraph, pRecordId, fLocal) {
@@ -1509,7 +1509,7 @@ class P2P {
      * @param {PWSTR} pwzPeerId Pointer to a string that identifies the creator that an application is requesting an enumeration for. Specify <b>NULL</b> to enumerate   all records.
      * @returns {Pointer<Void>} Receives a handle to an enumeration. Supply the handle to all calls to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphgetnextitem">PeerGraphGetNextItem</a>. When a handle is not needed, free it by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphendenumeration">PeerGraphEndEnumeration</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphenumrecords
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphEnumRecords(hGraph, pRecordType, pwzPeerId) {
@@ -1530,7 +1530,7 @@ class P2P {
      * @param {PWSTR} pwzCriteria Pointer to an XML string that specifies the records to search for. For information on formulating an XML query string to search the peer graphing records, see <a href="https://docs.microsoft.com/windows/desktop/P2PSdk/record-search-query-format">Record Search Query Format</a>.
      * @returns {Pointer<Void>} Handle to the enumeration.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphsearchrecords
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphSearchRecords(hGraph, pwzCriteria) {
@@ -1602,7 +1602,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphexportdatabase
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphExportDatabase(hGraph, pwzFilePath) {
@@ -1685,7 +1685,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphimportdatabase
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphImportDatabase(hGraph, pwzFilePath) {
@@ -1758,7 +1758,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphvalidatedeferredrecords
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphValidateDeferredRecords(hGraph, cRecordIds, pRecordIds) {
@@ -1778,7 +1778,7 @@ class P2P {
      * @param {Pointer<PEER_ADDRESS>} pAddress Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_address">PEER_ADDRESS</a> structure that contains the address of the node to  connect to.
      * @returns {Integer} Receives the connection ID for the requested connection.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphopendirectconnection
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphOpenDirectConnection(hGraph, pwzPeerId, pAddress) {
@@ -1853,7 +1853,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphsenddata
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphSendData(hGraph, ullConnectionId, pType, cbData, pvData) {
@@ -1923,7 +1923,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphclosedirectconnection
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphCloseDirectConnection(hGraph, ullConnectionId) {
@@ -1942,7 +1942,7 @@ class P2P {
      * @param {Integer} dwFlags The  type of connection to enumerate. This parameter is required. Valid values are specified by <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_connection_flags">PEER_CONNECTION_FLAGS</a>.
      * @returns {Pointer<Void>} Receives a handle to an  enumeration.  Use <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphgetnextitem">PeerGraphGetNextItem</a> to retrieve the actual connection information. When this handle is not required, free it by calling  <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphendenumeration">PeerGraphEndEnumeration</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphenumconnections
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphEnumConnections(hGraph, dwFlags) {
@@ -1961,7 +1961,7 @@ class P2P {
      * @param {PWSTR} pwzPeerId The peer ID   to obtain a node enumeration.	Specify <b>NULL</b> to return all nodes in  a peer graph.
      * @returns {Pointer<Void>} Receives a handle to an enumeration.  Use <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphgetnextitem">PeerGraphGetNextItem</a> to retrieve the actual node information. When this handle is not needed, free it by calling  <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphendenumeration">PeerGraphEndEnumeration</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphenumnodes
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphEnumNodes(hGraph, pwzPeerId) {
@@ -2025,7 +2025,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphsetpresence
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphSetPresence(hGraph, fPresent) {
@@ -2044,7 +2044,7 @@ class P2P {
      * @param {Integer} ullNodeId Specifies  the ID of a node   that an application receives  information about. Specify zero (0) to  retrieve information about the local node.
      * @returns {Pointer<PEER_NODE_INFO>} Receives a pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_node_info">PEER_NODE_INFO</a> structure that contains the requested information. When the handle is not needed, free it by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergraphfreedata">PeerGraphFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphgetnodeinfo
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphGetNodeInfo(hGraph, ullNodeId) {
@@ -2114,7 +2114,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphsetnodeattributes
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphSetNodeAttributes(hGraph, pwzAttributes) {
@@ -2176,7 +2176,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphpeertimetouniversaltime
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphPeerTimeToUniversalTime(hGraph, pftPeerTime, pftUniversalTime) {
@@ -2236,7 +2236,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergraphuniversaltimetopeertime
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGraphUniversalTimeToPeerTime(hGraph, pftUniversalTime, pftPeerTime) {
@@ -2254,7 +2254,7 @@ class P2P {
      * @param {Pointer<Void>} pvData Pointer to a block of data to be deallocated. This parameter must reference a valid block of memory.
      * @returns {String} Nothing - always returns an empty string
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerfreedata
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerFreeData(pvData) {
@@ -2268,7 +2268,7 @@ class P2P {
      * @param {Pointer<Void>} hPeerEnum Handle to the peer enumeration on which a count is performed. A peer enumeration function generates this handle.
      * @returns {Integer} Returns the total number of items in a peer enumeration.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergetitemcount
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGetItemCount(hPeerEnum) {
@@ -2287,7 +2287,7 @@ class P2P {
      * @param {Pointer<Integer>} pCount Pointer to an integer that specifies the number of items to be retrieved from the peer enumeration. When returned, it contains the number of items in <i>ppvItems</i>. This parameter cannot be <b>NULL</b>.
      * @returns {Pointer<Pointer<Void>>} Receives a pointer to an array of pointers to the next <i>pCount</i> items in the peer enumeration. The  data, for example, a record or member information block, depends on the actual peer enumeration type.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergetnextitem
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGetNextItem(hPeerEnum, pCount) {
@@ -2324,7 +2324,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerendenumeration
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerEndEnumeration(hPeerEnum) {
@@ -2397,7 +2397,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupstartup
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupStartup(wVersionRequested, pVersionData) {
@@ -2433,7 +2433,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupshutdown
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupShutdown() {
@@ -2458,7 +2458,7 @@ class P2P {
      * </ul>The remaining members are optional.
      * @returns {Pointer<Void>} Returns the  handle pointer to the  peer group. Any function called with this handle as a parameter  has the corresponding action performed on that peer group.  This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupcreate
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupCreate(pProperties) {
@@ -2476,7 +2476,7 @@ class P2P {
      * @param {PWSTR} pwzCloud Pointer to a Unicode string that contains the name of the PNRP cloud in which the peer group is located. If the value is <b>NULL</b>,  the cloud specified in the peer group properties is used.
      * @returns {Pointer<Void>} Pointer to a handle for a  peer group. If this value is <b>NULL</b>, the open operation is unsuccessful. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupopen
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupOpen(pwzIdentity, pwzGroupPeerName, pwzCloud) {
@@ -2498,7 +2498,7 @@ class P2P {
      * @param {PWSTR} pwzCloud Pointer to a Unicode string that contains the name of the PNRP cloud where a group is located.  The default value is <b>NULL</b>, which indicates that the cloud specified in the invitation must be used.
      * @returns {Pointer<Void>} Pointer to the handle of the peer group. To start communication with a group, call <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergroupconnect">PeerGroupConnect</a>. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupjoin
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupJoin(pwzIdentity, pwzInvitation, pwzCloud) {
@@ -2521,7 +2521,7 @@ class P2P {
      * @param {PWSTR} pwzCloud Pointer to a Unicode string that contains the name of the PNRP cloud where a group is located.  The default value is <b>NULL</b>, which indicates that the cloud specified in the invitation must be used.
      * @returns {Pointer<Void>} Pointer to the handle of the peer group. To start communication with a group, call <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergroupconnect">PeerGroupConnect</a>. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergrouppasswordjoin
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupPasswordJoin(pwzIdentity, pwzInvitation, pwzPassword, pwzCloud) {
@@ -2563,7 +2563,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupconnect
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupConnect(hGroup) {
@@ -2604,7 +2604,7 @@ class P2P {
      * 
      * Cryptography-specific errors may be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupconnectbyaddress
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupConnectByAddress(hGroup, cAddresses, pAddresses) {
@@ -2643,7 +2643,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupclose
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupClose(hGroup) {
@@ -2721,7 +2721,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupdelete
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupDelete(pwzIdentity, pwzGroupPeerName) {
@@ -2771,7 +2771,7 @@ class P2P {
      * </table>
      * @returns {PWSTR} Pointer to a Unicode string that contains the invitation from the issuer. This invitation can be passed to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergroupjoin">PeerGroupJoin</a> by the recipient in order to join the specified peer group. To return the details of the invitation as a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_invitation_info">PEER_INVITATION_INFO</a> structure, pass this string to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergroupparseinvitation">PeerGroupParseInvitation</a>. To release this data, pass this pointer to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupcreateinvitation
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupCreateInvitation(hGroup, pwzIdentityInfo, pftExpiration, cRoles, pRoles) {
@@ -2797,7 +2797,7 @@ class P2P {
      * <li><b>dwAuthenticationSchemes</b>. This field must have the <b>PEER_GROUP_PASSWORD_AUTHENTICATION</b> flag (0x00000001) set on it.</li>
      * </ul>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupcreatepasswordinvitation
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupCreatePasswordInvitation(hGroup) {
@@ -2815,7 +2815,7 @@ class P2P {
      * @param {PWSTR} pwzInvitation Pointer to a Unicode string that contains the specific peer group invitation. This parameter is required.
      * @returns {Pointer<PEER_INVITATION_INFO>} Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_invitation_info">PEER_INVITATION_INFO</a> structure with the details of a specific invitation. To release the resources used by this structure, pass this pointer to  <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupparseinvitation
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupParseInvitation(pwzInvitation) {
@@ -2833,7 +2833,7 @@ class P2P {
      * @param {Pointer<Void>} hGroup Handle to a peer group whose status is returned. This handle is returned by the <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergroupcreate">PeerGroupCreate</a>, <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergroupopen">PeerGroupOpen</a>, or <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergroupjoin">PeerGroupJoin</a> function. This parameter is required.
      * @returns {Integer} Pointer to a set of <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_group_status">PEER_GROUP_STATUS</a> flags that describe the status of a peer group.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupgetstatus
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupGetStatus(hGroup) {
@@ -2851,7 +2851,7 @@ class P2P {
      * @param {Pointer<Void>} hGroup Handle to a peer group whose properties are retrieved. This handle is returned by the <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergroupcreate">PeerGroupCreate</a>, <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergroupopen">PeerGroupOpen</a>, or <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergroupjoin">PeerGroupJoin</a> function. This parameter is required.
      * @returns {Pointer<PEER_GROUP_PROPERTIES>} Pointer to a  <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_group_properties">PEER_GROUP_PROPERTIES</a> structure that contains information about peer   group properties. This data must be freed with <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupgetproperties
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupGetProperties(hGroup) {
@@ -2955,7 +2955,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupsetproperties
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupSetProperties(hGroup, pProperties) {
@@ -2993,7 +2993,7 @@ class P2P {
      * @returns {Pointer<Void>} Pointer to the enumeration that contains the returned list of peer group members. This handle is passed to  
      * 	 <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergetnextitem">PeerGetNextItem</a> to retrieve the items, with each item represented as a pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_member">PEER_MEMBER</a> structure. When finished, <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerendenumeration">PeerEndEnumeration</a> is called to return the memory used by the enumeration. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupenummembers
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupEnumMembers(hGroup, dwFlags, pwzIdentity) {
@@ -3015,7 +3015,7 @@ class P2P {
      * @param {Pointer<PEER_ADDRESS>} pAddress Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_address">PEER_ADDRESS</a> structure that contains the IPv6 address   the peer  connects to. This parameter is required.
      * @returns {Integer} Unsigned 64-bit integer that identifies the direct connection. This ID value cannot be assumed as valid until the <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_group_event_type">PEER_GROUP_EVENT_DIRECT_CONNECTION</a> event is raised and indicates that the connection has been accepted by the other peer. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupopendirectconnection
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupOpenDirectConnection(hGroup, pwzIdentity, pAddress) {
@@ -3068,7 +3068,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupclosedirectconnection
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupCloseDirectConnection(hGroup, ullConnectionId) {
@@ -3088,7 +3088,7 @@ class P2P {
      * @returns {Pointer<Void>} Pointer to the enumeration that contains the returned list of active connections. This handle is passed to  
      * 	 <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergetnextitem">PeerGetNextItem</a> to retrieve the items, with each item represented as a pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_connection_info">PEER_CONNECTION_INFO</a> structure. When finished, <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerendenumeration">PeerEndEnumeration</a> is called to return the memory used by the enumeration. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupenumconnections
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupEnumConnections(hGroup, dwFlags) {
@@ -3142,7 +3142,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupsenddata
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupSendData(hGroup, ullConnectionId, pType, cbData, pvData) {
@@ -3164,7 +3164,7 @@ class P2P {
      * 		 structures that contains the peer event types for which registration  occurs. This parameter is required.
      * @returns {Pointer<Void>} Pointer to the returned HPEEREVENT handle. A peer can unregister for this peer event by passing this handle to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergroupunregisterevent">PeerGroupUnregisterEvent</a>. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupregisterevent
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupRegisterEvent(hGroup, hEvent, cEventRegistration, pEventRegistrations) {
@@ -3205,7 +3205,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupunregisterevent
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupUnregisterEvent(hPeerEvent) {
@@ -3223,7 +3223,7 @@ class P2P {
      * @param {Pointer<Void>} hPeerEvent Handle obtained from a previous call to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergroupregisterevent">PeerGroupRegisterEvent</a>. This parameter is required.
      * @returns {Pointer<PEER_GROUP_EVENT_DATA>} Pointer to a [PEER_GROUP_EVENT_DATA](/windows/win32/api/p2p/ns-p2p-peer_group_event_data-r1) structure that contains data about the peer event. This data structure must be freed after use with <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupgeteventdata
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupGetEventData(hPeerEvent) {
@@ -3242,7 +3242,7 @@ class P2P {
      * @param {Pointer<Guid>} pRecordId Specifies the GUID value that uniquely identifies a required record within a peer group. This parameter is required.
      * @returns {Pointer<PEER_RECORD>} Pointer to the address of a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_record">PEER_RECORD</a> structure that contains a returned record. This structure is freed by passing its pointer to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupgetrecord
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupGetRecord(hGroup, pRecordId) {
@@ -3392,7 +3392,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupaddrecord
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupAddRecord(hGroup, pRecord, pRecordId) {
@@ -3503,7 +3503,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupupdaterecord
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupUpdateRecord(hGroup, pRecord) {
@@ -3576,7 +3576,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupdeleterecord
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupDeleteRecord(hGroup, pRecordId) {
@@ -3596,7 +3596,7 @@ class P2P {
      * @returns {Pointer<Void>} Pointer to the enumeration that contains the returned list of records. This handle is passed to  
      * 	 <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergetnextitem">PeerGetNextItem</a> to retrieve the items, with each item represented as a pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_record">PEER_RECORD</a> structure. When finished, <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerendenumeration">PeerEndEnumeration</a> is called to return the memory used by the enumeration. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupenumrecords
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupEnumRecords(hGroup, pRecordType) {
@@ -3616,7 +3616,7 @@ class P2P {
      * @returns {Pointer<Void>} Pointer to the enumeration that contains the returned list of records. This handle is passed to  
      * 	 <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergetnextitem">PeerGetNextItem</a> to retrieve the items with each item represented as a pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_record">PEER_RECORD</a> structure. When finished, <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerendenumeration">PeerEndEnumeration</a> is called to return the memory used by the enumeration. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupsearchrecords
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupSearchRecords(hGroup, pwzCriteria) {
@@ -3671,7 +3671,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupexportdatabase
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupExportDatabase(hGroup, pwzFilePath) {
@@ -3737,7 +3737,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupimportdatabase
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupImportDatabase(hGroup, pwzFilePath) {
@@ -3782,7 +3782,7 @@ class P2P {
      * </table>
      * @returns {PWSTR} Pointer to an invitation XML string returned by the function call. This invitation is passed out-of-band to the invited peer who uses it in a call to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergroupjoin">PeerGroupJoin</a>. This parameter is optional.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupissuecredentials
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupIssueCredentials(hGroup, pwzSubjectIdentity, pCredentialInfo, dwFlags) {
@@ -3803,7 +3803,7 @@ class P2P {
      * @param {PWSTR} pwzPassword Specifies the password used to protect the exported configuration. There are no rules or limits for the formation of this password. This parameter is required.
      * @returns {PWSTR} Pointer to the returned XML configuration string that contains the identity, group peer name, cloud peer name, group scope, and the GMC for the identity. This parameter is required.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupexportconfig
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupExportConfig(hGroup, pwzPassword) {
@@ -3870,7 +3870,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupimportconfig
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupImportConfig(pwzXML, pwzPassword, fOverwrite, ppwzIdentity, ppwzGroup) {
@@ -3937,7 +3937,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergrouppeertimetouniversaltime
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupPeerTimeToUniversalTime(hGroup, pftPeerTime, pftUniversalTime) {
@@ -4000,7 +4000,7 @@ class P2P {
      * 
      * Cryptography-specific errors can be returned from the <a href="/windows/desktop/SecCrypto/microsoft-base-cryptographic-provider">Microsoft RSA Base Provider</a>. These errors are prefixed with CRYPT_* and defined in Winerror.h.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peergroupuniversaltimetopeertime
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerGroupUniversalTimeToPeerTime(hGroup, pftUniversalTime, pftPeerTime) {
@@ -4018,7 +4018,7 @@ class P2P {
      * @param {Pointer<Void>} hGroup 
      * @param {Pointer<Void>} hPeerEventHandle 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static PeerGroupResumePasswordAuthentication(hGroup, hPeerEventHandle) {
         hGroupMarshal := hGroup is VarRef ? "ptr" : "ptr"
@@ -4041,7 +4041,7 @@ class P2P {
      * <div> </div>
      * @returns {PWSTR} Receives a pointer to the name of an peer identity that is created. This name must be used in all subsequent calls to  the Peer Identity Manager, Peer Grouping, or PNRP functions that operate on behalf of the peer identity. Returns <b>NULL</b> if the peer identity cannot be created.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peeridentitycreate
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerIdentityCreate(pwzClassifier, pwzFriendlyName, hCryptProv) {
@@ -4060,7 +4060,7 @@ class P2P {
      * @param {PWSTR} pwzIdentity Specifies the peer identity to obtain a friendly name.
      * @returns {PWSTR} Receives a pointer to the friendly name. When <i>ppwzFriendlyName</i> is not required anymore, the application is responsible for freeing this string by calling  <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peeridentitygetfriendlyname
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerIdentityGetFriendlyName(pwzIdentity) {
@@ -4130,7 +4130,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peeridentitysetfriendlyname
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerIdentitySetFriendlyName(pwzIdentity, pwzFriendlyName) {
@@ -4149,7 +4149,7 @@ class P2P {
      * @param {PWSTR} pwzIdentity Specifies the peer identity to retrieve the key pair for.
      * @returns {Pointer} Receives a pointer to the handle of the  cryptographic service provider (CSP) that contains an AT_KEYEXCHANGE RSA key pair.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peeridentitygetcryptkey
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerIdentityGetCryptKey(pwzIdentity) {
@@ -4208,7 +4208,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peeridentitydelete
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerIdentityDelete(pwzIdentity) {
@@ -4225,7 +4225,7 @@ class P2P {
      * The PeerEnumIdentities function creates and returns a peer enumeration handle used to enumerate all the peer identities that belong to a specific user.
      * @returns {Pointer<Void>} Receives a handle to the peer enumeration that contains the list of peer identities, with each item represented as a pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_name_pair">PEER_NAME_PAIR</a> structure. Pass this handle to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergetnextitem">PeerGetNextItem</a> to retrieve the items; when finished, call <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerendenumeration">PeerEndEnumeration</a>  to release the memory.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerenumidentities
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerEnumIdentities() {
@@ -4241,7 +4241,7 @@ class P2P {
      * @param {PWSTR} pwzIdentity Specifies the peer identity to enumerate groups for.
      * @returns {Pointer<Void>} Receives a handle to the peer enumeration that contains the list of peer groups that the specified identity is a member of, with each item represented as a pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_name_pair">PEER_NAME_PAIR</a> structure. Pass this handle to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergetnextitem">PeerGetNextItem</a> to retrieve the items; when finished, call <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerendenumeration">PeerEndEnumeration</a> release the memory.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerenumgroups
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerEnumGroups(pwzIdentity) {
@@ -4264,7 +4264,7 @@ class P2P {
      * This parameter can only be <b>NULL</b> if <i>pwzIdentity</i> is not <b>NULL</b>.
      * @returns {PWSTR} Pointer that receives a pointer to the new peer name. When this string is not required anymore, free it by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercreatepeername
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerCreatePeerName(pwzIdentity, pwzClassifier) {
@@ -4283,7 +4283,7 @@ class P2P {
      * @param {PWSTR} pwzIdentity Specifies the peer identity to retrieve peer identity information for. When this parameter is passed as <b>NULL</b>, a "default" identity will be generated for the user by the peer infrastructure.
      * @returns {PWSTR} Pointer to a pointer to a Unicode string that contains the XML fragment. When <i>ppwzIdentityXML</i> is no longer required, the application is responsible for freeing this string by calling  <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peeridentitygetxml
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerIdentityGetXML(pwzIdentity) {
@@ -4302,7 +4302,7 @@ class P2P {
      * @param {PWSTR} pwzPassword Specifies the password to use to encrypt the peer identity. This parameter cannot be <b>NULL</b>. This password must also be used to import the peer identity, or the import operation fails.
      * @returns {PWSTR} Receives a pointer to the exported peer identity in XML format. If the export operation is successful, the application must free <i>ppwzExportXML</i> by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peeridentityexport
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerIdentityExport(pwzIdentity, pwzPassword) {
@@ -4323,7 +4323,7 @@ class P2P {
      * @param {PWSTR} pwzPassword Specifies the password to use to de-crypt a peer identity. The password must be identical to the password supplied to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peeridentityexport">PeerIdentityExport</a>. This parameter cannot be <b>NULL</b>.
      * @returns {PWSTR} Pointer to a string that represents a peer identity that is imported.  If the import operation is successful, the application must free <i>ppwzIdentity</i> by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peeridentityimport
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerIdentityImport(pwzImportXML, pwzPassword) {
@@ -4341,7 +4341,7 @@ class P2P {
      * The PeerIdentityGetDefault function retrieves the default peer name set for the current user.
      * @returns {PWSTR} Pointer to the address of a zero-terminated Unicode string that contains the default name of the current user.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peeridentitygetdefault
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerIdentityGetDefault() {
@@ -4386,7 +4386,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabstartup
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabStartup(wVersionRequested) {
@@ -4430,7 +4430,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabshutdown
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabShutdown() {
@@ -4509,7 +4509,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabsignin
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabSignin(hwndParent, dwSigninOptions) {
@@ -4567,7 +4567,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabsignout
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabSignout(dwSigninOptions) {
@@ -4582,7 +4582,7 @@ class P2P {
      * Obtains the peer's current signed-in peer collaboration network presence options.
      * @returns {Integer} The <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_signin_flags">PEER_SIGNIN_FLAGS</a> enumeration value is returned by this function.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabgetsigninoptions
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabGetSigninOptions() {
@@ -4605,7 +4605,7 @@ class P2P {
      * If the event is not provided the caller must poll for the result by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peercollabgetinvitationresponse">PeerCollabGetInvitationResponse</a>.
      * @returns {HANDLE} A pointer to a handle to the sent invitation. The framework will cleanup the response information after the invitation response is received if <b>NULL</b> is specified. When <b>NULL</b> is not the specified handle to the invitation provided, it must be closed by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peercollabclosehandle">PeerCollabCloseHandle</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabasyncinvitecontact
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabAsyncInviteContact(pcContact, pcEndpoint, pcInvitation, hEvent) {
@@ -4626,7 +4626,7 @@ class P2P {
      * 
      * Free the memory associated with this structure by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabgetinvitationresponse
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabGetInvitationResponse(hInvitation) {
@@ -4695,7 +4695,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabcancelinvitation
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabCancelInvitation(hInvitation) {
@@ -4742,7 +4742,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabclosehandle
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabCloseHandle(hInvitation) {
@@ -4766,7 +4766,7 @@ class P2P {
      * 
      * Free the memory returned by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabinvitecontact
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabInviteContact(pcContact, pcEndpoint, pcInvitation) {
@@ -4788,7 +4788,7 @@ class P2P {
      * If the event is not provided, the caller must poll for the result by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peercollabgetinvitationresponse">PeerCollabGetInvitationResponse</a>.
      * @returns {HANDLE} A pointer to a handle to the sent invitation. If this parameter is <b>NULL</b>, the framework will cleanup the response information after the invitation response is received. If this parameter is not <b>NULL</b>, the handle must be closed by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peercollabclosehandle">PeerCollabCloseHandle</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabasyncinviteendpoint
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabAsyncInviteEndpoint(pcEndpoint, pcInvitation, hEvent) {
@@ -4814,7 +4814,7 @@ class P2P {
      * 
      * Free the memory associated with this structure by pass it to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabinviteendpoint
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabInviteEndpoint(pcEndpoint, pcInvitation) {
@@ -4831,7 +4831,7 @@ class P2P {
      * 
      * Free the memory associated with this structure by passing it to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabgetapplaunchinfo
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabGetAppLaunchInfo() {
@@ -4877,7 +4877,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabregisterapplication
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabRegisterApplication(pcApplication, registrationType) {
@@ -4934,7 +4934,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabunregisterapplication
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabUnregisterApplication(pApplicationId, registrationType) {
@@ -4951,7 +4951,7 @@ class P2P {
      * @param {Integer} registrationType A <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_application_registration_type">PEER_APPLICATION_REGISTRATION_TYPE</a> enumeration value that describes whether the peer's application is registered to the current user or all users of the local machine.
      * @returns {Pointer<PEER_APPLICATION_REGISTRATION_INFO>} Pointer to the address of a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_application_registration_info">PEER_APPLICATION_REGISTRATION_INFO</a> structure that contains the information about a peer's specific registered application. The data returned in this parameter can be freed by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabgetapplicationregistrationinfo
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabGetApplicationRegistrationInfo(pApplicationId, registrationType) {
@@ -4967,7 +4967,7 @@ class P2P {
      * @param {Integer} registrationType A <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_application_registration_type">PEER_APPLICATION_REGISTRATION_TYPE</a> value that specifies whether the peer's application is registered to the <b>current user</b> or <b>all users</b> of the peer's machine.
      * @returns {Pointer<Void>} Pointer to a peer enumeration handle for the peer application registration information. This data is obtained by passing this handle to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergetnextitem">PeerGetNextItem</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabenumapplicationregistrationinfo
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabEnumApplicationRegistrationInfo(registrationType) {
@@ -4983,7 +4983,7 @@ class P2P {
      * @param {Pointer<PEER_ENDPOINT>} pcEndpoint Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_endpoint">PEER_ENDPOINT</a> structure that contains the specific endpoint associated with the contact specified in <i>pcContact</i> for which presence information must be returned.
      * @returns {Pointer<PEER_PRESENCE_INFO>} Pointer  to the address of the <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_presence_info">PEER_PRESENCE_INFO</a> structure that contains the requested presence data for the supplied endpoint.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabgetpresenceinfo
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabGetPresenceInfo(pcEndpoint) {
@@ -5002,7 +5002,7 @@ class P2P {
      * @param {Pointer<Guid>} pApplicationId Pointer to the GUID value that uniquely identifies a particular application of the supplied peer. If this parameter is supplied, the only peer application returned is the one that matches this GUID.
      * @returns {Pointer<Void>} Pointer to the handle for the enumerated set of registered applications that correspond to the GUID returned in <i>pObjectId</i>. Pass this handle to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergetnextitem">PeerGetNextItem</a> to obtain each item in the enumerated set.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabenumapplications
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabEnumApplications(pcEndpoint, pApplicationId) {
@@ -5021,7 +5021,7 @@ class P2P {
      * @param {Pointer<Guid>} pObjectId Pointer to a GUID value that uniquely identifies a peer object with the supplied peer. If this parameter is supplied, the only peer object returned is the one that matches this GUID.
      * @returns {Pointer<Void>} Pointer to the handle for the enumerated set of peer objects that correspond to the GUID returned in <i>pObjectId</i>. Pass this handle to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergetnextitem">PeerGetNextItem</a> to obtain each item in the enumerated set.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabenumobjects
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabEnumObjects(pcEndpoint, pObjectId) {
@@ -5037,7 +5037,7 @@ class P2P {
      * @param {Pointer<PEER_CONTACT>} pcContact Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_contact">PEER_CONTACT</a> structure that contains the contact information for a specific peer. This parameter must not be <b>NULL</b>.
      * @returns {Pointer<Void>} Pointer to a handle for the enumerated set of endpoints that are associated with the supplied peer contact. Pass this handle to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peergetnextitem">PeerGetNextItem</a> to obtain each item in the enumerated set.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabenumendpoints
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabEnumEndpoints(pcContact) {
@@ -5082,7 +5082,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabrefreshendpointdata
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabRefreshEndpointData(pcEndpoint) {
@@ -5127,7 +5127,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabdeleteendpointdata
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabDeleteEndpointData(pcEndpoint) {
@@ -5145,7 +5145,7 @@ class P2P {
      * If this parameter is set to <b>NULL</b>, the contact information for the current peer endpoint is obtained.
      * @returns {PWSTR} Pointer to a zero-terminated Unicode string buffer that contains the contact data for the endpoint supplied in <i>pcEndpoint</i>. Call <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a> to free the data.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabquerycontactdata
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabQueryContactData(pcEndpoint) {
@@ -5201,7 +5201,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabsubscribeendpointdata
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabSubscribeEndpointData(pcEndpoint) {
@@ -5257,7 +5257,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabunsubscribeendpointdata
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabUnsubscribeEndpointData(pcEndpoint) {
@@ -5324,7 +5324,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabsetpresenceinfo
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabSetPresenceInfo(pcPresenceInfo) {
@@ -5339,7 +5339,7 @@ class P2P {
      * Retrieves the name of the current endpoint of the calling peer, as previously set by a call to PeerCollabSetEndpointName.
      * @returns {PWSTR} Pointer to a zero-terminated Unicode string name of the peer endpoint currently used by the calling application.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabgetendpointname
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabGetEndpointName() {
@@ -5395,7 +5395,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabsetendpointname
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabSetEndpointName(pwzEndpointName) {
@@ -5464,7 +5464,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabsetobject
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabSetObject(pcObject) {
@@ -5531,7 +5531,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabdeleteobject
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabDeleteObject(pObjectId) {
@@ -5549,7 +5549,7 @@ class P2P {
      * @param {Pointer<PEER_COLLAB_EVENT_REGISTRATION>} pEventRegistrations An array of <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_collab_event_registration">PEER_COLLAB_EVENT_REGISTRATION</a> structures that specify the peer collaboration events for which the application requests notification.
      * @returns {Pointer<Void>} The peer event handle returned by this function. This handle is passed to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peercollabgeteventdata">PeerCollabGetEventData</a> when a peer collaboration network event is raised on the peer.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabregisterevent
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabRegisterEvent(hEvent, cEventRegistration, pEventRegistrations) {
@@ -5567,7 +5567,7 @@ class P2P {
      * @param {Pointer<Void>} hPeerEvent The peer collaboration network event handle obtained by a call to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peercollabregisterevent">PeerCollabRegisterEvent</a>.
      * @returns {Pointer<PEER_COLLAB_EVENT_DATA>} Pointer to a list of [PEER_COLLAB_EVENT_DATA](/windows/win32/api/p2p/ns-p2p-peer_collab_event_data-r1) structures that contain data about the peer collaboration network event. These data structures must be freed after use by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabgeteventdata
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabGetEventData(hPeerEvent) {
@@ -5614,7 +5614,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabunregisterevent
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabUnregisterEvent(hPeerEvent) {
@@ -5631,7 +5631,7 @@ class P2P {
      * Returns a handle to an enumerated set that contains all of the peer collaboration network &quot;people near me&quot; endpoints currently available on the subnet of the calling peer.
      * @returns {Pointer<Void>} Pointer to a handle of an enumerated set that contains all of the peer collaboration network "people near me" endpoints currently available on the subnet of the calling peer.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabenumpeoplenearme
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabEnumPeopleNearMe() {
@@ -5651,7 +5651,7 @@ class P2P {
      * 
      * Call <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a> on the address of the <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_contact">PEER_CONTACT</a> structure to free this data.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabaddcontact
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabAddContact(pwzContactData) {
@@ -5698,7 +5698,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabdeletecontact
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabDeleteContact(pwzPeerName) {
@@ -5720,7 +5720,7 @@ class P2P {
      * 
      * Call <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a> on the address of the <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_contact">PEER_CONTACT</a> structure to free this data.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabgetcontact
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabGetContact(pwzPeerName) {
@@ -5767,7 +5767,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabupdatecontact
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabUpdateContact(pContact) {
@@ -5782,7 +5782,7 @@ class P2P {
      * Returns a handle to an enumerated set that contains all of the peer collaboration network contacts currently available on the calling peer.
      * @returns {Pointer<Void>} Handle to an enumerated set that contains all of the peer collaboration network contacts currently available on the calling peer, excluding the "Me" contact.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabenumcontacts
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabEnumContacts() {
@@ -5802,7 +5802,7 @@ class P2P {
      * 
      * The memory returned here can be freed by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabexportcontact
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabExportContact(pwzPeerName) {
@@ -5820,7 +5820,7 @@ class P2P {
      * @param {PWSTR} pwzContactData Pointer to zero-terminated Unicode string buffer that contains XML contact data as returned by functions like <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peercollabquerycontactdata">PeerCollabQueryContactData</a> or <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peercollabexportcontact">PeerCollabExportContact</a>.
      * @returns {Pointer<PEER_CONTACT>} Pointer to the address of a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_contact">PEER_CONTACT</a> structure that contain the peer contact information parsed from <i>pwzContactData</i>. Free the memory allocated by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peercollabparsecontact
-     * @deprecated
+     * @deprecated 
      * @since windows6.0.6000
      */
     static PeerCollabParseContact(pwzContactData) {
@@ -5838,7 +5838,7 @@ class P2P {
      * @param {PWSTR} pwzPeerName Pointer to a zero-terminated Unicode string that contains the peer name to encode as a host name.
      * @returns {PWSTR} Pointer to the address of the zero-terminated Unicode string that contains the encoded host name. This string can be passed to <a href="https://docs.microsoft.com/windows/desktop/api/ws2tcpip/nf-ws2tcpip-getaddrinfo">getaddrinfo_v2</a> to obtain network information about the peer.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peernametopeerhostname
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerNameToPeerHostName(pwzPeerName) {
@@ -5856,7 +5856,7 @@ class P2P {
      * @param {PWSTR} pwzHostName Pointer to a zero-terminated Unicode string that contains the host name to decode.
      * @returns {PWSTR} Pointer to the address of the zero-terminated Unicode string that contains the decoded peer name. The returned  string must be released with <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerhostnametopeername
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerHostNameToPeerName(pwzHostName) {
@@ -5925,7 +5925,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerpnrpstartup
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerPnrpStartup(wVersionRequested) {
@@ -5969,7 +5969,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerpnrpshutdown
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerPnrpShutdown() {
@@ -5986,7 +5986,7 @@ class P2P {
      * @param {Pointer<PEER_PNRP_REGISTRATION_INFO>} pRegistrationInfo Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_pnrp_registration_info">PEER_PNRP_REGISTRATION_INFO</a> structure that contains the endpoint information for the registering peer node. If <b>NULL</b>, the API will register the peer with all known PNRP clouds, and any registered addresses are automatically selected by the infrastructure.
      * @returns {Pointer<Void>} Handle to the  PNRP registration for the calling peer node. Use this handle to update the registration or to deregister with the PNRP service.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerpnrpregister
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerPnrpRegister(pcwzPeerName, pRegistrationInfo) {
@@ -6034,7 +6034,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerpnrpupdateregistration
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerPnrpUpdateRegistration(hRegistration, pRegistrationInfo) {
@@ -6081,7 +6081,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerpnrpunregister
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerPnrpUnregister(hRegistration) {
@@ -6101,7 +6101,7 @@ class P2P {
      * @param {Pointer<Integer>} pcEndpoints The maximum number of endpoints to return in  <i>ppEndpoints</i>. Upon return, this parameter contains the actual number of endpoints in <i>ppEndpoints</i>.
      * @returns {Pointer<PEER_PNRP_ENDPOINT_INFO>} Pointer to a list of <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_pnrp_endpoint_info">PEER_PNRP_ENDPOINT_INFO</a> structures that contain the endpoints for which the peer name successfully resolved. Each endpoint contains one or more IP addresses at which the peer node can be reached.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerpnrpresolve
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerPnrpResolve(pcwzPeerName, pcwzCloudName, pcEndpoints) {
@@ -6125,7 +6125,7 @@ class P2P {
      * @param {HANDLE} hEvent Handle to the event signaled when a peer endpoint is resolved for the supplied peer name and are ready for consumption by calling PeerPnrpGetEndpoint. This event is signaled for every endpoint discovered by the PNRP service. If PEER_NO_MORE is returned by a call to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerpnrpgetendpoint">PeerPnrpGetEndpoint</a>, then all endpoints have been found for that peer.
      * @returns {Pointer<Void>} Handle to this peer name resolution request. This handle must be provided to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerpnrpendresolve">PeerPnrpEndResolve</a> after the resolution events are raised and the endpoints are obtained with corresponding calls to <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerpnrpgetendpoint">PeerPnrpGetEndpoint</a>, or if the operation fails.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerpnrpstartresolve
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerPnrpStartResolve(pcwzPeerName, pcwzCloudName, cMaxEndpoints, hEvent) {
@@ -6177,7 +6177,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerpnrpgetcloudinfo
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerPnrpGetCloudInfo(pcNumClouds, ppCloudInfo) {
@@ -6198,7 +6198,7 @@ class P2P {
      * 
      * This data returned by this parameter must be freed by calling <a href="https://docs.microsoft.com/windows/desktop/api/p2p/nf-p2p-peerfreedata">PeerFreeData</a>.
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerpnrpgetendpoint
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerPnrpGetEndpoint(hResolve) {
@@ -6245,7 +6245,7 @@ class P2P {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//p2p/nf-p2p-peerpnrpendresolve
-     * @deprecated
+     * @deprecated 
      * @since windows5.1.2600
      */
     static PeerPnrpEndResolve(hResolve) {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_APPLICATION.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_APPLICATION.ahk
@@ -32,7 +32,7 @@ class PEER_APPLICATION extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_data">PEER_DATA</a> structure that contains the application information in a member byte buffer. This information is available to anyone who can query for the local peer's member information. This data is limited to 16K.
-     * @deprecated
+     * @deprecated 
      * @type {PEER_DATA}
      */
     data{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_APPLICATION_REGISTRATION_INFO.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_APPLICATION_REGISTRATION_INFO.ahk
@@ -24,7 +24,7 @@ class PEER_APPLICATION_REGISTRATION_INFO extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_application">PEER_APPLICATION</a> structure that contains the specific peer application data.
-     * @deprecated
+     * @deprecated 
      * @type {PEER_APPLICATION}
      */
     application{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_APP_LAUNCH_INFO.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_APP_LAUNCH_INFO.ahk
@@ -15,7 +15,7 @@ class PEER_APP_LAUNCH_INFO extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_contact">PEER_CONTACT</a> structure that contains information about the contact that sent the request to the local peer to launch the application referenced by the application.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_CONTACT>}
      */
     pContact {
@@ -25,7 +25,7 @@ class PEER_APP_LAUNCH_INFO extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_endpoint">PEER_ENDPOINT</a> structure that contains information about the specific endpoint of the contact that sent the request to the local peer to launch the application referenced by the application
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_ENDPOINT>}
      */
     pEndpoint {
@@ -35,7 +35,7 @@ class PEER_APP_LAUNCH_INFO extends Win32Struct
 
     /**
      * Pointer to the <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_invitation">PEER_INVITATION</a> structure that contains the invitation to launch a specific peer application application on the local peer.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_INVITATION>}
      */
     pInvitation {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_COLLAB_EVENT_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_COLLAB_EVENT_DATA.ahk
@@ -21,7 +21,7 @@ class PEER_COLLAB_EVENT_DATA extends Win32Struct
     static packingSize => 8
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     eventType {
@@ -30,7 +30,7 @@ class PEER_COLLAB_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_WATCHLIST_CHANGED_DATA}
      */
     watchListChangedData{
@@ -42,7 +42,7 @@ class PEER_COLLAB_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_PRESENCE_CHANGED_DATA}
      */
     presenceChangedData{
@@ -54,7 +54,7 @@ class PEER_COLLAB_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_APPLICATION_CHANGED_DATA}
      */
     applicationChangedData{
@@ -66,7 +66,7 @@ class PEER_COLLAB_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_OBJECT_CHANGED_DATA}
      */
     objectChangedData{
@@ -78,7 +78,7 @@ class PEER_COLLAB_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_ENDPOINT_CHANGED_DATA}
      */
     endpointChangedData{
@@ -90,7 +90,7 @@ class PEER_COLLAB_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_PEOPLE_NEAR_ME_CHANGED_DATA}
      */
     peopleNearMeChangedData{
@@ -102,7 +102,7 @@ class PEER_COLLAB_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_REQUEST_STATUS_CHANGED_DATA}
      */
     requestStatusChangedData{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_COLLAB_EVENT_REGISTRATION.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_COLLAB_EVENT_REGISTRATION.ahk
@@ -15,7 +15,7 @@ class PEER_COLLAB_EVENT_REGISTRATION extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_collab_event_type">PEER_COLLAB_EVENT_TYPE</a> enumeration value that specifies the type of peer collaboration network event for which to register.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     eventType {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_CONNECTION_INFO.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_CONNECTION_INFO.ahk
@@ -64,7 +64,7 @@ class PEER_CONNECTION_INFO extends Win32Struct
 
     /**
      * Specifies the address of a remote node. The address is contained in a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_address">PEER_ADDRESS</a> structure.
-     * @deprecated
+     * @deprecated 
      * @type {PEER_ADDRESS}
      */
     address{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_CONTACT.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_CONTACT.ahk
@@ -70,7 +70,7 @@ class PEER_CONTACT extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_watch_permission">PEER_WATCH_PERMISSION</a> enumeration value that specifies the watch permissions for this contact.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     WatcherPermissions {
@@ -80,7 +80,7 @@ class PEER_CONTACT extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_data">PEER_DATA</a> structure that contains the security credentials for the contact in an opaque byte buffer.
-     * @deprecated
+     * @deprecated 
      * @type {PEER_DATA}
      */
     credentials{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_ENDPOINT.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_ENDPOINT.ahk
@@ -26,7 +26,7 @@ class PEER_ENDPOINT extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_address">PEER_ADDRESS</a> structure that contains the IPv6 network address of the endpoint.
-     * @deprecated
+     * @deprecated 
      * @type {PEER_ADDRESS}
      */
     address{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_APPLICATION_CHANGED_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_APPLICATION_CHANGED_DATA.ahk
@@ -26,7 +26,7 @@ class PEER_EVENT_APPLICATION_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_contact">PEER_CONTACT</a> structure that contains the peer contact information for a contact whose change in application  raised the event.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_CONTACT>}
      */
     pContact {
@@ -36,7 +36,7 @@ class PEER_EVENT_APPLICATION_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_endpoint">PEER_ENDPOINT</a> structure that contains the peer endpoint information for a contact whose change in application information raised the event.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_ENDPOINT>}
      */
     pEndpoint {
@@ -46,7 +46,7 @@ class PEER_EVENT_APPLICATION_CHANGED_DATA extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_change_type">PEER_CHANGE_TYPE</a> enumeration value that specifies the type of application change that occurred.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     changeType {
@@ -56,7 +56,7 @@ class PEER_EVENT_APPLICATION_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_application">PEER_APPLICATION</a> structure that contains the changed application information.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_APPLICATION>}
      */
     pApplication {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_CONNECTION_CHANGE_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_CONNECTION_CHANGE_DATA.ahk
@@ -63,7 +63,7 @@ class PEER_EVENT_CONNECTION_CHANGE_DATA extends Win32Struct
      * </td>
      * </tr>
      * </table>
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     status {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_ENDPOINT_CHANGED_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_ENDPOINT_CHANGED_DATA.ahk
@@ -20,7 +20,7 @@ class PEER_EVENT_ENDPOINT_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_contact">PEER_CONTACT</a> structure that contains the contact information for the contact who changed endpoints.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_CONTACT>}
      */
     pContact {
@@ -30,7 +30,7 @@ class PEER_EVENT_ENDPOINT_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_endpoint">PEER_ENDPOINT</a> structure that contains the new active endpoint for  the peer specified in <i>pContact</i>.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_ENDPOINT>}
      */
     pEndpoint {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_INCOMING_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_INCOMING_DATA.ahk
@@ -43,7 +43,7 @@ class PEER_EVENT_INCOMING_DATA extends Win32Struct
 
     /**
      * Specifies the actual data received.
-     * @deprecated
+     * @deprecated 
      * @type {PEER_DATA}
      */
     data{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_MEMBER_CHANGE_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_MEMBER_CHANGE_DATA.ahk
@@ -24,7 +24,7 @@ class PEER_EVENT_MEMBER_CHANGE_DATA extends Win32Struct
 
     /**
      * <b>PEER_MEMBER_CHANGE_TYPE</b> enumeration value that specifies the change event that occurred, such as a member joining or leaving.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     changeType {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_NODE_CHANGE_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_NODE_CHANGE_DATA.ahk
@@ -61,7 +61,7 @@ class PEER_EVENT_NODE_CHANGE_DATA extends Win32Struct
      * </td>
      * </tr>
      * </table>
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     changeType {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_OBJECT_CHANGED_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_OBJECT_CHANGED_DATA.ahk
@@ -26,7 +26,7 @@ class PEER_EVENT_OBJECT_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_contact">PEER_CONTACT</a> structure that contains the peer contact information for the contact whose peer object data changed.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_CONTACT>}
      */
     pContact {
@@ -36,7 +36,7 @@ class PEER_EVENT_OBJECT_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_endpoint">PEER_ENDPOINT</a> structure that contains the peer endpoint information for the contact whose peer object data changed.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_ENDPOINT>}
      */
     pEndpoint {
@@ -46,7 +46,7 @@ class PEER_EVENT_OBJECT_CHANGED_DATA extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_change_type">PEER_CHANGE_TYPE</a> enumeration value that specifies the type of change that occurred.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     changeType {
@@ -56,7 +56,7 @@ class PEER_EVENT_OBJECT_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_object">PEER_OBJECT</a> structure that contains the peer object data whose change raised the event. This most commonly occurs when a new peer object is received by the peer.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_OBJECT>}
      */
     pObject {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_PEOPLE_NEAR_ME_CHANGED_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_PEOPLE_NEAR_ME_CHANGED_DATA.ahk
@@ -22,7 +22,7 @@ class PEER_EVENT_PEOPLE_NEAR_ME_CHANGED_DATA extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_change_type">PEER_CHANGE_TYPE</a> enumeration value that describes the type of change that occurred for a contact available on the local subnet.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     changeType {
@@ -32,7 +32,7 @@ class PEER_EVENT_PEOPLE_NEAR_ME_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_people_near_me">PEER_PEOPLE_NEAR_ME</a> structure that contains the peer endpoint information for the contact on the subnet that raised the change event.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_PEOPLE_NEAR_ME>}
      */
     pPeopleNearMe {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_PRESENCE_CHANGED_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_PRESENCE_CHANGED_DATA.ahk
@@ -15,7 +15,7 @@ class PEER_EVENT_PRESENCE_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_contact">PEER_CONTACT</a> structure that contains the peer contact information for the contact whose change in presence raised the event.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_CONTACT>}
      */
     pContact {
@@ -25,7 +25,7 @@ class PEER_EVENT_PRESENCE_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_endpoint">PEER_ENDPOINT</a> structure that contains the peer endpoint information for the contact whose change in presence raised the event.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_ENDPOINT>}
      */
     pEndpoint {
@@ -35,7 +35,7 @@ class PEER_EVENT_PRESENCE_CHANGED_DATA extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_change_type">PEER_CHANGE_TYPE</a> enumeration value that specifies the type of presence change that occurred.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     changeType {
@@ -45,7 +45,7 @@ class PEER_EVENT_PRESENCE_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_presence_info">PEER_PRESENCE_INFO</a> structure that contains the updated presence information for the endpoint of the contact whose change in presence raised the event.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_PRESENCE_INFO>}
      */
     pPresenceInfo {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_RECORD_CHANGE_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_RECORD_CHANGE_DATA.ahk
@@ -24,7 +24,7 @@ class PEER_EVENT_RECORD_CHANGE_DATA extends Win32Struct
 
     /**
      * Specifies the type of change to a record or record type.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     changeType {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_REQUEST_STATUS_CHANGED_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_REQUEST_STATUS_CHANGED_DATA.ahk
@@ -20,7 +20,7 @@ class PEER_EVENT_REQUEST_STATUS_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_endpoint">PEER_ENDPOINT</a> structure that contains the peer endpoint information for the contact whose change in request status raised the event.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_ENDPOINT>}
      */
     pEndpoint {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_WATCHLIST_CHANGED_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_EVENT_WATCHLIST_CHANGED_DATA.ahk
@@ -22,7 +22,7 @@ class PEER_EVENT_WATCHLIST_CHANGED_DATA extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_contact">PEER_CONTACT</a> structure that contains information about the peer contact in the watchlist whose change raised the event.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_CONTACT>}
      */
     pContact {
@@ -32,7 +32,7 @@ class PEER_EVENT_WATCHLIST_CHANGED_DATA extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_change_type">PEER_CHANGE_TYPE</a> enumeration value that specifies the type of change that occurred in the peer's watchlist.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     changeType {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_GRAPH_EVENT_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_GRAPH_EVENT_DATA.ahk
@@ -21,7 +21,7 @@ class PEER_GRAPH_EVENT_DATA extends Win32Struct
 
     /**
      * The type of peer event this data corresponds to. Must be one of the <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_graph_event_type">PEER_GRAPH_EVENT_TYPE</a> values. The members that remain are given values based on the peer event type that has occurred.  Not all members contain data.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     eventType {
@@ -30,7 +30,7 @@ class PEER_GRAPH_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     dwStatus {
@@ -39,7 +39,7 @@ class PEER_GRAPH_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_INCOMING_DATA}
      */
     incomingData{
@@ -51,7 +51,7 @@ class PEER_GRAPH_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_RECORD_CHANGE_DATA}
      */
     recordChangeData{
@@ -63,7 +63,7 @@ class PEER_GRAPH_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_CONNECTION_CHANGE_DATA}
      */
     connectionChangeData{
@@ -75,7 +75,7 @@ class PEER_GRAPH_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_NODE_CHANGE_DATA}
      */
     nodeChangeData{
@@ -87,7 +87,7 @@ class PEER_GRAPH_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_SYNCHRONIZED_DATA}
      */
     synchronizedData{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_GRAPH_EVENT_REGISTRATION.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_GRAPH_EVENT_REGISTRATION.ahk
@@ -15,7 +15,7 @@ class PEER_GRAPH_EVENT_REGISTRATION extends Win32Struct
 
     /**
      * Specifies the type of peer event the application requires notifications for. The per events that can be registered for are specified by the <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_graph_event_type">PEER_GRAPH_EVENT_TYPE</a> enumeration.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     eventType {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_GROUP_EVENT_DATA.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_GROUP_EVENT_DATA.ahk
@@ -19,7 +19,7 @@ class PEER_GROUP_EVENT_DATA extends Win32Struct
     static packingSize => 8
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     eventType {
@@ -28,7 +28,7 @@ class PEER_GROUP_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     dwStatus {
@@ -37,7 +37,7 @@ class PEER_GROUP_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_INCOMING_DATA}
      */
     incomingData{
@@ -49,7 +49,7 @@ class PEER_GROUP_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_RECORD_CHANGE_DATA}
      */
     recordChangeData{
@@ -61,7 +61,7 @@ class PEER_GROUP_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_CONNECTION_CHANGE_DATA}
      */
     connectionChangeData{
@@ -73,7 +73,7 @@ class PEER_GROUP_EVENT_DATA extends Win32Struct
     }
 
     /**
-     * @deprecated
+     * @deprecated 
      * @type {PEER_EVENT_MEMBER_CHANGE_DATA}
      */
     memberChangeData{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_GROUP_EVENT_REGISTRATION.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_GROUP_EVENT_REGISTRATION.ahk
@@ -15,7 +15,7 @@ class PEER_GROUP_EVENT_REGISTRATION extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_group_event_type">PEER_GROUP_EVENT_TYPE</a> that specifies the peer group event type to register for.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     eventType {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_GROUP_PROPERTIES.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_GROUP_PROPERTIES.ahk
@@ -125,7 +125,7 @@ class PEER_GROUP_PROPERTIES extends Win32Struct
 
     /**
      * <b>Windows Vista or later.</b> GUID value that indicates the peer group role for which the password is required for authentication.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<Guid>}
      */
     groupPasswordRole {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_INVITATION.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_INVITATION.ahk
@@ -30,7 +30,7 @@ class PEER_INVITATION extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_data">PEER_DATA</a> structure that contains opaque data describing possible additional application-specific settings (for example, an address and port on which the activity will occur, or a specific video codec to use). This data is limited to 16K.
-     * @deprecated
+     * @deprecated 
      * @type {PEER_DATA}
      */
     applicationData{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_INVITATION_INFO.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_INVITATION_INFO.ahk
@@ -277,7 +277,7 @@ class PEER_INVITATION_INFO extends Win32Struct
 
     /**
      * <b>Windows Vista or later.</b>           The <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_group_authentication_scheme">PEER_GROUP_AUTHENTICATION_SCHEME</a> enumeration value that indicates the type of authentication used to validate the peer group invitee.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     authScheme {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_INVITATION_RESPONSE.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_INVITATION_RESPONSE.ahk
@@ -15,7 +15,7 @@ class PEER_INVITATION_RESPONSE extends Win32Struct
 
     /**
      * [PEER_INVITATION_RESPONSE_TYPE](./ne-p2p-peer_invitation_response_type.md) enumeration value that specifies the action the peer takes in response to the invitation.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     action {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_NODE_INFO.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_NODE_INFO.ahk
@@ -51,7 +51,7 @@ class PEER_NODE_INFO extends Win32Struct
 
     /**
      * Points to  an array of <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_address">PEER_ADDRESS</a> structures that indicate which addresses and  ports this instance is listening to for group traffic. This member is required and has no default value.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PEER_ADDRESS>}
      */
     pAddresses {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_OBJECT.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_OBJECT.ahk
@@ -36,7 +36,7 @@ class PEER_OBJECT extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_data">PEER_DATA</a> structure that contains information which describes the peer object.
-     * @deprecated
+     * @deprecated 
      * @type {PEER_DATA}
      */
     data{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_PEOPLE_NEAR_ME.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_PEOPLE_NEAR_ME.ahk
@@ -29,7 +29,7 @@ class PEER_PEOPLE_NEAR_ME extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_endpoint">PEER_ENDPOINT</a> structure that contains the IPv6 network address of the peer whose endpoint shares the same subnet.
-     * @deprecated
+     * @deprecated 
      * @type {PEER_ENDPOINT}
      */
     endpoint{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_PNRP_ENDPOINT_INFO.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_PNRP_ENDPOINT_INFO.ahk
@@ -52,7 +52,7 @@ class PEER_PNRP_ENDPOINT_INFO extends Win32Struct
 
     /**
      * Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_data">PEER_DATA</a> structure that contains application-specific data for the peer endpoint (such as a message or an image).
-     * @deprecated
+     * @deprecated 
      * @type {PEER_DATA}
      */
     payload{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_PNRP_REGISTRATION_INFO.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_PNRP_REGISTRATION_INFO.ahk
@@ -70,7 +70,7 @@ class PEER_PNRP_REGISTRATION_INFO extends Win32Struct
 
     /**
      * A <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_data">PEER_DATA</a> structure that contains a pointer to an opaque byte buffer containing application-specific data for the peer endpoint (such as a message or an image).
-     * @deprecated
+     * @deprecated 
      * @type {PEER_DATA}
      */
     payload{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_PRESENCE_INFO.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_PRESENCE_INFO.ahk
@@ -20,7 +20,7 @@ class PEER_PRESENCE_INFO extends Win32Struct
 
     /**
      * <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ne-p2p-peer_presence_status">PEER_PRESENCE_STATUS</a> enumeration value that indicates the current availability or level of participation by the peer in a peer collaboration network.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     status {

--- a/Windows/Win32/NetworkManagement/P2P/PEER_RECORD.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_RECORD.ahk
@@ -157,7 +157,7 @@ class PEER_RECORD extends Win32Struct
 
     /**
      * Specifies the security data contained in a  <a href="https://docs.microsoft.com/windows/desktop/api/p2p/ns-p2p-peer_data">PEER_DATA</a> structure. The Graphing API uses this member, and provides  the security provider with a place to store security data, for example, a signature.  The Grouping API cannot modify this member.
-     * @deprecated
+     * @deprecated 
      * @type {PEER_DATA}
      */
     securityData{
@@ -170,7 +170,7 @@ class PEER_RECORD extends Win32Struct
 
     /**
      * Specifies the actual data that this record contains.
-     * @deprecated
+     * @deprecated 
      * @type {PEER_DATA}
      */
     data{

--- a/Windows/Win32/NetworkManagement/P2P/PEER_SECURITY_INTERFACE.ahk
+++ b/Windows/Win32/NetworkManagement/P2P/PEER_SECURITY_INTERFACE.ahk
@@ -76,7 +76,7 @@ class PEER_SECURITY_INTERFACE extends Win32Struct
 
     /**
      * Pointer to a callback function that is called when a record requires validation. This member is optional and can be <b>NULL</b>. If <b>pfnSecureRecord</b> is <b>NULL</b>, this member must also be <b>NULL</b>.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PFNPEER_VALIDATE_RECORD>}
      */
     pfnValidateRecord {
@@ -86,7 +86,7 @@ class PEER_SECURITY_INTERFACE extends Win32Struct
 
     /**
      * Pointer to a callback function that is called when a record must be secured. This member is optional and can be <b>NULL</b>. If <b>pfnValidateRecord</b> is <b>NULL</b>, this member must also be <b>NULL</b>.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PFNPEER_SECURE_RECORD>}
      */
     pfnSecureRecord {
@@ -96,7 +96,7 @@ class PEER_SECURITY_INTERFACE extends Win32Struct
 
     /**
      * Pointer to a callback function used to free any data allocated by the callback pointed to by <b>pfnSecureRecord</b>. This member is optional and can be <b>NULL</b>.
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PFNPEER_FREE_SECURITY_DATA>}
      */
     pfnFreeSecurityData {
@@ -106,7 +106,7 @@ class PEER_SECURITY_INTERFACE extends Win32Struct
 
     /**
      * 
-     * @deprecated
+     * @deprecated 
      * @type {Pointer<PFNPEER_ON_PASSWORD_AUTH_FAILED>}
      */
     pfnAuthFailed {

--- a/Windows/Win32/Networking/WinSock/ADDRINFOEX2A.ahk
+++ b/Windows/Win32/Networking/WinSock/ADDRINFOEX2A.ahk
@@ -7,7 +7,7 @@
  * @namespace Windows.Win32.Networking.WinSock
  * @version v4.0.30319
  * @charset ANSI
- * @deprecated
+ * @deprecated ADDRINFOEX2W
  */
 class ADDRINFOEX2A extends Win32Struct
 {

--- a/Windows/Win32/Networking/WinSock/ADDRINFOEXA.ahk
+++ b/Windows/Win32/Networking/WinSock/ADDRINFOEXA.ahk
@@ -7,7 +7,7 @@
  * @namespace Windows.Win32.Networking.WinSock
  * @version v4.0.30319
  * @charset ANSI
- * @deprecated
+ * @deprecated ADDRINFOEXW
  */
 class ADDRINFOEXA extends Win32Struct
 {

--- a/Windows/Win32/Networking/WinSock/Apis.ahk
+++ b/Windows/Win32/Networking/WinSock/Apis.ahk
@@ -8042,7 +8042,7 @@ class WinSock {
      * <b>inet_addr</b> returns the value <b>INADDR_ANY</b>. If <b>NULL</b> is passed in the <i>cp</i> parameter, then 
      * <b>inet_addr</b> returns the value <b>INADDR_NONE</b>.
      * @see https://docs.microsoft.com/windows/win32/api//winsock/nf-winsock-inet_addr
-     * @deprecated
+     * @deprecated inet_pton() or InetPton()
      * @since windows8.1
      */
     static inet_addr(cp) {
@@ -8063,7 +8063,7 @@ class WinSock {
      * @returns {PSTR} If no error occurs, 
      * <b>inet_ntoa</b> returns a character pointer to a static buffer containing the text address in standard ".'' notation. Otherwise, it returns <b>NULL</b>.
      * @see https://docs.microsoft.com/windows/win32/api//winsock/nf-winsock-inet_ntoa
-     * @deprecated
+     * @deprecated inet_ntop() or InetNtop()
      * @since windows8.1
      */
     static inet_ntoa(in_R) {
@@ -10241,7 +10241,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock/nf-winsock-gethostbyaddr
-     * @deprecated
+     * @deprecated getnameinfo() or GetNameInfoW()
      * @since windows8.1
      */
     static gethostbyaddr(addr, len, type) {
@@ -10372,7 +10372,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock/nf-winsock-gethostbyname
-     * @deprecated
+     * @deprecated getaddrinfo() or GetAddrInfoW()
      * @since windows8.1
      */
     static gethostbyname(name) {
@@ -11211,7 +11211,7 @@ class WinSock {
      * This function has been removed in compliance with the Windows Sockets 2 specification, revision 2.2.0.
      * @returns {BOOL} 
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsaisblocking
-     * @deprecated
+     * @deprecated Winsock 2
      */
     static WSAIsBlocking() {
         A_LastError := 0
@@ -11227,7 +11227,7 @@ class WinSock {
      * This function has been removed in compliance with the Windows Sockets 2 specification, revision 2.2.0.
      * @returns {Integer} 
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsaunhookblockinghook
-     * @deprecated
+     * @deprecated Winsock 2
      */
     static WSAUnhookBlockingHook() {
         A_LastError := 0
@@ -11244,7 +11244,7 @@ class WinSock {
      * @param {Pointer<FARPROC>} lpBlockFunc 
      * @returns {Pointer<FARPROC>} 
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsasetblockinghook
-     * @deprecated
+     * @deprecated Winsock 2
      */
     static WSASetBlockingHook(lpBlockFunc) {
         A_LastError := 0
@@ -11260,7 +11260,7 @@ class WinSock {
      * The WSACancelBlockingCall function has been removed in compliance with the Windows Sockets 2 specification, revision 2.2.0.
      * @returns {Integer} 
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsacancelblockingcall
-     * @deprecated
+     * @deprecated Winsock 2
      */
     static WSACancelBlockingCall() {
         A_LastError := 0
@@ -11408,7 +11408,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock/nf-winsock-wsaasyncgetservbyname
-     * @deprecated
+     * @deprecated getservbyname()
      * @since windows5.0
      */
     static WSAAsyncGetServByName(hWnd, wMsg, name, proto, buf, buflen) {
@@ -11562,7 +11562,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock/nf-winsock-wsaasyncgetservbyport
-     * @deprecated
+     * @deprecated getservbyport()
      * @since windows5.0
      */
     static WSAAsyncGetServByPort(hWnd, wMsg, port, proto, buf, buflen) {
@@ -11712,7 +11712,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock/nf-winsock-wsaasyncgetprotobyname
-     * @deprecated
+     * @deprecated getprotobyname()
      * @since windows5.0
      */
     static WSAAsyncGetProtoByName(hWnd, wMsg, name, buf, buflen) {
@@ -11862,7 +11862,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock/nf-winsock-wsaasyncgetprotobynumber
-     * @deprecated
+     * @deprecated getprotobynumber()
      * @since windows5.0
      */
     static WSAAsyncGetProtoByNumber(hWnd, wMsg, number, buf, buflen) {
@@ -12007,7 +12007,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock/nf-winsock-wsaasyncgethostbyname
-     * @deprecated
+     * @deprecated GetAddrInfoExW()
      * @since windows5.0
      */
     static WSAAsyncGetHostByName(hWnd, wMsg, name, buf, buflen) {
@@ -12159,7 +12159,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock/nf-winsock-wsaasyncgethostbyaddr
-     * @deprecated
+     * @deprecated getnameinfo() or GetNameInfoW()
      * @since windows5.0
      */
     static WSAAsyncGetHostByAddr(hWnd, wMsg, addr, len, type, buf, buflen) {
@@ -12250,7 +12250,7 @@ class WinSock {
      * <a href="/windows/desktop/WinSock/windows-sockets-error-codes-2">WSAEALREADY</a>, since in both cases the error indicates that there is no asynchronous operation in progress with the indicated handle. (Trivial exception: zero is always an invalid asynchronous task handle.) The Windows Sockets specification does not prescribe how a conformant Windows Sockets provider should distinguish between the two cases. For maximum portability, a Windows Sockets application should treat the two errors as equivalent.</div>
      * <div> </div>
      * @see https://docs.microsoft.com/windows/win32/api//winsock/nf-winsock-wsacancelasyncrequest
-     * @deprecated
+     * @deprecated 
      * @since windows5.0
      */
     static WSACancelAsyncRequest(hAsyncTaskHandle) {
@@ -12442,7 +12442,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock/nf-winsock-wsaasyncselect
-     * @deprecated
+     * @deprecated WSAEventSelect()
      * @since windows5.0
      */
     static WSAAsyncSelect(s, hWnd, wMsg, lEvent) {
@@ -13222,7 +13222,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsaconnectbynamea
-     * @deprecated
+     * @deprecated WSAConnectByNameW()
      * @since windows8.1
      */
     static WSAConnectByNameA(s, nodename, servicename, LocalAddressLength, LocalAddress, RemoteAddressLength, RemoteAddress, timeout) {
@@ -13547,7 +13547,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsaduplicatesocketa
-     * @deprecated
+     * @deprecated WSADuplicateSocketW()
      * @since windows8.1
      */
     static WSADuplicateSocketA(s, dwProcessId, lpProtocolInfo) {
@@ -13867,7 +13867,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsaenumprotocolsa
-     * @deprecated
+     * @deprecated WSAEnumProtocolsW()
      * @since windows8.1
      */
     static WSAEnumProtocolsA(lpiProtocols, lpProtocolBuffer, lpdwBufferLength) {
@@ -14440,7 +14440,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsagetqosbyname
-     * @deprecated
+     * @deprecated 
      * @since windows5.0
      */
     static WSAGetQOSByName(s, lpQOSName, lpQOS) {
@@ -15524,7 +15524,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsarecvdisconnect
-     * @deprecated
+     * @deprecated WSARecv()
      * @since windows5.0
      */
     static WSARecvDisconnect(s, lpInboundDisconnectData) {
@@ -16425,7 +16425,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsasenddisconnect
-     * @deprecated
+     * @deprecated WSASend()
      * @since windows5.0
      */
     static WSASendDisconnect(s, lpOutboundDisconnectData) {
@@ -17496,7 +17496,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsasocketa
-     * @deprecated
+     * @deprecated WSASocketW()
      * @since windows8.1
      */
     static WSASocketA(af, type, protocol, lpProtocolInfo, g, dwFlags) {
@@ -18372,7 +18372,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsaaddresstostringa
-     * @deprecated
+     * @deprecated WSAAddressToStringW()
      * @since windows8.1
      */
     static WSAAddressToStringA(lpsaAddress, dwAddressLength, lpProtocolInfo, lpszAddressString, lpdwAddressStringLength) {
@@ -18537,7 +18537,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsastringtoaddressa
-     * @deprecated
+     * @deprecated WSAStringToAddressW()
      * @since windows8.1
      */
     static WSAStringToAddressA(AddressString, AddressFamily, lpProtocolInfo, lpAddress, lpAddressLength) {
@@ -18900,7 +18900,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsalookupservicebegina
-     * @deprecated
+     * @deprecated WSALookupServiceBeginW()
      * @since windows8.1
      */
     static WSALookupServiceBeginA(lpqsRestrictions, dwControlFlags, lphLookup) {
@@ -19489,7 +19489,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsalookupservicenexta
-     * @deprecated
+     * @deprecated WSALookupServiceNextW()
      * @since windows8.1
      */
     static WSALookupServiceNextA(hLookup, dwControlFlags, lpdwBufferLength, lpqsResults) {
@@ -20134,7 +20134,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsainstallserviceclassa
-     * @deprecated
+     * @deprecated WSAInstallServiceClassW()
      * @since windows5.0
      */
     static WSAInstallServiceClassA(lpServiceClassInfo) {
@@ -20473,7 +20473,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsagetserviceclassinfoa
-     * @deprecated
+     * @deprecated WSAGetServiceClassInfoW()
      * @since windows5.0
      */
     static WSAGetServiceClassInfoA(lpProviderId, lpServiceClassId, lpdwBufSize, lpServiceClassInfo) {
@@ -20665,7 +20665,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsaenumnamespaceprovidersa
-     * @deprecated
+     * @deprecated WSAEnumNameSpaceProvidersW()
      * @since windows8.1
      */
     static WSAEnumNameSpaceProvidersA(lpdwBufferLength, lpnspBuffer) {
@@ -20802,7 +20802,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsaenumnamespaceprovidersexa
-     * @deprecated
+     * @deprecated WSAEnumNameSpaceProvidersW()
      * @since windows8.1
      */
     static WSAEnumNameSpaceProvidersExA(lpdwBufferLength, lpnspBuffer) {
@@ -20990,7 +20990,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsagetserviceclassnamebyclassida
-     * @deprecated
+     * @deprecated WSAGetServiceClassNameByClassIdW()
      * @since windows5.0
      */
     static WSAGetServiceClassNameByClassIdA(lpServiceClassId, lpszServiceClassName, lpdwBufferLength) {
@@ -21243,7 +21243,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock2/nf-winsock2-wsasetservicea
-     * @deprecated
+     * @deprecated WSASetServiceW()
      * @since windows8.1
      */
     static WSASetServiceA(lpqsRegInfo, essoperation, dwControlFlags) {
@@ -22646,7 +22646,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//winsock/nf-winsock-wsarecvex
-     * @deprecated
+     * @deprecated WSARecv()
      * @since windows5.0
      */
     static WSARecvEx(s, buf, len, flags) {
@@ -26712,7 +26712,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//ws2tcpip/nf-ws2tcpip-getaddrinfoexa
-     * @deprecated
+     * @deprecated GetAddrInfoExW()
      * @since windows6.0.6000
      */
     static GetAddrInfoExA(pName, pServiceName, dwNameSpace, lpNspId, hints, ppResult, timeout, lpOverlapped, lpCompletionRoutine, lpNameHandle) {
@@ -27320,7 +27320,7 @@ class WinSock {
      * </tr>
      * </table>
      * @see https://docs.microsoft.com/windows/win32/api//ws2tcpip/nf-ws2tcpip-setaddrinfoexa
-     * @deprecated
+     * @deprecated SetAddrInfoExW()
      * @since windows8.1
      */
     static SetAddrInfoExA(pName, pServiceName, pAddresses, dwAddressCount, lpBlob, dwFlags, dwNameSpace, lpNspId, timeout, lpOverlapped, lpCompletionRoutine, lpNameHandle) {
@@ -27556,7 +27556,7 @@ class WinSock {
      * <b>addrinfoex</b> structure or structures is also freed.
      * @returns {String} Nothing - always returns an empty string
      * @see https://docs.microsoft.com/windows/win32/api//ws2tcpip/nf-ws2tcpip-freeaddrinfoex
-     * @deprecated
+     * @deprecated FreeAddrInfoExW()
      * @since windows8.1
      */
     static FreeAddrInfoEx(pAddrInfoEx) {

--- a/Windows/Win32/Networking/WinSock/WSANAMESPACE_INFOA.ahk
+++ b/Windows/Win32/Networking/WinSock/WSANAMESPACE_INFOA.ahk
@@ -26,7 +26,7 @@
  * @namespace Windows.Win32.Networking.WinSock
  * @version v4.0.30319
  * @charset ANSI
- * @deprecated
+ * @deprecated WSANAMESPACE_INFOW
  */
 class WSANAMESPACE_INFOA extends Win32Struct
 {

--- a/Windows/Win32/Networking/WinSock/WSANAMESPACE_INFOEXA.ahk
+++ b/Windows/Win32/Networking/WinSock/WSANAMESPACE_INFOEXA.ahk
@@ -29,7 +29,7 @@
  * @namespace Windows.Win32.Networking.WinSock
  * @version v4.0.30319
  * @charset ANSI
- * @deprecated
+ * @deprecated WSANAMESPACE_INFOEXW
  */
 class WSANAMESPACE_INFOEXA extends Win32Struct
 {

--- a/Windows/Win32/Networking/WinSock/WSANSCLASSINFOA.ahk
+++ b/Windows/Win32/Networking/WinSock/WSANSCLASSINFOA.ahk
@@ -19,7 +19,7 @@
  * @namespace Windows.Win32.Networking.WinSock
  * @version v4.0.30319
  * @charset ANSI
- * @deprecated
+ * @deprecated WSANSCLASSINFOW
  */
 class WSANSCLASSINFOA extends Win32Struct
 {

--- a/Windows/Win32/Networking/WinSock/WSAPROTOCOL_INFOA.ahk
+++ b/Windows/Win32/Networking/WinSock/WSAPROTOCOL_INFOA.ahk
@@ -13,7 +13,7 @@
  * @namespace Windows.Win32.Networking.WinSock
  * @version v4.0.30319
  * @charset ANSI
- * @deprecated
+ * @deprecated WSAPROTOCOL_INFOW
  */
 class WSAPROTOCOL_INFOA extends Win32Struct
 {

--- a/Windows/Win32/Networking/WinSock/WSAQUERYSET2A.ahk
+++ b/Windows/Win32/Networking/WinSock/WSAQUERYSET2A.ahk
@@ -22,7 +22,7 @@
  * @namespace Windows.Win32.Networking.WinSock
  * @version v4.0.30319
  * @charset ANSI
- * @deprecated
+ * @deprecated WSAQUERYSET2W
  */
 class WSAQUERYSET2A extends Win32Struct
 {

--- a/Windows/Win32/Networking/WinSock/WSAQUERYSETA.ahk
+++ b/Windows/Win32/Networking/WinSock/WSAQUERYSETA.ahk
@@ -22,7 +22,7 @@
  * @namespace Windows.Win32.Networking.WinSock
  * @version v4.0.30319
  * @charset ANSI
- * @deprecated
+ * @deprecated WSAQUERYSETW
  */
 class WSAQUERYSETA extends Win32Struct
 {

--- a/Windows/Win32/Networking/WinSock/WSASERVICECLASSINFOA.ahk
+++ b/Windows/Win32/Networking/WinSock/WSASERVICECLASSINFOA.ahk
@@ -12,7 +12,7 @@
  * @namespace Windows.Win32.Networking.WinSock
  * @version v4.0.30319
  * @charset ANSI
- * @deprecated
+ * @deprecated WSASERVICECLASSINFOW
  */
 class WSASERVICECLASSINFOA extends Win32Struct
 {

--- a/Windows/Win32/Security/Isolation/Apis.ahk
+++ b/Windows/Win32/Security/Isolation/Apis.ahk
@@ -49,7 +49,7 @@ class Isolation {
      * 
      * @param {Pointer<Void>} Reserved 
      * @returns {BOOL} 
-     * @deprecated
+     * @deprecated IsProcessInWDAGContainer is deprecated and might not work on all platforms. For more info, see MSDN.
      */
     static IsProcessInWDAGContainer(Reserved) {
         ReservedMarshal := Reserved is VarRef ? "ptr" : "ptr"
@@ -64,7 +64,7 @@ class Isolation {
     /**
      * 
      * @returns {BOOL} 
-     * @deprecated
+     * @deprecated IsProcessInIsolatedContainer is deprecated and might not work on all platforms. For more info, see MSDN.
      */
     static IsProcessInIsolatedContainer() {
         result := DllCall("api-ms-win-security-isolatedcontainer-l1-1-0.dll\IsProcessInIsolatedContainer", "int*", &isProcessInIsolatedContainer := 0, "int")

--- a/Windows/Win32/Storage/FileHistory/Apis.ahk
+++ b/Windows/Win32/Storage/FileHistory/Apis.ahk
@@ -229,7 +229,7 @@ class FileHistory {
      * If the File History Service is not started yet and this parameter is <b>FALSE</b>, this function fails and returns an unsuccessful <b>HRESULT</b> value.
      * @returns {FH_SERVICE_PIPE_HANDLE} On successful return, this parameter contains a non-NULL handle representing a newly opened communication channel to the File History Service.
      * @see https://docs.microsoft.com/windows/win32/api//fhsvcctl/nf-fhsvcctl-fhserviceopenpipe
-     * @deprecated
+     * @deprecated FhServiceOpenPipe is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows8.0
      */
     static FhServiceOpenPipe(StartServiceIfStopped) {
@@ -246,7 +246,7 @@ class FileHistory {
      * @param {FH_SERVICE_PIPE_HANDLE} Pipe The communication channel handle returned by an earlier <a href="https://docs.microsoft.com/windows/desktop/api/fhsvcctl/nf-fhsvcctl-fhserviceopenpipe">FhServiceOpenPipe</a> call.
      * @returns {HRESULT} <b>S_OK</b> on success, or an unsuccessful <b>HRESULT</b> value on failure. Possible unsuccessful <b>HRESULT</b> values include values defined in the FhErrors.h header file.
      * @see https://docs.microsoft.com/windows/win32/api//fhsvcctl/nf-fhsvcctl-fhserviceclosepipe
-     * @deprecated
+     * @deprecated FhServiceClosePipe is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows8.0
      */
     static FhServiceClosePipe(Pipe) {
@@ -267,7 +267,7 @@ class FileHistory {
      * If <b>FALSE</b>, the File History Service is instructed to use normal priority I/O for the immediate backup scheduled by this function. This results in faster backups but negatively affects the responsiveness and performance of user applications.
      * @returns {HRESULT} <b>S_OK</b> on success, or an unsuccessful <b>HRESULT</b> on failure. Possible unsuccessful <b>HRESULT</b> values include values defined in the FhErrors.h header file.
      * @see https://docs.microsoft.com/windows/win32/api//fhsvcctl/nf-fhsvcctl-fhservicestartbackup
-     * @deprecated
+     * @deprecated FhServiceStartBackup is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows8.0
      */
     static FhServiceStartBackup(Pipe, LowPriorityIo) {
@@ -288,7 +288,7 @@ class FileHistory {
      * If <b>FALSE</b>, this function only stops the ongoing backup cycle.
      * @returns {HRESULT} <b>S_OK</b> on success, or an unsuccessful <b>HRESULT</b> value on failure. Possible unsuccessful <b>HRESULT</b> values include values defined in the FhErrors.h header file.
      * @see https://docs.microsoft.com/windows/win32/api//fhsvcctl/nf-fhsvcctl-fhservicestopbackup
-     * @deprecated
+     * @deprecated FhServiceStopBackup is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows8.0
      */
     static FhServiceStopBackup(Pipe, StopTracking) {
@@ -306,7 +306,7 @@ class FileHistory {
      * @param {FH_SERVICE_PIPE_HANDLE} Pipe The communication channel handle returned by an earlier <a href="https://docs.microsoft.com/windows/desktop/api/fhsvcctl/nf-fhsvcctl-fhserviceopenpipe">FhServiceOpenPipe</a> call.
      * @returns {HRESULT} <b>S_OK</b> on success, or an unsuccessful <b>HRESULT</b> value on failure. Possible unsuccessful <b>HRESULT</b> values include values defined in the FhErrors.h header file.
      * @see https://docs.microsoft.com/windows/win32/api//fhsvcctl/nf-fhsvcctl-fhservicereloadconfiguration
-     * @deprecated
+     * @deprecated FhServiceReloadConfiguration is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows8.0
      */
     static FhServiceReloadConfiguration(Pipe) {
@@ -324,7 +324,7 @@ class FileHistory {
      * @param {FH_SERVICE_PIPE_HANDLE} Pipe The communication channel handle returned by an earlier <a href="https://docs.microsoft.com/windows/desktop/api/fhsvcctl/nf-fhsvcctl-fhserviceopenpipe">FhServiceOpenPipe</a> call.
      * @returns {HRESULT} <b>S_OK</b> on success, or an unsuccessful <b>HRESULT</b> value on failure. Possible unsuccessful <b>HRESULT</b> values include values defined in the FhErrors.h header file.
      * @see https://docs.microsoft.com/windows/win32/api//fhsvcctl/nf-fhsvcctl-fhserviceblockbackup
-     * @deprecated
+     * @deprecated FhServiceBlockBackup is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows8.0
      */
     static FhServiceBlockBackup(Pipe) {
@@ -342,7 +342,7 @@ class FileHistory {
      * @param {FH_SERVICE_PIPE_HANDLE} Pipe The communication channel handle returned by an earlier <a href="https://docs.microsoft.com/windows/desktop/api/fhsvcctl/nf-fhsvcctl-fhserviceopenpipe">FhServiceOpenPipe</a> call.
      * @returns {HRESULT} <b>S_OK</b> on success, or an unsuccessful <b>HRESULT</b> value on failure. Possible unsuccessful <b>HRESULT</b> values include values defined in the FhErrors.h header file.
      * @see https://docs.microsoft.com/windows/win32/api//fhsvcctl/nf-fhsvcctl-fhserviceunblockbackup
-     * @deprecated
+     * @deprecated FhServiceUnblockBackup is deprecated and might not work on all platforms. For more info, see MSDN.
      * @since windows8.0
      */
     static FhServiceUnblockBackup(Pipe) {

--- a/Windows/Win32/Storage/FileSystem/Apis.ahk
+++ b/Windows/Win32/Storage/FileSystem/Apis.ahk
@@ -12283,7 +12283,7 @@ class FileSystem {
      * @param {Pointer<Integer>} pcbMetadata 
      * @param {Pointer<Pointer<Integer>>} ppbMetadata 
      * @returns {Integer} 
-     * @deprecated
+     * @deprecated 
      */
     static GetEncryptedFileMetadata(lpFileName, pcbMetadata, ppbMetadata) {
         lpFileName := lpFileName is String ? StrPtr(lpFileName) : lpFileName
@@ -12304,7 +12304,7 @@ class FileSystem {
      * @param {Integer} dwOperation 
      * @param {Pointer<ENCRYPTION_CERTIFICATE_HASH_LIST>} pCertificatesAdded 
      * @returns {Integer} 
-     * @deprecated
+     * @deprecated 
      */
     static SetEncryptedFileMetadata(lpFileName, pbOldMetadata, pbNewMetadata, pOwnerHash, dwOperation, pCertificatesAdded) {
         lpFileName := lpFileName is String ? StrPtr(lpFileName) : lpFileName
@@ -12320,7 +12320,7 @@ class FileSystem {
      * 
      * @param {Pointer<Integer>} pbMetadata 
      * @returns {String} Nothing - always returns an empty string
-     * @deprecated
+     * @deprecated 
      */
     static FreeEncryptedFileMetadata(pbMetadata) {
         pbMetadataMarshal := pbMetadata is VarRef ? "char*" : "ptr"

--- a/Windows/Win32/System/ClrHosting/Apis.ahk
+++ b/Windows/Win32/System/ClrHosting/Apis.ahk
@@ -99,7 +99,7 @@ class ClrHosting {
      * @param {Integer} cchBuffer 
      * @param {Pointer<Integer>} dwLength 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static GetCORSystemDirectory(pbuffer, cchBuffer, dwLength) {
         pbuffer := pbuffer is String ? StrPtr(pbuffer) : pbuffer
@@ -119,7 +119,7 @@ class ClrHosting {
      * @param {Integer} cchBuffer 
      * @param {Pointer<Integer>} dwLength 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static GetCORVersion(pbBuffer, cchBuffer, dwLength) {
         pbBuffer := pbBuffer is String ? StrPtr(pbBuffer) : pbBuffer
@@ -140,7 +140,7 @@ class ClrHosting {
      * @param {Integer} cchBuffer 
      * @param {Pointer<Integer>} dwLength 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static GetFileVersion(szFilename, szBuffer, cchBuffer, dwLength) {
         szFilename := szFilename is String ? StrPtr(szFilename) : szFilename
@@ -161,7 +161,7 @@ class ClrHosting {
      * @param {Integer} cchBuffer 
      * @param {Pointer<Integer>} dwLength 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static GetCORRequiredVersion(pbuffer, cchBuffer, dwLength) {
         pbuffer := pbuffer is String ? StrPtr(pbuffer) : pbuffer
@@ -189,7 +189,7 @@ class ClrHosting {
      * @param {Integer} cchBuffer 
      * @param {Pointer<Integer>} dwlength 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static GetRequestedRuntimeInfo(pExe, pwszVersion, pConfigurationFile, startupFlags, runtimeInfoFlags, pDirectory, dwDirectory, dwDirectoryLength, pVersion, cchBuffer, dwlength) {
         pExe := pExe is String ? StrPtr(pExe) : pExe
@@ -214,7 +214,7 @@ class ClrHosting {
      * @param {PWSTR} pVersion 
      * @param {Integer} cchBuffer 
      * @returns {Integer} 
-     * @deprecated
+     * @deprecated 
      */
     static GetRequestedRuntimeVersion(pExe, pVersion, cchBuffer) {
         pExe := pExe is String ? StrPtr(pExe) : pExe
@@ -238,7 +238,7 @@ class ClrHosting {
      * @param {Pointer<Guid>} riid 
      * @param {Pointer<Pointer<Void>>} ppv 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static CorBindToRuntimeHost(pwszVersion, pwszBuildFlavor, pwszHostConfigFile, pReserved, startupFlags, rclsid, riid, ppv) {
         pwszVersion := pwszVersion is String ? StrPtr(pwszVersion) : pwszVersion
@@ -264,7 +264,7 @@ class ClrHosting {
      * @param {Pointer<Guid>} riid 
      * @param {Pointer<Pointer<Void>>} ppv 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static CorBindToRuntimeEx(pwszVersion, pwszBuildFlavor, startupFlags, rclsid, riid, ppv) {
         pwszVersion := pwszVersion is String ? StrPtr(pwszVersion) : pwszVersion
@@ -288,7 +288,7 @@ class ClrHosting {
      * @param {Pointer<Guid>} riid 
      * @param {Pointer<Pointer<Void>>} ppv 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static CorBindToRuntimeByCfg(pCfgStream, reserved, startupFlags, rclsid, riid, ppv) {
         ppvMarshal := ppv is VarRef ? "ptr*" : "ptr"
@@ -308,7 +308,7 @@ class ClrHosting {
      * @param {Pointer<Guid>} riid 
      * @param {Pointer<Pointer<Void>>} ppv 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static CorBindToRuntime(pwszVersion, pwszBuildFlavor, rclsid, riid, ppv) {
         pwszVersion := pwszVersion is String ? StrPtr(pwszVersion) : pwszVersion
@@ -330,7 +330,7 @@ class ClrHosting {
      * @param {Pointer<Guid>} riid 
      * @param {Pointer<Pointer<Void>>} ppv 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static CorBindToCurrentRuntime(pwszFileName, rclsid, riid, ppv) {
         pwszFileName := pwszFileName is String ? StrPtr(pwszFileName) : pwszFileName
@@ -350,7 +350,7 @@ class ClrHosting {
      * @param {Pointer<Guid>} riid 
      * @param {Pointer<Pointer<Void>>} ppObject 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static ClrCreateManagedInstance(pTypeName, riid, ppObject) {
         pTypeName := pTypeName is String ? StrPtr(pTypeName) : pTypeName
@@ -367,7 +367,7 @@ class ClrHosting {
     /**
      * 
      * @returns {String} Nothing - always returns an empty string
-     * @deprecated
+     * @deprecated 
      */
     static CorMarkThreadInThreadPool() {
         DllCall("MSCorEE.dll\CorMarkThreadInThreadPool")
@@ -380,7 +380,7 @@ class ClrHosting {
      * @param {PWSTR} lpszCmdLine 
      * @param {Integer} nCmdShow 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static RunDll32ShimW(hwnd, hinst, lpszCmdLine, nCmdShow) {
         hwnd := hwnd is Win32Handle ? NumGet(hwnd, "ptr") : hwnd
@@ -402,7 +402,7 @@ class ClrHosting {
      * @param {Pointer<HMODULE>} phModDll 
      * @returns {HRESULT} 
      * @see https://learn.microsoft.com/windows/win32/DevNotes/loadlibraryshim
-     * @deprecated
+     * @deprecated 
      */
     static LoadLibraryShim(szDllName, szVersion, pvReserved, phModDll) {
         szDllName := szDllName is String ? StrPtr(szDllName) : szDllName
@@ -426,7 +426,7 @@ class ClrHosting {
      * @param {PWSTR} szVersion 
      * @param {Pointer<Void>} pvReserved 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static CallFunctionShim(szDllName, szFunctionName, lpvArgument1, lpvArgument2, szVersion, pvReserved) {
         szDllName := szDllName is String ? StrPtr(szDllName) : szDllName
@@ -449,7 +449,7 @@ class ClrHosting {
      * @param {PSTR} pwszProcName 
      * @param {Pointer<Pointer<Void>>} ppv 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static GetRealProcAddress(pwszProcName, ppv) {
         pwszProcName := pwszProcName is String ? StrPtr(pwszProcName) : pwszProcName
@@ -467,7 +467,7 @@ class ClrHosting {
      * 
      * @param {Integer} exitCode 
      * @returns {String} Nothing - always returns an empty string
-     * @deprecated
+     * @deprecated 
      */
     static CorExitProcess(exitCode) {
         DllCall("MSCorEE.dll\CorExitProcess", "int", exitCode)
@@ -480,7 +480,7 @@ class ClrHosting {
      * @param {Integer} iMax 
      * @param {Integer} bQuiet 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static LoadStringRC(iResouceID, szBuffer, iMax, bQuiet) {
         szBuffer := szBuffer is String ? StrPtr(szBuffer) : szBuffer
@@ -501,7 +501,7 @@ class ClrHosting {
      * @param {Integer} bQuiet 
      * @param {Pointer<Integer>} pcwchUsed 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static LoadStringRCEx(lcid, iResouceID, szBuffer, iMax, bQuiet, pcwchUsed) {
         szBuffer := szBuffer is String ? StrPtr(szBuffer) : szBuffer
@@ -521,7 +521,7 @@ class ClrHosting {
      * @param {Pointer<Pointer<FLockClrVersionCallback>>} pBeginHostSetup 
      * @param {Pointer<Pointer<FLockClrVersionCallback>>} pEndHostSetup 
      * @returns {HRESULT} 
-     * @deprecated
+     * @deprecated 
      */
     static LockClrVersion(hostCallback, pBeginHostSetup, pEndHostSetup) {
         pBeginHostSetupMarshal := pBeginHostSetup is VarRef ? "ptr*" : "ptr"
@@ -539,7 +539,7 @@ class ClrHosting {
      * @param {Integer} iDebuggerVersion 
      * @param {PWSTR} szDebuggeeVersion 
      * @returns {IUnknown} 
-     * @deprecated
+     * @deprecated 
      */
     static CreateDebuggingInterfaceFromVersion(iDebuggerVersion, szDebuggeeVersion) {
         szDebuggeeVersion := szDebuggeeVersion is String ? StrPtr(szDebuggeeVersion) : szDebuggeeVersion
@@ -557,7 +557,7 @@ class ClrHosting {
      * @param {PWSTR} pVersion 
      * @param {Integer} cchBuffer 
      * @returns {Integer} 
-     * @deprecated
+     * @deprecated 
      */
     static GetVersionFromProcess(hProcess, pVersion, cchBuffer) {
         hProcess := hProcess is Win32Handle ? NumGet(hProcess, "ptr") : hProcess

--- a/Windows/Win32/System/Diagnostics/Debug/Apis.ahk
+++ b/Windows/Win32/System/Diagnostics/Debug/Apis.ahk
@@ -10750,7 +10750,7 @@ class Debug {
      * @param {Integer} flags 
      * @param {PSTR} FilePath 
      * @returns {BOOL} 
-     * @deprecated
+     * @deprecated 
      */
     static FindFileInPath(hprocess, SearchPathA, FileName, id, two, three, flags, FilePath) {
         hprocess := hprocess is Win32Handle ? NumGet(hprocess, "ptr") : hprocess
@@ -10774,7 +10774,7 @@ class Debug {
      * @param {Integer} three 
      * @param {PSTR} FilePath 
      * @returns {BOOL} 
-     * @deprecated
+     * @deprecated 
      */
     static FindFileInSearchPath(hprocess, SearchPathA, FileName, one, two, three, FilePath) {
         hprocess := hprocess is Win32Handle ? NumGet(hprocess, "ptr") : hprocess
@@ -10793,7 +10793,7 @@ class Debug {
      * @param {Pointer<PSYM_ENUMERATESYMBOLS_CALLBACK>} EnumSymbolsCallback 
      * @param {Pointer<Void>} UserContext 
      * @returns {BOOL} 
-     * @deprecated
+     * @deprecated 
      */
     static SymEnumSym(hProcess, BaseOfDll, EnumSymbolsCallback, UserContext) {
         hProcess := hProcess is Win32Handle ? NumGet(hProcess, "ptr") : hProcess
@@ -10817,7 +10817,7 @@ class Debug {
      * If the function fails, the return value is <b>FALSE</b>. To retrieve extended error information, call 
      * <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
      * @see https://docs.microsoft.com/windows/win32/api//dbghelp/nf-dbghelp-symenumeratesymbols64
-     * @deprecated
+     * @deprecated 
      */
     static SymEnumerateSymbols64(hProcess, BaseOfDll, EnumSymbolsCallback, UserContext) {
         hProcess := hProcess is Win32Handle ? NumGet(hProcess, "ptr") : hProcess
@@ -10846,7 +10846,7 @@ class Debug {
      * If the function fails, the return value is <b>FALSE</b>. To retrieve extended error information, call 
      * <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
      * @see https://docs.microsoft.com/windows/win32/api//dbghelp/nf-dbghelp-symenumeratesymbolsw64
-     * @deprecated
+     * @deprecated 
      */
     static SymEnumerateSymbolsW64(hProcess, BaseOfDll, EnumSymbolsCallback, UserContext) {
         hProcess := hProcess is Win32Handle ? NumGet(hProcess, "ptr") : hProcess
@@ -10875,7 +10875,7 @@ class Debug {
      * If the function fails, the return value is <b>FALSE</b>. To retrieve extended error information, call 
      * <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
      * @see https://docs.microsoft.com/windows/win32/api//dbghelp/nf-dbghelp-symenumeratesymbols
-     * @deprecated
+     * @deprecated 
      */
     static SymEnumerateSymbols(hProcess, BaseOfDll, EnumSymbolsCallback, UserContext) {
         hProcess := hProcess is Win32Handle ? NumGet(hProcess, "ptr") : hProcess
@@ -10904,7 +10904,7 @@ class Debug {
      * If the function fails, the return value is <b>FALSE</b>. To retrieve extended error information, call 
      * <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
      * @see https://docs.microsoft.com/windows/win32/api//dbghelp/nf-dbghelp-symenumeratesymbolsw
-     * @deprecated
+     * @deprecated 
      */
     static SymEnumerateSymbolsW(hProcess, BaseOfDll, EnumSymbolsCallback, UserContext) {
         hProcess := hProcess is Win32Handle ? NumGet(hProcess, "ptr") : hProcess

--- a/Windows/Win32/System/Diagnostics/Debug/IMAGE_OPTIONAL_HEADER32.ahk
+++ b/Windows/Win32/System/Diagnostics/Debug/IMAGE_OPTIONAL_HEADER32.ahk
@@ -671,7 +671,7 @@ class IMAGE_OPTIONAL_HEADER32 extends Win32Struct
 
     /**
      * This member is obsolete.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     LoaderFlags {

--- a/Windows/Win32/System/Diagnostics/Debug/IMAGE_OPTIONAL_HEADER64.ahk
+++ b/Windows/Win32/System/Diagnostics/Debug/IMAGE_OPTIONAL_HEADER64.ahk
@@ -651,7 +651,7 @@ class IMAGE_OPTIONAL_HEADER64 extends Win32Struct
 
     /**
      * This member is obsolete.
-     * @deprecated
+     * @deprecated 
      * @type {Integer}
      */
     LoaderFlags {

--- a/Windows/Win32/System/EventLog/EVENTSFORLOGFILE.ahk
+++ b/Windows/Win32/System/EventLog/EVENTSFORLOGFILE.ahk
@@ -5,7 +5,7 @@
 /**
  * @namespace Windows.Win32.System.EventLog
  * @version v4.0.30319
- * @deprecated
+ * @deprecated struct EVENTSFORLOGFILE is deprecated and might not work on all platforms. For more info, see MSDN.
  */
 class EVENTSFORLOGFILE extends Win32Struct
 {

--- a/Windows/Win32/System/Search/Apis.ahk
+++ b/Windows/Win32/System/Search/Apis.ahk
@@ -17454,7 +17454,7 @@ class Search {
      * @param {Pointer<Void>} ParameterValue 
      * @param {Pointer<Integer>} StrLen_or_Ind 
      * @returns {Integer} 
-     * @deprecated
+     * @deprecated ODBC API: SQLBindParam is deprecated. Please use SQLBindParameter instead.
      */
     static SQLBindParam(StatementHandle, ParameterNumber, ValueType, ParameterType, LengthPrecision, ParameterScale, ParameterValue, StrLen_or_Ind) {
         StatementHandleMarshal := StatementHandle is VarRef ? "ptr" : "ptr"
@@ -17617,7 +17617,7 @@ class Search {
      * @param {Integer} Value 
      * @returns {Integer} 
      * @see https://learn.microsoft.com/sql/odbc/reference/syntax/sqlsetconnectoption-function
-     * @deprecated
+     * @deprecated ODBC API: SQLSetConnectOption is deprecated. Please use SQLSetConnectAttr instead.
      */
     static SQLSetConnectOption(ConnectionHandle, Option, Value) {
         ConnectionHandleMarshal := ConnectionHandle is VarRef ? "ptr" : "ptr"
@@ -17662,7 +17662,7 @@ class Search {
      * @param {Pointer<Integer>} StrLen_or_Ind 
      * @returns {Integer} 
      * @see https://learn.microsoft.com/sql/odbc/reference/syntax/sqlsetparam-function
-     * @deprecated
+     * @deprecated ODBC API: SQLSetParam is deprecated. Please use SQLBindParameter instead.
      */
     static SQLSetParam(StatementHandle, ParameterNumber, ValueType, ParameterType, LengthPrecision, ParameterScale, ParameterValue, StrLen_or_Ind) {
         StatementHandleMarshal := StatementHandle is VarRef ? "ptr" : "ptr"
@@ -17680,7 +17680,7 @@ class Search {
      * @param {Integer} Value 
      * @returns {Integer} 
      * @see https://learn.microsoft.com/sql/odbc/reference/syntax/sqlsetstmtoption-function
-     * @deprecated
+     * @deprecated ODBC API: SQLSetStmtOption is deprecated. Please use SQLSetStmtAttr instead.
      */
     static SQLSetStmtOption(StatementHandle, Option, Value) {
         StatementHandleMarshal := StatementHandle is VarRef ? "ptr" : "ptr"
@@ -18421,7 +18421,7 @@ class Search {
      * @param {Pointer<Void>} Value 
      * @returns {Integer} 
      * @see https://learn.microsoft.com/sql/odbc/reference/syntax/sqlgetconnectoption-function
-     * @deprecated
+     * @deprecated ODBC API: SQLGetConnectOption is deprecated. Please use SQLGetConnectAttr instead.
      */
     static SQLGetConnectOption(ConnectionHandle, Option, Value) {
         ConnectionHandleMarshal := ConnectionHandle is VarRef ? "ptr" : "ptr"
@@ -18593,7 +18593,7 @@ class Search {
      * @param {Pointer<Void>} Value 
      * @returns {Integer} 
      * @see https://learn.microsoft.com/sql/odbc/reference/syntax/sqlgetstmtoption-function
-     * @deprecated
+     * @deprecated ODBC API: SQLGetStmtOption is deprecated. Please use SQLGetStmtAttr instead.
      */
     static SQLGetStmtOption(StatementHandle, Option, Value) {
         StatementHandleMarshal := StatementHandle is VarRef ? "ptr" : "ptr"

--- a/Windows/Win32/System/SystemInformation/Apis.ahk
+++ b/Windows/Win32/System/SystemInformation/Apis.ahk
@@ -713,7 +713,7 @@ class SystemInformation {
      * 
      * For all platforms, the low-order word contains the version number of the operating system. The low-order byte of this word specifies the major version number, in hexadecimal notation. The high-order byte specifies the minor version (revision) number, in hexadecimal notation. The  high-order bit is zero, the next 7 bits represent the build number, and the low-order byte is 5.
      * @see https://docs.microsoft.com/windows/win32/api//sysinfoapi/nf-sysinfoapi-getversion
-     * @deprecated
+     * @deprecated 
      * @since windows5.0
      */
     static GetVersion() {
@@ -1362,7 +1362,7 @@ class SystemInformation {
      * <a href="/windows/desktop/api/winnt/ns-winnt-osversioninfoa">OSVERSIONINFO</a> or 
      * <a href="/windows/desktop/api/winnt/ns-winnt-osversioninfoexa">OSVERSIONINFOEX</a> structure.
      * @see https://docs.microsoft.com/windows/win32/api//sysinfoapi/nf-sysinfoapi-getversionexa
-     * @deprecated
+     * @deprecated 
      * @since windows5.0
      */
     static GetVersionExA(lpVersionInformation) {
@@ -1392,7 +1392,7 @@ class SystemInformation {
      * <a href="/windows/desktop/api/winnt/ns-winnt-osversioninfoa">OSVERSIONINFO</a> or 
      * <a href="/windows/desktop/api/winnt/ns-winnt-osversioninfoexa">OSVERSIONINFOEX</a> structure.
      * @see https://docs.microsoft.com/windows/win32/api//sysinfoapi/nf-sysinfoapi-getversionexw
-     * @deprecated
+     * @deprecated 
      * @since windows5.0
      */
     static GetVersionExW(lpVersionInformation) {

--- a/Windows/Win32/System/SystemServices/PACKEDEVENTINFO.ahk
+++ b/Windows/Win32/System/SystemServices/PACKEDEVENTINFO.ahk
@@ -4,7 +4,7 @@
 /**
  * @namespace Windows.Win32.System.SystemServices
  * @version v4.0.30319
- * @deprecated
+ * @deprecated struct PACKEDEVENTINFO is deprecated and might not work on all platforms. For more info, see MSDN.
  */
 class PACKEDEVENTINFO extends Win32Struct
 {

--- a/Windows/Win32/UI/ColorSystem/Apis.ahk
+++ b/Windows/Win32/UI/ColorSystem/Apis.ahk
@@ -1573,7 +1573,7 @@ class ColorSystem {
      * 
      * If this function fails, the return value is **FALSE**. For extended error information, call **GetLastError**.
      * @see https://docs.microsoft.com/windows/win32/api//icm/nf-icm-getcolordirectorya
-     * @deprecated
+     * @deprecated GetColorDirectoryW is deprecated and might not work on all platforms. For more info, see MSDN.
      */
     static GetColorDirectoryA(pMachineName, pBuffer, pdwSize) {
         pMachineName := pMachineName is String ? StrPtr(pMachineName) : pMachineName
@@ -1593,7 +1593,7 @@ class ColorSystem {
      * 
      * If this function fails, the return value is **FALSE**. For extended error information, call **GetLastError**.
      * @see https://docs.microsoft.com/windows/win32/api//icm/nf-icm-getcolordirectoryw
-     * @deprecated
+     * @deprecated GetColorDirectoryA is deprecated and might not work on all platforms. For more info, see MSDN.
      */
     static GetColorDirectoryW(pMachineName, pBuffer, pdwSize) {
         pMachineName := pMachineName is String ? StrPtr(pMachineName) : pMachineName

--- a/Windows/Win32/UI/Shell/IFolderView2.ahk
+++ b/Windows/Win32/UI/Shell/IFolderView2.ahk
@@ -70,7 +70,7 @@ class IFolderView2 extends IFolderView{
      * @param {Pointer<PROPVARIANT>} propvar 
      * @returns {HRESULT} 
      * @see https://learn.microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifolderview2-setviewproperty
-     * @deprecated
+     * @deprecated 
      */
     SetViewProperty(pidl, propkey, propvar) {
         result := ComCall(19, this, "ptr", pidl, "ptr", propkey, "ptr", propvar, "HRESULT")
@@ -83,7 +83,7 @@ class IFolderView2 extends IFolderView{
      * @param {Pointer<PROPERTYKEY>} propkey 
      * @returns {PROPVARIANT} 
      * @see https://learn.microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifolderview2-getviewproperty
-     * @deprecated
+     * @deprecated 
      */
     GetViewProperty(pidl, propkey) {
         ppropvar := PROPVARIANT()
@@ -97,7 +97,7 @@ class IFolderView2 extends IFolderView{
      * @param {PWSTR} pszPropList 
      * @returns {HRESULT} 
      * @see https://learn.microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifolderview2-settileviewproperties
-     * @deprecated
+     * @deprecated 
      */
     SetTileViewProperties(pidl, pszPropList) {
         pszPropList := pszPropList is String ? StrPtr(pszPropList) : pszPropList
@@ -112,7 +112,7 @@ class IFolderView2 extends IFolderView{
      * @param {PWSTR} pszPropList 
      * @returns {HRESULT} 
      * @see https://learn.microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifolderview2-setextendedtileviewproperties
-     * @deprecated
+     * @deprecated 
      */
     SetExtendedTileViewProperties(pidl, pszPropList) {
         pszPropList := pszPropList is String ? StrPtr(pszPropList) : pszPropList


### PR DESCRIPTION
When generating documentation headers for deprecated APIs, if the metadata has a message, include it in the header:

```autohotkey
/**
 * @see https://learn.microsoft.com/windows/win32/api/d2d1/nf-d2d1-id2d1factory-getdesktopdpi
 * @deprecated Deprecated. Use DisplayInformation::LogicalDpi for Windows Store Apps or GetDpiForWindow for desktop apps.
 */
GetDesktopDpi(dpiX, dpiY) {
    dpiXMarshal := dpiX is VarRef ? "float*" : "ptr"
    dpiYMarshal := dpiY is VarRef ? "float*" : "ptr"

    ComCall(4, this, dpiXMarshal, dpiX, dpiYMarshal, dpiY)
}
```

Generator: https://github.com/holy-tao/AhkWin32Structs-Generator/pull/28
Fixes #56 