### PR TITLE
Update Win32 Metadata to 68.0.4-preview

### DIFF
--- a/Windows/Win32/Graphics/GdiPlus/Version.ahk
+++ b/Windows/Win32/Graphics/GdiPlus/Version.ahk
@@ -1,8 +1,6 @@
 #Requires AutoHotkey v2.0.0 64-bit
 
 /**
- * 
- * @see https://learn.microsoft.com/windows/win32/TaskSchd/taskschedulerschema-version-registrationinfotype-element
  * @namespace Windows.Win32.Graphics.GdiPlus
  * @version v4.0.30319
  */

--- a/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/Apis.ahk
@@ -2970,9 +2970,6 @@ class WindowsFilteringPlatform {
 
     /**
      * Opens a session to the filter engine.
-     * @param {PWSTR} serverName Type: <b>const wchar_t*</b>
-     * 
-     * This value must be <b>NULL</b>.
      * @param {Integer} authnService Type: <b>UINT32</b>
      * 
      * Specifies the authentication service to use. Allowed services are RPC_C_AUTHN_WINNT and RPC_C_AUTHN_DEFAULT.
@@ -3044,8 +3041,8 @@ class WindowsFilteringPlatform {
      * @see https://docs.microsoft.com/windows/win32/api//fwpmu/nf-fwpmu-fwpmengineopen0
      * @since windows6.0.6000
      */
-    static FwpmEngineOpen0(serverName, authnService, authIdentity, session, engineHandle) {
-        serverName := serverName is String ? StrPtr(serverName) : serverName
+    static FwpmEngineOpen0(authnService, authIdentity, session, engineHandle) {
+        static serverName := 0 ;Reserved parameters must always be NULL
 
         result := DllCall("fwpuclnt.dll\FwpmEngineOpen0", "ptr", serverName, "uint", authnService, "ptr", authIdentity, "ptr", session, "ptr", engineHandle, "uint")
         return result

--- a/Windows/Win32/Security/Apis.ahk
+++ b/Windows/Win32/Security/Apis.ahk
@@ -3025,7 +3025,12 @@ class Security {
 
         lpnLengthNeededMarshal := lpnLengthNeeded is VarRef ? "uint*" : "ptr"
 
+        A_LastError := 0
+
         result := DllCall("ADVAPI32.dll\GetFileSecurityW", "ptr", lpFileName, "uint", RequestedInformation, "ptr", pSecurityDescriptor, "uint", nLength, lpnLengthNeededMarshal, lpnLengthNeeded, "int")
+        if(A_LastError)
+            throw OSError()
+
         return result
     }
 

--- a/version.ini
+++ b/version.ini
@@ -4,4 +4,4 @@ metadata = v4.0.30319
 # NuGet package versions used to generate files
 [Packages]
 Microsoft.Windows.SDK.Win32Docs = 0.1.8-alpha
-Microsoft.Windows.SDK.Win32Metadata = 67.0.4-preview
+Microsoft.Windows.SDK.Win32Metadata = 68.0.4-preview


### PR DESCRIPTION
Automated update of generated Win32 bindings.
- Metadata version: **68.0.4-preview**
- ApiDocs version: **0.1.8-alpha**

See the win32metadata [releases](https://github.com/microsoft/win32metadata/releases/tag/v68.0.4-preview) page for details.

Triggered by update-packages workflow.