### PR TITLE
Don't check LastError if BOOL-Returning functions succeed

### DIFF
--- a/Windows/Win32/Devices/Bluetooth/Apis.ahk
+++ b/Windows/Win32/Devices/Bluetooth/Apis.ahk
@@ -4296,7 +4296,7 @@ class Bluetooth {
         A_LastError := 0
 
         result := DllCall("BluetoothApis.dll\BluetoothFindNextRadio", "ptr", hFind, "ptr", phRadio, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4315,7 +4315,7 @@ class Bluetooth {
         A_LastError := 0
 
         result := DllCall("BluetoothApis.dll\BluetoothFindRadioClose", "ptr", hFind, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4484,7 +4484,7 @@ class Bluetooth {
         A_LastError := 0
 
         result := DllCall("BluetoothApis.dll\BluetoothFindNextDevice", "ptr", hFind, "ptr", pbtdi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4503,7 +4503,7 @@ class Bluetooth {
         A_LastError := 0
 
         result := DllCall("BluetoothApis.dll\BluetoothFindDeviceClose", "ptr", hFind, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4672,7 +4672,7 @@ class Bluetooth {
         A_LastError := 0
 
         result := DllCall("bthprops.cpl\BluetoothSelectDevices", "ptr", pbtsdp, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4705,7 +4705,7 @@ class Bluetooth {
         A_LastError := 0
 
         result := DllCall("bthprops.cpl\BluetoothDisplayDeviceProperties", "ptr", hwndParent, "ptr", pbtdi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5176,7 +5176,7 @@ class Bluetooth {
         A_LastError := 0
 
         result := DllCall("BluetoothApis.dll\BluetoothUnregisterAuthentication", "ptr", hRegHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5508,7 +5508,7 @@ class Bluetooth {
         A_LastError := 0
 
         result := DllCall("BluetoothApis.dll\BluetoothSdpEnumAttributes", "ptr", pSDPStream, "uint", cbStreamSize, "ptr", pfnCallback, pvParamMarshal, pvParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Devices/Communication/Apis.ahk
+++ b/Windows/Win32/Devices/Communication/Apis.ahk
@@ -510,7 +510,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ClearCommBreak", "ptr", hFile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -538,7 +538,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ClearCommError", "ptr", hFile, lpErrorsMarshal, lpErrors, "ptr", lpStat, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -563,7 +563,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetupComm", "ptr", hFile, "uint", dwInQueue, "uint", dwOutQueue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -587,7 +587,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EscapeCommFunction", "ptr", hFile, "uint", dwFunc, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -615,7 +615,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetCommConfig", "ptr", hCommDev, "ptr", lpCC, lpdwSizeMarshal, lpdwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -641,7 +641,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetCommMask", "ptr", hFile, lpEvtMaskMarshal, lpEvtMask, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -669,7 +669,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetCommProperties", "ptr", hFile, "ptr", lpCommProp, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -695,7 +695,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetCommModemStatus", "ptr", hFile, lpModemStatMarshal, lpModemStat, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -720,7 +720,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetCommState", "ptr", hFile, "ptr", lpDCB, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -745,7 +745,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetCommTimeouts", "ptr", hFile, "ptr", lpCommTimeouts, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -769,7 +769,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\PurgeComm", "ptr", hFile, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -792,7 +792,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetCommBreak", "ptr", hFile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -818,7 +818,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetCommConfig", "ptr", hCommDev, "ptr", lpCC, "uint", dwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -842,7 +842,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetCommMask", "ptr", hFile, "uint", dwEvtMask, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -867,7 +867,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetCommState", "ptr", hFile, "ptr", lpDCB, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -892,7 +892,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetCommTimeouts", "ptr", hFile, "ptr", lpCommTimeouts, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -916,7 +916,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\TransmitCommChar", "ptr", hFile, "char", cChar, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -956,7 +956,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WaitCommEvent", "ptr", hFile, lpEvtMaskMarshal, lpEvtMask, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1089,7 +1089,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\BuildCommDCBA", "ptr", lpDef, "ptr", lpDCB, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1127,7 +1127,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\BuildCommDCBW", "ptr", lpDef, "ptr", lpDCB, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1176,7 +1176,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\BuildCommDCBAndTimeoutsA", "ptr", lpDef, "ptr", lpDCB, "ptr", lpCommTimeouts, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1225,7 +1225,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\BuildCommDCBAndTimeoutsW", "ptr", lpDef, "ptr", lpDCB, "ptr", lpCommTimeouts, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1251,7 +1251,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CommConfigDialogA", "ptr", lpszName, "ptr", hWnd, "ptr", lpCC, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1277,7 +1277,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CommConfigDialogW", "ptr", lpszName, "ptr", hWnd, "ptr", lpCC, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1304,7 +1304,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetDefaultCommConfigA", "ptr", lpszName, "ptr", lpCC, lpdwSizeMarshal, lpdwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1331,7 +1331,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetDefaultCommConfigW", "ptr", lpszName, "ptr", lpCC, lpdwSizeMarshal, lpdwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1356,7 +1356,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetDefaultCommConfigA", "ptr", lpszName, "ptr", lpCC, "uint", dwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1381,7 +1381,7 @@ class Communication {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetDefaultCommConfigW", "ptr", lpszName, "ptr", lpCC, "uint", dwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Devices/DeviceAndDriverInstallation/Apis.ahk
+++ b/Windows/Win32/Devices/DeviceAndDriverInstallation/Apis.ahk
@@ -5138,7 +5138,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetInfInformationA", InfSpecMarshal, InfSpec, "uint", SearchControl, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5172,7 +5172,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetInfInformationW", InfSpecMarshal, InfSpec, "uint", SearchControl, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5202,7 +5202,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueryInfFileInformationA", "ptr", InfInformation, "uint", InfIndex, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5232,7 +5232,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueryInfFileInformationW", "ptr", InfInformation, "uint", InfIndex, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5261,7 +5261,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueryInfOriginalFileInformationA", "ptr", InfInformation, "uint", InfIndex, "ptr", AlternatePlatformInfo, "ptr", OriginalFileInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5290,7 +5290,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueryInfOriginalFileInformationW", "ptr", InfInformation, "uint", InfIndex, "ptr", AlternatePlatformInfo, "ptr", OriginalFileInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5323,7 +5323,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueryInfVersionInformationA", "ptr", InfInformation, "uint", InfIndex, "ptr", Key, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5356,7 +5356,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueryInfVersionInformationW", "ptr", InfInformation, "uint", InfIndex, "ptr", Key, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5384,7 +5384,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetInfDriverStoreLocationA", "ptr", FileName, "ptr", AlternatePlatformInfo, "ptr", LocaleName, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5412,7 +5412,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetInfDriverStoreLocationW", "ptr", FileName, "ptr", AlternatePlatformInfo, "ptr", LocaleName, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5439,7 +5439,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetInfPublishedNameA", "ptr", DriverStoreLocation, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5466,7 +5466,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetInfPublishedNameW", "ptr", DriverStoreLocation, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5495,7 +5495,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetInfFileListA", "ptr", DirectoryPath, "uint", InfStyle, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5524,7 +5524,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetInfFileListW", "ptr", DirectoryPath, "uint", InfStyle, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5627,7 +5627,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupOpenAppendInfFileW", "ptr", FileName, InfHandleMarshal, InfHandle, ErrorLineMarshal, ErrorLine, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5658,7 +5658,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupOpenAppendInfFileA", "ptr", FileName, InfHandleMarshal, InfHandle, ErrorLineMarshal, ErrorLine, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5697,7 +5697,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupFindFirstLineA", InfHandleMarshal, InfHandle, "ptr", Section, "ptr", Key, "ptr", Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5723,7 +5723,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupFindFirstLineW", InfHandleMarshal, InfHandle, "ptr", Section, "ptr", Key, "ptr", Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5743,7 +5743,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupFindNextLine", "ptr", ContextIn, "ptr", ContextOut, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5768,7 +5768,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupFindNextMatchLineA", "ptr", ContextIn, "ptr", Key, "ptr", ContextOut, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5793,7 +5793,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupFindNextMatchLineW", "ptr", ContextIn, "ptr", Key, "ptr", ContextOut, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5820,7 +5820,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetLineByIndexA", InfHandleMarshal, InfHandle, "ptr", Section, "uint", Index, "ptr", Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5847,7 +5847,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetLineByIndexW", InfHandleMarshal, InfHandle, "ptr", Section, "uint", Index, "ptr", Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5932,7 +5932,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetLineTextA", "ptr", Context, InfHandleMarshal, InfHandle, "ptr", Section, "ptr", Key, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5965,7 +5965,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetLineTextW", "ptr", Context, InfHandleMarshal, InfHandle, "ptr", Section, "ptr", Key, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6011,7 +6011,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetStringFieldA", "ptr", Context, "uint", FieldIndex, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6039,7 +6039,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetStringFieldW", "ptr", Context, "uint", FieldIndex, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6070,7 +6070,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetIntField", "ptr", Context, "uint", FieldIndex, IntegerValueMarshal, IntegerValue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6098,7 +6098,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetMultiSzFieldA", "ptr", Context, "uint", FieldIndex, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6126,7 +6126,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetMultiSzFieldW", "ptr", Context, "uint", FieldIndex, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6156,7 +6156,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetBinaryField", "ptr", Context, "uint", FieldIndex, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6254,7 +6254,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetFileCompressionInfoExA", "ptr", SourceFileName, "ptr", ActualSourceFileNameBuffer, "uint", ActualSourceFileNameBufferLen, RequiredBufferLenMarshal, RequiredBufferLen, SourceFileSizeMarshal, SourceFileSize, TargetFileSizeMarshal, TargetFileSize, CompressionTypeMarshal, CompressionType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6290,7 +6290,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetFileCompressionInfoExW", "ptr", SourceFileName, "ptr", ActualSourceFileNameBuffer, "uint", ActualSourceFileNameBufferLen, RequiredBufferLenMarshal, RequiredBufferLen, SourceFileSizeMarshal, SourceFileSize, TargetFileSizeMarshal, TargetFileSize, CompressionTypeMarshal, CompressionType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6383,7 +6383,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetSourceFileLocationA", InfHandleMarshal, InfHandle, "ptr", InfContext, "ptr", FileName, SourceIdMarshal, SourceId, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6416,7 +6416,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetSourceFileLocationW", InfHandleMarshal, InfHandle, "ptr", InfContext, "ptr", FileName, SourceIdMarshal, SourceId, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6447,7 +6447,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetSourceFileSizeA", InfHandleMarshal, InfHandle, "ptr", InfContext, "ptr", FileName, "ptr", Section, FileSizeMarshal, FileSize, "uint", RoundingFactor, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6478,7 +6478,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetSourceFileSizeW", InfHandleMarshal, InfHandle, "ptr", InfContext, "ptr", FileName, "ptr", Section, FileSizeMarshal, FileSize, "uint", RoundingFactor, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6510,7 +6510,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetTargetPathA", InfHandleMarshal, InfHandle, "ptr", InfContext, "ptr", Section, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6542,7 +6542,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetTargetPathW", InfHandleMarshal, InfHandle, "ptr", InfContext, "ptr", Section, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6566,7 +6566,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupSetSourceListA", "uint", Flags, SourceListMarshal, SourceList, "uint", SourceCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6590,7 +6590,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupSetSourceListW", "uint", Flags, SourceListMarshal, SourceList, "uint", SourceCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6607,7 +6607,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupCancelTemporarySourceList", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6630,7 +6630,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupAddToSourceListA", "uint", Flags, "ptr", Source, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6653,7 +6653,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupAddToSourceListW", "uint", Flags, "ptr", Source, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6676,7 +6676,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupRemoveFromSourceListA", "uint", Flags, "ptr", Source, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6699,7 +6699,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupRemoveFromSourceListW", "uint", Flags, "ptr", Source, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6725,7 +6725,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQuerySourceListA", "uint", Flags, ListMarshal, List, CountMarshal, Count, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6751,7 +6751,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQuerySourceListW", "uint", Flags, ListMarshal, List, CountMarshal, Count, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6775,7 +6775,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupFreeSourceListA", ListMarshal, List, "uint", Count, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6799,7 +6799,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupFreeSourceListW", ListMarshal, List, "uint", Count, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7213,7 +7213,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupSetDirectoryIdA", InfHandleMarshal, InfHandle, "uint", Id, "ptr", Directory, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7239,7 +7239,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupSetDirectoryIdW", InfHandleMarshal, InfHandle, "uint", Id, "ptr", Directory, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7268,7 +7268,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupSetDirectoryIdExA", InfHandleMarshal, InfHandle, "uint", Id, "ptr", Directory, "uint", Flags, "uint", Reserved1, "ptr", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7297,7 +7297,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupSetDirectoryIdExW", InfHandleMarshal, InfHandle, "uint", Id, "ptr", Directory, "uint", Flags, "uint", Reserved1, "ptr", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7327,7 +7327,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetSourceInfoA", InfHandleMarshal, InfHandle, "uint", SourceId, "uint", InfoDesired, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7357,7 +7357,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetSourceInfoW", InfHandleMarshal, InfHandle, "uint", SourceId, "uint", InfoDesired, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7393,7 +7393,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupInstallFileA", InfHandleMarshal, InfHandle, "ptr", InfContext, "ptr", SourceFile, "ptr", SourcePathRoot, "ptr", DestinationName, "uint", CopyStyle, "ptr", CopyMsgHandler, ContextMarshal, Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7429,7 +7429,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupInstallFileW", InfHandleMarshal, InfHandle, "ptr", InfContext, "ptr", SourceFile, "ptr", SourcePathRoot, "ptr", DestinationName, "uint", CopyStyle, "ptr", CopyMsgHandler, ContextMarshal, Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7467,7 +7467,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupInstallFileExA", InfHandleMarshal, InfHandle, "ptr", InfContext, "ptr", SourceFile, "ptr", SourcePathRoot, "ptr", DestinationName, "uint", CopyStyle, "ptr", CopyMsgHandler, ContextMarshal, Context, FileWasInUseMarshal, FileWasInUse, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7505,7 +7505,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupInstallFileExW", InfHandleMarshal, InfHandle, "ptr", InfContext, "ptr", SourceFile, "ptr", SourcePathRoot, "ptr", DestinationName, "uint", CopyStyle, "ptr", CopyMsgHandler, ContextMarshal, Context, FileWasInUseMarshal, FileWasInUse, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7562,7 +7562,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupSetFileQueueAlternatePlatformA", QueueHandleMarshal, QueueHandle, "ptr", AlternatePlatformInfo, "ptr", AlternateDefaultCatalogFile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7588,7 +7588,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupSetFileQueueAlternatePlatformW", QueueHandleMarshal, QueueHandle, "ptr", AlternatePlatformInfo, "ptr", AlternateDefaultCatalogFile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7614,7 +7614,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupSetPlatformPathOverrideA", "ptr", Override, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7640,7 +7640,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupSetPlatformPathOverrideW", "ptr", Override, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7679,7 +7679,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueCopyA", QueueHandleMarshal, QueueHandle, "ptr", SourceRootPath, "ptr", SourcePath, "ptr", SourceFilename, "ptr", SourceDescription, "ptr", SourceTagfile, "ptr", TargetDirectory, "ptr", TargetFilename, "uint", CopyStyle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7718,7 +7718,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueCopyW", QueueHandleMarshal, QueueHandle, "ptr", SourceRootPath, "ptr", SourcePath, "ptr", SourceFilename, "ptr", SourceDescription, "ptr", SourceTagfile, "ptr", TargetDirectory, "ptr", TargetFilename, "uint", CopyStyle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7739,7 +7739,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueCopyIndirectA", "ptr", CopyParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7760,7 +7760,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueCopyIndirectW", "ptr", CopyParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7793,7 +7793,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueDefaultCopyA", QueueHandleMarshal, QueueHandle, InfHandleMarshal, InfHandle, "ptr", SourceRootPath, "ptr", SourceFilename, "ptr", TargetFilename, "uint", CopyStyle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7826,7 +7826,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueDefaultCopyW", QueueHandleMarshal, QueueHandle, InfHandleMarshal, InfHandle, "ptr", SourceRootPath, "ptr", SourceFilename, "ptr", TargetFilename, "uint", CopyStyle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7859,7 +7859,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueCopySectionA", QueueHandleMarshal, QueueHandle, "ptr", SourceRootPath, InfHandleMarshal, InfHandle, ListInfHandleMarshal, ListInfHandle, "ptr", Section, "uint", CopyStyle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7892,7 +7892,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueCopySectionW", QueueHandleMarshal, QueueHandle, "ptr", SourceRootPath, InfHandleMarshal, InfHandle, ListInfHandleMarshal, ListInfHandle, "ptr", Section, "uint", CopyStyle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7920,7 +7920,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueDeleteA", QueueHandleMarshal, QueueHandle, "ptr", PathPart1, "ptr", PathPart2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7948,7 +7948,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueDeleteW", QueueHandleMarshal, QueueHandle, "ptr", PathPart1, "ptr", PathPart2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7978,7 +7978,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueDeleteSectionA", QueueHandleMarshal, QueueHandle, InfHandleMarshal, InfHandle, ListInfHandleMarshal, ListInfHandle, "ptr", Section, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8008,7 +8008,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueDeleteSectionW", QueueHandleMarshal, QueueHandle, InfHandleMarshal, InfHandle, ListInfHandleMarshal, ListInfHandle, "ptr", Section, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8040,7 +8040,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueRenameA", QueueHandleMarshal, QueueHandle, "ptr", SourcePath, "ptr", SourceFilename, "ptr", TargetPath, "ptr", TargetFilename, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8072,7 +8072,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueRenameW", QueueHandleMarshal, QueueHandle, "ptr", SourcePath, "ptr", SourceFilename, "ptr", TargetPath, "ptr", TargetFilename, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8102,7 +8102,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueRenameSectionA", QueueHandleMarshal, QueueHandle, InfHandleMarshal, InfHandle, ListInfHandleMarshal, ListInfHandle, "ptr", Section, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8132,7 +8132,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueueRenameSectionW", QueueHandleMarshal, QueueHandle, InfHandleMarshal, InfHandle, ListInfHandleMarshal, ListInfHandle, "ptr", Section, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8166,7 +8166,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupCommitFileQueueA", "ptr", Owner, QueueHandleMarshal, QueueHandle, "ptr", MsgHandler, ContextMarshal, Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8200,7 +8200,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupCommitFileQueueW", "ptr", Owner, QueueHandleMarshal, QueueHandle, "ptr", MsgHandler, ContextMarshal, Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8379,7 +8379,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupScanFileQueueA", FileQueueMarshal, FileQueue, "uint", Flags, "ptr", Window, "ptr", CallbackRoutine, CallbackContextMarshal, CallbackContext, ResultMarshal, Result, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8558,7 +8558,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupScanFileQueueW", FileQueueMarshal, FileQueue, "uint", Flags, "ptr", Window, "ptr", CallbackRoutine, CallbackContextMarshal, CallbackContext, ResultMarshal, Result, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8632,7 +8632,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetFileQueueCount", FileQueueMarshal, FileQueue, "uint", SubQueueFileOp, NumOperationsMarshal, NumOperations, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8690,7 +8690,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupGetFileQueueFlags", FileQueueMarshal, FileQueue, FlagsMarshal, Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8768,7 +8768,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupSetFileQueueFlags", FileQueueMarshal, FileQueue, "uint", FlagMask, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8846,7 +8846,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupCopyOEMInfA", "ptr", SourceInfFileName, "ptr", OEMSourceMediaLocation, "uint", OEMSourceMediaType, "uint", CopyStyle, "ptr", DestinationInfFileName, "uint", DestinationInfFileNameSize, RequiredSizeMarshal, RequiredSize, DestinationInfFileNameComponentMarshal, DestinationInfFileNameComponent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8924,7 +8924,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupCopyOEMInfW", "ptr", SourceInfFileName, "ptr", OEMSourceMediaLocation, "uint", OEMSourceMediaType, "uint", CopyStyle, "ptr", DestinationInfFileName, "uint", DestinationInfFileNameSize, RequiredSizeMarshal, RequiredSize, DestinationInfFileNameComponentMarshal, DestinationInfFileNameComponent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9037,7 +9037,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupUninstallNewlyCopiedInfs", FileQueueMarshal, FileQueue, "uint", Flags, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9153,7 +9153,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDestroyDiskSpaceList", DiskSpaceMarshal, DiskSpace, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9185,7 +9185,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueryDrivesInDiskSpaceListA", DiskSpaceMarshal, DiskSpace, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9217,7 +9217,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueryDrivesInDiskSpaceListW", DiskSpaceMarshal, DiskSpace, "ptr", ReturnBuffer, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9305,7 +9305,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQuerySpaceRequiredOnDriveA", DiskSpaceMarshal, DiskSpace, "ptr", DriveSpec, SpaceRequiredMarshal, SpaceRequired, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9393,7 +9393,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQuerySpaceRequiredOnDriveW", DiskSpaceMarshal, DiskSpace, "ptr", DriveSpec, SpaceRequiredMarshal, SpaceRequired, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9421,7 +9421,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupAdjustDiskSpaceListA", DiskSpaceMarshal, DiskSpace, "ptr", DriveRoot, "int64", Amount, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9449,7 +9449,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupAdjustDiskSpaceListW", DiskSpaceMarshal, DiskSpace, "ptr", DriveRoot, "int64", Amount, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9479,7 +9479,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupAddToDiskSpaceListA", DiskSpaceMarshal, DiskSpace, "ptr", TargetFilespec, "int64", FileSize, "uint", Operation, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9509,7 +9509,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupAddToDiskSpaceListW", DiskSpaceMarshal, DiskSpace, "ptr", TargetFilespec, "int64", FileSize, "uint", Operation, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9541,7 +9541,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupAddSectionToDiskSpaceListA", DiskSpaceMarshal, DiskSpace, InfHandleMarshal, InfHandle, ListInfHandleMarshal, ListInfHandle, "ptr", SectionName, "uint", Operation, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9573,7 +9573,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupAddSectionToDiskSpaceListW", DiskSpaceMarshal, DiskSpace, InfHandleMarshal, InfHandle, ListInfHandleMarshal, ListInfHandle, "ptr", SectionName, "uint", Operation, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9604,7 +9604,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupAddInstallSectionToDiskSpaceListA", DiskSpaceMarshal, DiskSpace, InfHandleMarshal, InfHandle, LayoutInfHandleMarshal, LayoutInfHandle, "ptr", SectionName, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9635,7 +9635,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupAddInstallSectionToDiskSpaceListW", DiskSpaceMarshal, DiskSpace, InfHandleMarshal, InfHandle, LayoutInfHandleMarshal, LayoutInfHandle, "ptr", SectionName, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9666,7 +9666,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupRemoveFromDiskSpaceListA", DiskSpaceMarshal, DiskSpace, "ptr", TargetFilespec, "uint", Operation, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9697,7 +9697,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupRemoveFromDiskSpaceListW", DiskSpaceMarshal, DiskSpace, "ptr", TargetFilespec, "uint", Operation, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9729,7 +9729,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupRemoveSectionFromDiskSpaceListA", DiskSpaceMarshal, DiskSpace, InfHandleMarshal, InfHandle, ListInfHandleMarshal, ListInfHandle, "ptr", SectionName, "uint", Operation, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9761,7 +9761,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupRemoveSectionFromDiskSpaceListW", DiskSpaceMarshal, DiskSpace, InfHandleMarshal, InfHandle, ListInfHandleMarshal, ListInfHandle, "ptr", SectionName, "uint", Operation, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9792,7 +9792,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupRemoveInstallSectionFromDiskSpaceListA", DiskSpaceMarshal, DiskSpace, InfHandleMarshal, InfHandle, LayoutInfHandleMarshal, LayoutInfHandle, "ptr", SectionName, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9823,7 +9823,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupRemoveInstallSectionFromDiskSpaceListW", DiskSpaceMarshal, DiskSpace, InfHandleMarshal, InfHandle, LayoutInfHandleMarshal, LayoutInfHandle, "ptr", SectionName, "ptr", Reserved1, "uint", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9852,7 +9852,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupIterateCabinetA", "ptr", CabinetFile, "uint", Reserved, "ptr", MsgHandler, ContextMarshal, Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9881,7 +9881,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupIterateCabinetW", "ptr", CabinetFile, "uint", Reserved, "ptr", MsgHandler, ContextMarshal, Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10593,7 +10593,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupInstallFromInfSectionA", "ptr", Owner, InfHandleMarshal, InfHandle, "ptr", SectionName, "uint", Flags, "ptr", RelativeKeyRoot, "ptr", SourceRootPath, "uint", CopyFlags, "ptr", MsgHandler, ContextMarshal, Context, "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10668,7 +10668,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupInstallFromInfSectionW", "ptr", Owner, InfHandleMarshal, InfHandle, "ptr", SectionName, "uint", Flags, "ptr", RelativeKeyRoot, "ptr", SourceRootPath, "uint", CopyFlags, "ptr", MsgHandler, ContextMarshal, Context, "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10706,7 +10706,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupInstallFilesFromInfSectionA", InfHandleMarshal, InfHandle, LayoutInfHandleMarshal, LayoutInfHandle, FileQueueMarshal, FileQueue, "ptr", SectionName, "ptr", SourceRootPath, "uint", CopyFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10744,7 +10744,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupInstallFilesFromInfSectionW", InfHandleMarshal, InfHandle, LayoutInfHandleMarshal, LayoutInfHandle, FileQueueMarshal, FileQueue, "ptr", SectionName, "ptr", SourceRootPath, "uint", CopyFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10923,7 +10923,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupInstallServicesFromInfSectionA", InfHandleMarshal, InfHandle, "ptr", SectionName, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11102,7 +11102,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupInstallServicesFromInfSectionW", InfHandleMarshal, InfHandle, "ptr", SectionName, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11295,7 +11295,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupInstallServicesFromInfSectionExA", InfHandleMarshal, InfHandle, "ptr", SectionName, "uint", Flags, "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", Reserved1, "ptr", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11488,7 +11488,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupInstallServicesFromInfSectionExW", InfHandleMarshal, InfHandle, "ptr", SectionName, "uint", Flags, "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", Reserved1, "ptr", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11741,7 +11741,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupTerminateFileLog", FileLogHandleMarshal, FileLogHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11779,7 +11779,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupLogFileA", FileLogHandleMarshal, FileLogHandle, "ptr", LogSectionName, "ptr", SourceFilename, "ptr", TargetFilename, "uint", Checksum, "ptr", DiskTagfile, "ptr", DiskDescription, "ptr", OtherInfo, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11817,7 +11817,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupLogFileW", FileLogHandleMarshal, FileLogHandle, "ptr", LogSectionName, "ptr", SourceFilename, "ptr", TargetFilename, "uint", Checksum, "ptr", DiskTagfile, "ptr", DiskDescription, "ptr", OtherInfo, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11845,7 +11845,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupRemoveFileLogEntryA", FileLogHandleMarshal, FileLogHandle, "ptr", LogSectionName, "ptr", TargetFilename, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11873,7 +11873,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupRemoveFileLogEntryW", FileLogHandleMarshal, FileLogHandle, "ptr", LogSectionName, "ptr", TargetFilename, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11968,7 +11968,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueryFileLogA", FileLogHandleMarshal, FileLogHandle, "ptr", LogSectionName, "ptr", TargetFilename, "int", DesiredInfo, "ptr", DataOut, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12063,7 +12063,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupQueryFileLogW", FileLogHandleMarshal, FileLogHandle, "ptr", LogSectionName, "ptr", TargetFilename, "int", DesiredInfo, "ptr", DataOut, "uint", ReturnBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12080,7 +12080,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupOpenLog", "int", Erase, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12103,7 +12103,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupLogErrorA", "ptr", MessageString, "uint", Severity, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12126,7 +12126,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupLogErrorW", "ptr", MessageString, "uint", Severity, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12421,7 +12421,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceInfoListClass", "ptr", DeviceInfoSet, "ptr", ClassGuid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12441,7 +12441,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceInfoListDetailA", "ptr", DeviceInfoSet, "ptr", DeviceInfoSetDetailData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12461,7 +12461,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceInfoListDetailW", "ptr", DeviceInfoSet, "ptr", DeviceInfoSetDetailData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12489,7 +12489,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiCreateDeviceInfoA", "ptr", DeviceInfoSet, "ptr", DeviceName, "ptr", ClassGuid, "ptr", DeviceDescription, "ptr", hwndParent, "uint", CreationFlags, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12517,7 +12517,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiCreateDeviceInfoW", "ptr", DeviceInfoSet, "ptr", DeviceName, "ptr", ClassGuid, "ptr", DeviceDescription, "ptr", hwndParent, "uint", CreationFlags, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12542,7 +12542,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiOpenDeviceInfoA", "ptr", DeviceInfoSet, "ptr", DeviceInstanceId, "ptr", hwndParent, "uint", OpenFlags, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12567,7 +12567,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiOpenDeviceInfoW", "ptr", DeviceInfoSet, "ptr", DeviceInstanceId, "ptr", hwndParent, "uint", OpenFlags, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12593,7 +12593,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceInstanceIdA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DeviceInstanceId, "uint", DeviceInstanceIdSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12619,7 +12619,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceInstanceIdW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DeviceInstanceId, "uint", DeviceInstanceIdSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12639,7 +12639,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiDeleteDeviceInfo", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12660,7 +12660,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiEnumDeviceInfo", "ptr", DeviceInfoSet, "uint", MemberIndex, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12679,7 +12679,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiDestroyDeviceInfoList", "ptr", DeviceInfoSet, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12704,7 +12704,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiEnumDeviceInterfaces", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", InterfaceClassGuid, "uint", MemberIndex, "ptr", DeviceInterfaceData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12729,7 +12729,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiCreateDeviceInterfaceA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", InterfaceClassGuid, "ptr", ReferenceString, "uint", CreationFlags, "ptr", DeviceInterfaceData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12754,7 +12754,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiCreateDeviceInterfaceW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", InterfaceClassGuid, "ptr", ReferenceString, "uint", CreationFlags, "ptr", DeviceInterfaceData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12777,7 +12777,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiOpenDeviceInterfaceA", "ptr", DeviceInfoSet, "ptr", DevicePath, "uint", OpenFlags, "ptr", DeviceInterfaceData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12800,7 +12800,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiOpenDeviceInterfaceW", "ptr", DeviceInfoSet, "ptr", DevicePath, "uint", OpenFlags, "ptr", DeviceInterfaceData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12865,7 +12865,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceInterfaceAlias", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "ptr", AliasInterfaceClassGuid, "ptr", AliasDeviceInterfaceData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12885,7 +12885,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiDeleteDeviceInterfaceData", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12907,7 +12907,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiRemoveDeviceInterface", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12933,7 +12933,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceInterfaceDetailA", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "ptr", DeviceInterfaceDetailData, "uint", DeviceInterfaceDetailDataSize, RequiredSizeMarshal, RequiredSize, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12961,7 +12961,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceInterfaceDetailW", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "ptr", DeviceInterfaceDetailData, "uint", DeviceInterfaceDetailDataSize, RequiredSizeMarshal, RequiredSize, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12981,7 +12981,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiInstallDeviceInterfaces", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13004,7 +13004,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetDeviceInterfaceDefault", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "uint", Flags, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13047,7 +13047,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiRegisterDeviceInfo", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Flags, "ptr", CompareProc, CompareContextMarshal, CompareContext, "ptr", DupDeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13070,7 +13070,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiBuildDriverInfoList", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", DriverType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13089,7 +13089,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiCancelDriverInfoSearch", "ptr", DeviceInfoSet, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13112,7 +13112,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiEnumDriverInfoA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", DriverType, "uint", MemberIndex, "ptr", DriverInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13135,7 +13135,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiEnumDriverInfoW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", DriverType, "uint", MemberIndex, "ptr", DriverInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13156,7 +13156,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetSelectedDriverA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DriverInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13177,7 +13177,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetSelectedDriverW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DriverInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13198,7 +13198,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetSelectedDriverA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DriverInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13219,7 +13219,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetSelectedDriverW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DriverInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13245,7 +13245,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDriverInfoDetailA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DriverInfoData, "ptr", DriverInfoDetailData, "uint", DriverInfoDetailDataSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13271,7 +13271,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDriverInfoDetailW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DriverInfoData, "ptr", DriverInfoDetailData, "uint", DriverInfoDetailDataSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13292,7 +13292,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiDestroyDriverInfoList", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", DriverType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13464,7 +13464,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetINFClassA", "ptr", InfName, "ptr", ClassGuid, "ptr", ClassName, "uint", ClassNameSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13490,7 +13490,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetINFClassW", "ptr", InfName, "ptr", ClassGuid, "ptr", ClassName, "uint", ClassNameSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13514,7 +13514,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiBuildClassInfoList", "uint", Flags, "ptr", ClassGuidList, "uint", ClassGuidListSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13541,7 +13541,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiBuildClassInfoListExA", "uint", Flags, "ptr", ClassGuidList, "uint", ClassGuidListSize, RequiredSizeMarshal, RequiredSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13568,7 +13568,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiBuildClassInfoListExW", "uint", Flags, "ptr", ClassGuidList, "uint", ClassGuidListSize, RequiredSizeMarshal, RequiredSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13592,7 +13592,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassDescriptionA", "ptr", ClassGuid, "ptr", ClassDescription, "uint", ClassDescriptionSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13616,7 +13616,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassDescriptionW", "ptr", ClassGuid, "ptr", ClassDescription, "uint", ClassDescriptionSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13644,7 +13644,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassDescriptionExA", "ptr", ClassGuid, "ptr", ClassDescription, "uint", ClassDescriptionSize, RequiredSizeMarshal, RequiredSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13672,7 +13672,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassDescriptionExW", "ptr", ClassGuid, "ptr", ClassDescription, "uint", ClassDescriptionSize, RequiredSizeMarshal, RequiredSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13699,7 +13699,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiCallClassInstaller", "uint", InstallFunction, "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13719,7 +13719,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSelectDevice", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13739,7 +13739,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSelectBestCompatDrv", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13759,7 +13759,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiInstallDevice", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13779,7 +13779,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiInstallDriverFiles", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13799,7 +13799,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiRegisterCoDeviceInstallers", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13834,7 +13834,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiUnremoveDevice", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13853,7 +13853,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiRestartDevices", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13873,7 +13873,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiChangeState", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13898,7 +13898,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiInstallClassA", "ptr", hwndParent, "ptr", InfFileName, "uint", Flags, FileQueueMarshal, FileQueue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13923,7 +13923,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiInstallClassW", "ptr", hwndParent, "ptr", InfFileName, "uint", Flags, FileQueueMarshal, FileQueue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13951,7 +13951,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiInstallClassExA", "ptr", hwndParent, "ptr", InfFileName, "uint", Flags, FileQueueMarshal, FileQueue, "ptr", InterfaceClassGuid, "ptr", Reserved1, "ptr", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13979,7 +13979,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiInstallClassExW", "ptr", hwndParent, "ptr", InfFileName, "uint", Flags, FileQueueMarshal, FileQueue, "ptr", InterfaceClassGuid, "ptr", Reserved1, "ptr", Reserved2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14148,7 +14148,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiDeleteDeviceInterfaceRegKey", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "uint", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14268,7 +14268,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiDeleteDevRegKey", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Scope, "uint", HwProfile, "uint", KeyType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14292,7 +14292,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetHwProfileList", HwProfileListMarshal, HwProfileList, "uint", HwProfileListSize, RequiredSizeMarshal, RequiredSize, CurrentlyActiveIndexMarshal, CurrentlyActiveIndex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14321,7 +14321,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetHwProfileListExA", HwProfileListMarshal, HwProfileList, "uint", HwProfileListSize, RequiredSizeMarshal, RequiredSize, CurrentlyActiveIndexMarshal, CurrentlyActiveIndex, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14350,7 +14350,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetHwProfileListExW", HwProfileListMarshal, HwProfileList, "uint", HwProfileListSize, RequiredSizeMarshal, RequiredSize, CurrentlyActiveIndexMarshal, CurrentlyActiveIndex, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14474,7 +14474,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDevicePropertyKeys", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", PropertyKeyArray, "uint", PropertyKeyCount, RequiredPropertyKeyCountMarshal, RequiredPropertyKeyCount, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14633,7 +14633,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDevicePropertyW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", PropertyKey, PropertyTypeMarshal, PropertyType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, RequiredSizeMarshal, RequiredSize, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14789,7 +14789,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetDevicePropertyW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", PropertyKey, "uint", PropertyType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14912,7 +14912,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceInterfacePropertyKeys", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "ptr", PropertyKeyArray, "uint", PropertyKeyCount, RequiredPropertyKeyCountMarshal, RequiredPropertyKeyCount, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15072,7 +15072,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceInterfacePropertyW", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "ptr", PropertyKey, PropertyTypeMarshal, PropertyType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, RequiredSizeMarshal, RequiredSize, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15228,7 +15228,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetDeviceInterfacePropertyW", "ptr", DeviceInfoSet, "ptr", DeviceInterfaceData, "ptr", PropertyKey, "uint", PropertyType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15371,7 +15371,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassPropertyKeys", "ptr", ClassGuid, "ptr", PropertyKeyArray, "uint", PropertyKeyCount, RequiredPropertyKeyCountMarshal, RequiredPropertyKeyCount, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15530,7 +15530,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassPropertyKeysExW", "ptr", ClassGuid, "ptr", PropertyKeyArray, "uint", PropertyKeyCount, RequiredPropertyKeyCountMarshal, RequiredPropertyKeyCount, "uint", Flags, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15698,7 +15698,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassPropertyW", "ptr", ClassGuid, "ptr", PropertyKey, PropertyTypeMarshal, PropertyType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, RequiredSizeMarshal, RequiredSize, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15882,7 +15882,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassPropertyExW", "ptr", ClassGuid, "ptr", PropertyKey, PropertyTypeMarshal, PropertyType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, RequiredSizeMarshal, RequiredSize, "uint", Flags, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16035,7 +16035,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetClassPropertyW", "ptr", ClassGuid, "ptr", PropertyKey, "uint", PropertyType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16204,7 +16204,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetClassPropertyExW", "ptr", ClassGuid, "ptr", PropertyKey, "uint", PropertyType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, "uint", Flags, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16232,7 +16232,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceRegistryPropertyA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Property, PropertyRegDataTypeMarshal, PropertyRegDataType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16260,7 +16260,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceRegistryPropertyW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Property, PropertyRegDataTypeMarshal, PropertyRegDataType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16290,7 +16290,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassRegistryPropertyA", "ptr", ClassGuid, "uint", Property, PropertyRegDataTypeMarshal, PropertyRegDataType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, RequiredSizeMarshal, RequiredSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16320,7 +16320,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassRegistryPropertyW", "ptr", ClassGuid, "uint", Property, PropertyRegDataTypeMarshal, PropertyRegDataType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, RequiredSizeMarshal, RequiredSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16343,7 +16343,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetDeviceRegistryPropertyA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Property, "ptr", PropertyBuffer, "uint", PropertyBufferSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16366,7 +16366,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetDeviceRegistryPropertyW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Property, "ptr", PropertyBuffer, "uint", PropertyBufferSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16391,7 +16391,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetClassRegistryPropertyA", "ptr", ClassGuid, "uint", Property, "ptr", PropertyBuffer, "uint", PropertyBufferSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16416,7 +16416,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetClassRegistryPropertyW", "ptr", ClassGuid, "uint", Property, "ptr", PropertyBuffer, "uint", PropertyBufferSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16437,7 +16437,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceInstallParamsA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DeviceInstallParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16458,7 +16458,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDeviceInstallParamsW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DeviceInstallParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16483,7 +16483,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassInstallParamsA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", ClassInstallParams, "uint", ClassInstallParamsSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16508,7 +16508,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassInstallParamsW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", ClassInstallParams, "uint", ClassInstallParamsSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16529,7 +16529,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetDeviceInstallParamsA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DeviceInstallParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16550,7 +16550,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetDeviceInstallParamsW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DeviceInstallParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16572,7 +16572,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetClassInstallParamsA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", ClassInstallParams, "uint", ClassInstallParamsSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16596,7 +16596,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetClassInstallParamsW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", ClassInstallParams, "uint", ClassInstallParamsSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16618,7 +16618,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDriverInstallParamsA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DriverInfoData, "ptr", DriverInstallParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16640,7 +16640,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetDriverInstallParamsW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DriverInfoData, "ptr", DriverInstallParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16662,7 +16662,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetDriverInstallParamsA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DriverInfoData, "ptr", DriverInstallParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16684,7 +16684,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetDriverInstallParamsW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DriverInfoData, "ptr", DriverInstallParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16705,7 +16705,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiLoadClassIcon", "ptr", ClassGuid, "ptr", LargeIcon, MiniIconIndexMarshal, MiniIconIndex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16729,7 +16729,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiLoadDeviceIcon", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", cxIcon, "uint", cyIcon, "uint", Flags, "ptr", hIcon, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16903,7 +16903,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassBitmapIndex", "ptr", ClassGuid, MiniIconIndexMarshal, MiniIconIndex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16920,7 +16920,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassImageList", "ptr", ClassImageListData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16942,7 +16942,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassImageListExA", "ptr", ClassImageListData, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16964,7 +16964,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassImageListExW", "ptr", ClassImageListData, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16985,7 +16985,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassImageIndex", "ptr", ClassImageListData, "ptr", ClassGuid, ImageIndexMarshal, ImageIndex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17002,7 +17002,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiDestroyClassImageList", "ptr", ClassImageListData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17028,7 +17028,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassDevPropertySheetsA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", PropertySheetHeader, "uint", PropertySheetHeaderPageListSize, RequiredSizeMarshal, RequiredSize, "uint", PropertySheetType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17054,7 +17054,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetClassDevPropertySheetsW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", PropertySheetHeader, "uint", PropertySheetHeaderPageListSize, RequiredSizeMarshal, RequiredSize, "uint", PropertySheetType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17074,7 +17074,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiAskForOEMDisk", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17096,7 +17096,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSelectOEMDrv", "ptr", hwndParent, "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17120,7 +17120,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiClassNameFromGuidA", "ptr", ClassGuid, "ptr", ClassName, "uint", ClassNameSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17144,7 +17144,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiClassNameFromGuidW", "ptr", ClassGuid, "ptr", ClassName, "uint", ClassNameSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17172,7 +17172,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiClassNameFromGuidExA", "ptr", ClassGuid, "ptr", ClassName, "uint", ClassNameSize, RequiredSizeMarshal, RequiredSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17200,7 +17200,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiClassNameFromGuidExW", "ptr", ClassGuid, "ptr", ClassName, "uint", ClassNameSize, RequiredSizeMarshal, RequiredSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17224,7 +17224,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiClassGuidsFromNameA", "ptr", ClassName, "ptr", ClassGuidList, "uint", ClassGuidListSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17248,7 +17248,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiClassGuidsFromNameW", "ptr", ClassName, "ptr", ClassGuidList, "uint", ClassGuidListSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17276,7 +17276,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiClassGuidsFromNameExA", "ptr", ClassName, "ptr", ClassGuidList, "uint", ClassGuidListSize, RequiredSizeMarshal, RequiredSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17304,7 +17304,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiClassGuidsFromNameExW", "ptr", ClassName, "ptr", ClassGuidList, "uint", ClassGuidListSize, RequiredSizeMarshal, RequiredSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17328,7 +17328,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetHwProfileFriendlyNameA", "uint", HwProfile, "ptr", FriendlyName, "uint", FriendlyNameSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17352,7 +17352,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetHwProfileFriendlyNameW", "uint", HwProfile, "ptr", FriendlyName, "uint", FriendlyNameSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17380,7 +17380,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetHwProfileFriendlyNameExA", "uint", HwProfile, "ptr", FriendlyName, "uint", FriendlyNameSize, RequiredSizeMarshal, RequiredSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17408,7 +17408,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetHwProfileFriendlyNameExW", "uint", HwProfile, "ptr", FriendlyName, "uint", FriendlyNameSize, RequiredSizeMarshal, RequiredSize, "ptr", MachineName, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17444,7 +17444,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetSelectedDevice", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17464,7 +17464,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiSetSelectedDevice", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17490,7 +17490,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetActualModelsSectionA", "ptr", Context, "ptr", AlternatePlatformInfo, "ptr", InfSectionWithExt, "uint", InfSectionWithExtSize, RequiredSizeMarshal, RequiredSize, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17516,7 +17516,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetActualModelsSectionW", "ptr", Context, "ptr", AlternatePlatformInfo, "ptr", InfSectionWithExt, "uint", InfSectionWithExtSize, RequiredSizeMarshal, RequiredSize, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17545,7 +17545,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetActualSectionToInstallA", InfHandleMarshal, InfHandle, "ptr", InfSectionName, "ptr", InfSectionWithExt, "uint", InfSectionWithExtSize, RequiredSizeMarshal, RequiredSize, ExtensionMarshal, Extension, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17574,7 +17574,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetActualSectionToInstallW", InfHandleMarshal, InfHandle, "ptr", InfSectionName, "ptr", InfSectionWithExt, "uint", InfSectionWithExtSize, RequiredSizeMarshal, RequiredSize, ExtensionMarshal, Extension, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17606,7 +17606,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetActualSectionToInstallExA", InfHandleMarshal, InfHandle, "ptr", InfSectionName, "ptr", AlternatePlatformInfo, "ptr", InfSectionWithExt, "uint", InfSectionWithExtSize, RequiredSizeMarshal, RequiredSize, ExtensionMarshal, Extension, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17638,7 +17638,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetActualSectionToInstallExW", InfHandleMarshal, InfHandle, "ptr", InfSectionName, "ptr", AlternatePlatformInfo, "ptr", InfSectionWithExt, "uint", InfSectionWithExtSize, RequiredSizeMarshal, RequiredSize, ExtensionMarshal, Extension, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17670,7 +17670,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupEnumInfSectionsA", InfHandleMarshal, InfHandle, "uint", Index, "ptr", Buffer, "uint", Size, SizeNeededMarshal, SizeNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17702,7 +17702,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupEnumInfSectionsW", InfHandleMarshal, InfHandle, "uint", Index, "ptr", Buffer, "uint", Size, SizeNeededMarshal, SizeNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17766,7 +17766,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetCustomDevicePropertyA", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", CustomPropertyName, "uint", Flags, PropertyRegDataTypeMarshal, PropertyRegDataType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17796,7 +17796,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("SETUPAPI.dll\SetupDiGetCustomDevicePropertyW", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", CustomPropertyName, "uint", Flags, PropertyRegDataTypeMarshal, PropertyRegDataType, "ptr", PropertyBuffer, "uint", PropertyBufferSize, RequiredSizeMarshal, RequiredSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23237,7 +23237,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("newdev.dll\UpdateDriverForPlugAndPlayDevicesA", "ptr", hwndParent, "ptr", HardwareId, "ptr", FullInfPath, "uint", InstallFlags, bRebootRequiredMarshal, bRebootRequired, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23333,7 +23333,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("newdev.dll\UpdateDriverForPlugAndPlayDevicesW", "ptr", hwndParent, "ptr", HardwareId, "ptr", FullInfPath, "uint", InstallFlags, bRebootRequiredMarshal, bRebootRequired, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23400,7 +23400,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("newdev.dll\DiInstallDevice", "ptr", hwndParent, "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", DriverInfoData, "uint", Flags, NeedRebootMarshal, NeedReboot, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23482,7 +23482,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("newdev.dll\DiInstallDriverW", "ptr", hwndParent, "ptr", InfPath, "uint", Flags, NeedRebootMarshal, NeedReboot, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23564,7 +23564,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("newdev.dll\DiInstallDriverA", "ptr", hwndParent, "ptr", InfPath, "uint", Flags, NeedRebootMarshal, NeedReboot, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23629,7 +23629,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("newdev.dll\DiUninstallDevice", "ptr", hwndParent, "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Flags, NeedRebootMarshal, NeedReboot, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23654,7 +23654,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("newdev.dll\DiUninstallDriverW", "ptr", hwndParent, "ptr", InfPath, "uint", Flags, NeedRebootMarshal, NeedReboot, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23736,7 +23736,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("newdev.dll\DiUninstallDriverA", "ptr", hwndParent, "ptr", InfPath, "uint", Flags, NeedRebootMarshal, NeedReboot, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23813,7 +23813,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("newdev.dll\DiShowUpdateDevice", "ptr", hwndParent, "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "uint", Flags, NeedRebootMarshal, NeedReboot, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23898,7 +23898,7 @@ class DeviceAndDriverInstallation {
         A_LastError := 0
 
         result := DllCall("newdev.dll\DiRollbackDriver", "ptr", DeviceInfoSet, "ptr", DeviceInfoData, "ptr", hwndParent, "uint", Flags, NeedRebootMarshal, NeedReboot, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Devices/Display/Apis.ahk
+++ b/Windows/Win32/Devices/Display/Apis.ahk
@@ -3851,7 +3851,7 @@ class Display {
         A_LastError := 0
 
         result := DllCall("dxva2.dll\GetNumberOfPhysicalMonitorsFromHMONITOR", "ptr", hMonitor, pdwNumberOfPhysicalMonitorsMarshal, pdwNumberOfPhysicalMonitors, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3887,7 +3887,7 @@ class Display {
         A_LastError := 0
 
         result := DllCall("dxva2.dll\GetPhysicalMonitorsFromHMONITOR", "ptr", hMonitor, "uint", dwPhysicalMonitorArraySize, "ptr", pPhysicalMonitorArray, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3923,7 +3923,7 @@ class Display {
         A_LastError := 0
 
         result := DllCall("dxva2.dll\DestroyPhysicalMonitor", "ptr", hMonitor, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3941,7 +3941,7 @@ class Display {
         A_LastError := 0
 
         result := DllCall("dxva2.dll\DestroyPhysicalMonitors", "uint", dwPhysicalMonitorArraySize, "ptr", pPhysicalMonitorArray, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Devices/Fax/Apis.ahk
+++ b/Windows/Win32/Devices/Fax/Apis.ahk
@@ -1432,7 +1432,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxConnectFaxServerA", "ptr", MachineName, "ptr", FaxHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1500,7 +1500,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxConnectFaxServerW", "ptr", MachineName, "ptr", FaxHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1692,7 +1692,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSendDocumentA", "ptr", FaxHandle, "ptr", FileName, "ptr", JobParams, "ptr", CoverpageInfo, FaxJobIdMarshal, FaxJobId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1809,7 +1809,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSendDocumentW", "ptr", FaxHandle, "ptr", FileName, "ptr", JobParams, "ptr", CoverpageInfo, FaxJobIdMarshal, FaxJobId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1907,7 +1907,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSendDocumentForBroadcastA", "ptr", FaxHandle, "ptr", FileName, FaxJobIdMarshal, FaxJobId, "ptr", FaxRecipientCallback, ContextMarshal, Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2005,7 +2005,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSendDocumentForBroadcastW", "ptr", FaxHandle, "ptr", FileName, FaxJobIdMarshal, FaxJobId, "ptr", FaxRecipientCallback, ContextMarshal, Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2079,7 +2079,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxEnumJobsA", "ptr", FaxHandle, JobEntryMarshal, JobEntry, JobsReturnedMarshal, JobsReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2153,7 +2153,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxEnumJobsW", "ptr", FaxHandle, JobEntryMarshal, JobEntry, JobsReturnedMarshal, JobsReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2226,7 +2226,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxGetJobA", "ptr", FaxHandle, "uint", JobId, JobEntryMarshal, JobEntry, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2299,7 +2299,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxGetJobW", "ptr", FaxHandle, "uint", JobId, JobEntryMarshal, JobEntry, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2360,7 +2360,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSetJobA", "ptr", FaxHandle, "uint", JobId, "uint", Command, "ptr", JobEntry, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2421,7 +2421,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSetJobW", "ptr", FaxHandle, "uint", JobId, "uint", Command, "ptr", JobEntry, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2513,7 +2513,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxGetDeviceStatusA", "ptr", FaxPortHandle, DeviceStatusMarshal, DeviceStatus, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2583,7 +2583,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxGetDeviceStatusW", "ptr", FaxPortHandle, DeviceStatusMarshal, DeviceStatus, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2666,7 +2666,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxGetConfigurationA", "ptr", FaxHandle, FaxConfigMarshal, FaxConfig, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2736,7 +2736,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxGetConfigurationW", "ptr", FaxHandle, FaxConfigMarshal, FaxConfig, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2804,7 +2804,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSetConfigurationA", "ptr", FaxHandle, "ptr", FaxConfig, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2872,7 +2872,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSetConfigurationW", "ptr", FaxHandle, "ptr", FaxConfig, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2950,7 +2950,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxGetLoggingCategoriesA", "ptr", FaxHandle, CategoriesMarshal, Categories, NumberCategoriesMarshal, NumberCategories, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3028,7 +3028,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxGetLoggingCategoriesW", "ptr", FaxHandle, CategoriesMarshal, Categories, NumberCategoriesMarshal, NumberCategories, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3110,7 +3110,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSetLoggingCategoriesA", "ptr", FaxHandle, "ptr", Categories, "uint", NumberCategories, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3192,7 +3192,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSetLoggingCategoriesW", "ptr", FaxHandle, "ptr", Categories, "uint", NumberCategories, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3266,7 +3266,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxEnumPortsA", "ptr", FaxHandle, PortInfoMarshal, PortInfo, PortsReturnedMarshal, PortsReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3340,7 +3340,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxEnumPortsW", "ptr", FaxHandle, PortInfoMarshal, PortInfo, PortsReturnedMarshal, PortsReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3410,7 +3410,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxGetPortA", "ptr", FaxPortHandle, PortInfoMarshal, PortInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3480,7 +3480,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxGetPortW", "ptr", FaxPortHandle, PortInfoMarshal, PortInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3548,7 +3548,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSetPortA", "ptr", FaxPortHandle, "ptr", PortInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3616,7 +3616,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSetPortW", "ptr", FaxPortHandle, "ptr", PortInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3694,7 +3694,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxEnumRoutingMethodsA", "ptr", FaxPortHandle, RoutingMethodMarshal, RoutingMethod, MethodsReturnedMarshal, MethodsReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3772,7 +3772,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxEnumRoutingMethodsW", "ptr", FaxPortHandle, RoutingMethodMarshal, RoutingMethod, MethodsReturnedMarshal, MethodsReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3848,7 +3848,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxEnableRoutingMethodA", "ptr", FaxPortHandle, "ptr", RoutingGuid, "int", Enabled, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3924,7 +3924,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxEnableRoutingMethodW", "ptr", FaxPortHandle, "ptr", RoutingGuid, "int", Enabled, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3998,7 +3998,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxEnumGlobalRoutingInfoA", "ptr", FaxHandle, RoutingInfoMarshal, RoutingInfo, MethodsReturnedMarshal, MethodsReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4072,7 +4072,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxEnumGlobalRoutingInfoW", "ptr", FaxHandle, RoutingInfoMarshal, RoutingInfo, MethodsReturnedMarshal, MethodsReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4140,7 +4140,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSetGlobalRoutingInfoA", "ptr", FaxHandle, "ptr", RoutingInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4208,7 +4208,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSetGlobalRoutingInfoW", "ptr", FaxHandle, "ptr", RoutingInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4301,7 +4301,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxGetRoutingInfoA", "ptr", FaxPortHandle, "ptr", RoutingGuid, RoutingInfoBufferMarshal, RoutingInfoBuffer, RoutingInfoBufferSizeMarshal, RoutingInfoBufferSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4394,7 +4394,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxGetRoutingInfoW", "ptr", FaxPortHandle, "ptr", RoutingGuid, RoutingInfoBufferMarshal, RoutingInfoBuffer, RoutingInfoBufferSizeMarshal, RoutingInfoBufferSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4475,7 +4475,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSetRoutingInfoA", "ptr", FaxPortHandle, "ptr", RoutingGuid, RoutingInfoBufferMarshal, RoutingInfoBuffer, "uint", RoutingInfoBufferSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4556,7 +4556,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxSetRoutingInfoW", "ptr", FaxPortHandle, "ptr", RoutingGuid, RoutingInfoBufferMarshal, RoutingInfoBuffer, "uint", RoutingInfoBufferSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4693,7 +4693,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxStartPrintJobA", "ptr", PrinterName, "ptr", PrintInfo, FaxJobIdMarshal, FaxJobId, "ptr", FaxContextInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4801,7 +4801,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxStartPrintJobW", "ptr", PrinterName, "ptr", PrintInfo, FaxJobIdMarshal, FaxJobId, "ptr", FaxContextInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4867,7 +4867,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxPrintCoverPageA", "ptr", FaxContextInfo, "ptr", CoverPageInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4933,7 +4933,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxPrintCoverPageW", "ptr", FaxContextInfo, "ptr", CoverPageInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4988,7 +4988,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxRegisterServiceProviderW", "ptr", DeviceProvider, "ptr", FriendlyName, "ptr", ImageName, "ptr", TspName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5074,7 +5074,7 @@ class Fax {
         A_LastError := 0
 
         result := DllCall("WINFAX.dll\FaxRegisterRoutingExtensionW", "ptr", FaxHandle, "ptr", ExtensionName, "ptr", FriendlyName, "ptr", ImageName, "ptr", CallBack, ContextMarshal, Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Devices/Usb/Apis.ahk
+++ b/Windows/Win32/Devices/Usb/Apis.ahk
@@ -2815,7 +2815,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_Initialize", "ptr", DeviceHandle, "ptr", InterfaceHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2911,7 +2911,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_GetAssociatedInterface", "ptr", InterfaceHandle, "char", AssociatedInterfaceIndex, "ptr", AssociatedInterfaceHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2968,7 +2968,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_GetDescriptor", "ptr", InterfaceHandle, "char", DescriptorType, "char", Index, "ushort", LanguageID, "ptr", Buffer, "uint", BufferLength, LengthTransferredMarshal, LengthTransferred, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3024,7 +3024,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_QueryInterfaceSettings", "ptr", InterfaceHandle, "char", AlternateInterfaceNumber, "ptr", UsbAltInterfaceDescriptor, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3074,7 +3074,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_QueryDeviceInformation", "ptr", InterfaceHandle, "uint", InformationType, BufferLengthMarshal, BufferLength, "ptr", Buffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3118,7 +3118,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_SetCurrentAlternateSetting", "ptr", InterfaceHandle, "char", SettingNumber, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3162,7 +3162,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_GetCurrentAlternateSetting", "ptr", InterfaceHandle, SettingNumberMarshal, SettingNumber, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3230,7 +3230,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_QueryPipe", "ptr", InterfaceHandle, "char", AlternateInterfaceNumber, "char", PipeIndex, "ptr", PipeInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3298,7 +3298,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_QueryPipeEx", "ptr", InterfaceHandle, "char", AlternateSettingNumber, "char", PipeIndex, "ptr", PipeInformationEx, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3367,7 +3367,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_SetPipePolicy", "ptr", InterfaceHandle, "char", PipeID, "uint", PolicyType, "uint", ValueLength, "ptr", Value, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3416,7 +3416,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_GetPipePolicy", "ptr", InterfaceHandle, "char", PipeID, "uint", PolicyType, ValueLengthMarshal, ValueLength, "ptr", Value, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3499,7 +3499,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_ReadPipe", "ptr", InterfaceHandle, "char", PipeID, "ptr", Buffer, "uint", BufferLength, LengthTransferredMarshal, LengthTransferred, "ptr", Overlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3582,7 +3582,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_WritePipe", "ptr", InterfaceHandle, "char", PipeID, "ptr", Buffer, "uint", BufferLength, LengthTransferredMarshal, LengthTransferred, "ptr", Overlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3644,7 +3644,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_ControlTransfer", "ptr", InterfaceHandle, "ptr", SetupPacket, "ptr", Buffer, "uint", BufferLength, LengthTransferredMarshal, LengthTransferred, "ptr", Overlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3688,7 +3688,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_ResetPipe", "ptr", InterfaceHandle, "char", PipeID, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3732,7 +3732,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_AbortPipe", "ptr", InterfaceHandle, "char", PipeID, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3774,7 +3774,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_FlushPipe", "ptr", InterfaceHandle, "char", PipeID, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3883,7 +3883,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_SetPowerPolicy", "ptr", InterfaceHandle, "uint", PolicyType, "uint", ValueLength, "ptr", Value, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3970,7 +3970,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_GetPowerPolicy", "ptr", InterfaceHandle, "uint", PolicyType, ValueLengthMarshal, ValueLength, "ptr", Value, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3993,7 +3993,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_GetOverlappedResult", "ptr", InterfaceHandle, "ptr", lpOverlapped, lpNumberOfBytesTransferredMarshal, lpNumberOfBytesTransferred, "int", bWait, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4060,7 +4060,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_GetCurrentFrameNumber", "ptr", InterfaceHandle, CurrentFrameNumberMarshal, CurrentFrameNumber, TimeStampMarshal, TimeStamp, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4080,7 +4080,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_GetAdjustedFrameNumber", CurrentFrameNumberMarshal, CurrentFrameNumber, "int64", TimeStamp, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4107,7 +4107,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_RegisterIsochBuffer", "ptr", InterfaceHandle, "char", PipeID, "ptr", Buffer, "uint", BufferLength, IsochBufferHandleMarshal, IsochBufferHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4126,7 +4126,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_UnregisterIsochBuffer", IsochBufferHandleMarshal, IsochBufferHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4150,7 +4150,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_WriteIsochPipe", BufferHandleMarshal, BufferHandle, "uint", Offset, "uint", Length, FrameNumberMarshal, FrameNumber, "ptr", Overlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4176,7 +4176,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_ReadIsochPipe", BufferHandleMarshal, BufferHandle, "uint", Offset, "uint", Length, FrameNumberMarshal, FrameNumber, "uint", NumberOfPackets, "ptr", IsoPacketDescriptors, "ptr", Overlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4201,7 +4201,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_WriteIsochPipeAsap", BufferHandleMarshal, BufferHandle, "uint", Offset, "uint", Length, "int", ContinueStream, "ptr", Overlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4228,7 +4228,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_ReadIsochPipeAsap", BufferHandleMarshal, BufferHandle, "uint", Offset, "uint", Length, "int", ContinueStream, "uint", NumberOfPackets, "ptr", IsoPacketDescriptors, "ptr", Overlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4272,7 +4272,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_StartTrackingForTimeSync", "ptr", InterfaceHandle, "ptr", StartTrackingInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4317,7 +4317,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_GetCurrentFrameNumberAndQpc", "ptr", InterfaceHandle, "ptr", FrameQpcInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4360,7 +4360,7 @@ class Usb {
         A_LastError := 0
 
         result := DllCall("WINUSB.dll\WinUsb_StopTrackingForTimeSync", "ptr", InterfaceHandle, "ptr", StopTrackingInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Foundation/Apis.ahk
+++ b/Windows/Win32/Foundation/Apis.ahk
@@ -35355,7 +35355,7 @@ class Foundation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CloseHandle", "ptr", hObject, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -35405,7 +35405,7 @@ class Foundation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DuplicateHandle", "ptr", hSourceProcessHandle, "ptr", hSourceHandle, "ptr", hTargetProcessHandle, "ptr", lpTargetHandle, "uint", dwDesiredAccess, "int", bInheritHandle, "uint", dwOptions, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -35484,7 +35484,7 @@ class Foundation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetHandleInformation", "ptr", hObject, lpdwFlagsMarshal, lpdwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -35513,7 +35513,7 @@ class Foundation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetHandleInformation", "ptr", hObject, "uint", dwMask, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -35537,7 +35537,7 @@ class Foundation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FreeLibrary", "ptr", hLibModule, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Globalization/Apis.ahk
+++ b/Windows/Win32/Globalization/Apis.ahk
@@ -4467,7 +4467,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("GDI32.dll\TranslateCharsetInfo", lpSrcMarshal, lpSrc, "ptr", lpCs, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5151,7 +5151,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetStringTypeExW", "uint", Locale, "uint", dwInfoType, "ptr", lpSrcStr, "int", cchSrc, lpCharTypeMarshal, lpCharType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5217,7 +5217,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetStringTypeW", "uint", dwInfoType, "ptr", lpSrcStr, "int", cchSrc, lpCharTypeMarshal, lpCharType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5532,7 +5532,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetCPInfo", "uint", CodePage, "ptr", lpCPInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5603,7 +5603,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetCPInfoExA", "uint", CodePage, "uint", dwFlags, "ptr", lpCPInfoEx, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5674,7 +5674,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetCPInfoExW", "uint", CodePage, "uint", dwFlags, "ptr", lpCPInfoEx, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6114,7 +6114,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetLocaleInfoA", "uint", Locale, "uint", LCType, "ptr", lpLCData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6169,7 +6169,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetLocaleInfoW", "uint", Locale, "uint", LCType, "ptr", lpLCData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6350,7 +6350,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetCalendarInfoA", "uint", Locale, "uint", Calendar, "uint", CalType, "ptr", lpCalData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6409,7 +6409,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetCalendarInfoW", "uint", Locale, "uint", Calendar, "uint", CalType, "ptr", lpCalData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6428,7 +6428,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\IsDBCSLeadByte", "char", TestChar, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6493,7 +6493,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\IsDBCSLeadByteEx", "uint", CodePage, "char", TestChar, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6957,7 +6957,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumCalendarInfoA", "ptr", lpCalInfoEnumProc, "uint", Locale, "uint", Calendar, "uint", CalType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7003,7 +7003,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumCalendarInfoW", "ptr", lpCalInfoEnumProc, "uint", Locale, "uint", Calendar, "uint", CalType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7053,7 +7053,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumCalendarInfoExA", "ptr", lpCalInfoEnumProcEx, "uint", Locale, "uint", Calendar, "uint", CalType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7103,7 +7103,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumCalendarInfoExW", "ptr", lpCalInfoEnumProcEx, "uint", Locale, "uint", Calendar, "uint", CalType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7148,7 +7148,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumTimeFormatsA", "ptr", lpTimeFmtEnumProc, "uint", Locale, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7193,7 +7193,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumTimeFormatsW", "ptr", lpTimeFmtEnumProc, "uint", Locale, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7238,7 +7238,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumDateFormatsA", "ptr", lpDateFmtEnumProc, "uint", Locale, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7283,7 +7283,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumDateFormatsW", "ptr", lpDateFmtEnumProc, "uint", Locale, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7332,7 +7332,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumDateFormatsExA", "ptr", lpDateFmtEnumProcEx, "uint", Locale, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7381,7 +7381,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumDateFormatsExW", "ptr", lpDateFmtEnumProcEx, "uint", Locale, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7447,7 +7447,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNLSVersion", "uint", Function, "uint", Locale, "ptr", lpVersionInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7677,7 +7677,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumSystemGeoID", "uint", GeoClass, "int", ParentGeoId, "ptr", lpGeoEnumProc, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7725,7 +7725,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumSystemGeoNames", "uint", geoClass, "ptr", geoEnumProc, "ptr", data, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7829,7 +7829,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetUserGeoID", "int", GeoId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7890,7 +7890,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetUserGeoName", "ptr", geoName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8141,7 +8141,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetProcessPreferredUILanguages", "uint", dwFlags, pulNumLanguagesMarshal, pulNumLanguages, "ptr", pwszLanguagesBuffer, pcchLanguagesBufferMarshal, pcchLanguagesBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8200,7 +8200,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetProcessPreferredUILanguages", "uint", dwFlags, "ptr", pwszLanguagesBuffer, pulNumLanguagesMarshal, pulNumLanguages, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8238,7 +8238,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetUserPreferredUILanguages", "uint", dwFlags, pulNumLanguagesMarshal, pulNumLanguages, "ptr", pwszLanguagesBuffer, pcchLanguagesBufferMarshal, pcchLanguagesBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8321,7 +8321,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetSystemPreferredUILanguages", "uint", dwFlags, pulNumLanguagesMarshal, pulNumLanguages, "ptr", pwszLanguagesBuffer, pcchLanguagesBufferMarshal, pcchLanguagesBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8433,7 +8433,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetThreadPreferredUILanguages", "uint", dwFlags, pulNumLanguagesMarshal, pulNumLanguages, "ptr", pwszLanguagesBuffer, pcchLanguagesBufferMarshal, pcchLanguagesBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8575,7 +8575,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetFileMUIInfo", "uint", dwFlags, "ptr", pcwszFilePath, "ptr", pFileMUIInfo, pcbFileMUIInfoMarshal, pcbFileMUIInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8717,7 +8717,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetFileMUIPath", "uint", dwFlags, "ptr", pcwszFilePath, "ptr", pwszLanguage, pcchLanguageMarshal, pcchLanguage, "ptr", pwszFileMUIPath, pcchFileMUIPathMarshal, pcchFileMUIPath, pululEnumeratorMarshal, pululEnumerator, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8850,7 +8850,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetUILanguageInfo", "uint", dwFlags, "ptr", pwmszLanguage, "ptr", pwszFallbackLanguages, pcchFallbackLanguagesMarshal, pcchFallbackLanguages, pAttributesMarshal, pAttributes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8971,7 +8971,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetStringTypeA", "uint", Locale, "uint", dwInfoType, "ptr", lpSrcStr, "int", cchSrc, lpCharTypeMarshal, lpCharType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9070,7 +9070,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumSystemLocalesA", "ptr", lpLocaleEnumProc, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9131,7 +9131,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumSystemLocalesW", "ptr", lpLocaleEnumProc, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9156,7 +9156,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumSystemLanguageGroupsA", "ptr", lpLanguageGroupEnumProc, "uint", dwFlags, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9181,7 +9181,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumSystemLanguageGroupsW", "ptr", lpLanguageGroupEnumProc, "uint", dwFlags, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9207,7 +9207,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumLanguageGroupLocalesA", "ptr", lpLangGroupLocaleEnumProc, "uint", LanguageGroup, "uint", dwFlags, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9233,7 +9233,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumLanguageGroupLocalesW", "ptr", lpLangGroupLocaleEnumProc, "uint", LanguageGroup, "uint", dwFlags, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9331,7 +9331,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumUILanguagesA", "ptr", lpUILanguageEnumProc, "uint", dwFlags, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9429,7 +9429,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumUILanguagesW", "ptr", lpUILanguageEnumProc, "uint", dwFlags, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9453,7 +9453,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumSystemCodePagesA", "ptr", lpCodePageEnumProc, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9477,7 +9477,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumSystemCodePagesW", "ptr", lpCodePageEnumProc, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9708,7 +9708,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\IsNormalizedString", "int", NormForm, "ptr", lpString, "int", cwLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9757,7 +9757,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\VerifyScripts", "uint", dwFlags, "ptr", lpLocaleScripts, "int", cchLocaleScripts, "ptr", lpTestScripts, "int", cchTestScripts, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10120,7 +10120,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\IsNLSDefinedString", "uint", Function, "uint", dwFlags, "ptr", lpVersionInformation, "ptr", lpString, "int", cchStr, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10162,7 +10162,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNLSVersionEx", "uint", function, "ptr", lpLocaleName, "ptr", lpVersionInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10668,7 +10668,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumCalendarInfoExEx", "ptr", pCalInfoEnumProcExEx, "ptr", lpLocaleName, "uint", Calendar, "ptr", lpReserved, "uint", CalType, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10708,7 +10708,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumDateFormatsExEx", "ptr", lpDateFmtEnumProcExEx, "ptr", lpLocaleName, "uint", dwFlags, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10747,7 +10747,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumTimeFormatsEx", "ptr", lpTimeFmtEnumProcEx, "ptr", lpLocaleName, "uint", dwFlags, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10792,7 +10792,7 @@ class Globalization {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumSystemLocalesEx", "ptr", lpLocaleEnumProcEx, "uint", dwFlags, "ptr", lParam, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Graphics/Gdi/Apis.ahk
+++ b/Windows/Win32/Graphics/Gdi/Apis.ahk
@@ -4531,7 +4531,7 @@ class Gdi {
         A_LastError := 0
 
         result := DllCall("GDI32.dll\BitBlt", "ptr", hdc, "int", x, "int", y, "int", cx, "int", cy, "ptr", hdcSrc, "int", x1, "int", y1, "uint", rop, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5874,7 +5874,7 @@ class Gdi {
         A_LastError := 0
 
         result := DllCall("GDI32.dll\CreateScalableFontResourceA", "uint", fdwHidden, "ptr", lpszFont, "ptr", lpszFile, "ptr", lpszPath, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5902,7 +5902,7 @@ class Gdi {
         A_LastError := 0
 
         result := DllCall("GDI32.dll\CreateScalableFontResourceW", "uint", fdwHidden, "ptr", lpszFont, "ptr", lpszFile, "ptr", lpszPath, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14408,7 +14408,7 @@ class Gdi {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetSysColors", "int", cElements, lpaElementsMarshal, lpaElements, lpaRgbValuesMarshal, lpaRgbValues, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Graphics/OpenGL/Apis.ahk
+++ b/Windows/Win32/Graphics/OpenGL/Apis.ahk
@@ -3722,7 +3722,7 @@ class OpenGL {
         A_LastError := 0
 
         result := DllCall("GDI32.dll\SetPixelFormat", "ptr", hdc, "int", format, "ptr", ppfd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3769,7 +3769,7 @@ class OpenGL {
         A_LastError := 0
 
         result := DllCall("OPENGL32.dll\wglCopyContext", "ptr", param0, "ptr", param1, "uint", param2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3833,7 +3833,7 @@ class OpenGL {
         A_LastError := 0
 
         result := DllCall("OPENGL32.dll\wglDeleteContext", "ptr", param0, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3897,7 +3897,7 @@ class OpenGL {
         A_LastError := 0
 
         result := DllCall("OPENGL32.dll\wglMakeCurrent", "ptr", param0, "ptr", param1, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3920,7 +3920,7 @@ class OpenGL {
         A_LastError := 0
 
         result := DllCall("OPENGL32.dll\wglShareLists", "ptr", param0, "ptr", param1, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3944,7 +3944,7 @@ class OpenGL {
         A_LastError := 0
 
         result := DllCall("OPENGL32.dll\wglUseFontBitmapsA", "ptr", param0, "uint", param1, "uint", param2, "uint", param3, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3968,7 +3968,7 @@ class OpenGL {
         A_LastError := 0
 
         result := DllCall("OPENGL32.dll\wglUseFontBitmapsW", "ptr", param0, "uint", param1, "uint", param2, "uint", param3, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3989,7 +3989,7 @@ class OpenGL {
         A_LastError := 0
 
         result := DllCall("GDI32.dll\SwapBuffers", "ptr", param0, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4017,7 +4017,7 @@ class OpenGL {
         A_LastError := 0
 
         result := DllCall("OPENGL32.dll\wglUseFontOutlinesA", "ptr", param0, "uint", param1, "uint", param2, "uint", param3, "float", param4, "float", param5, "int", param6, "ptr", param7, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4045,7 +4045,7 @@ class OpenGL {
         A_LastError := 0
 
         result := DllCall("OPENGL32.dll\wglUseFontOutlinesW", "ptr", param0, "uint", param1, "uint", param2, "uint", param3, "float", param4, "float", param5, "int", param6, "ptr", param7, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4142,7 +4142,7 @@ class OpenGL {
         A_LastError := 0
 
         result := DllCall("OPENGL32.dll\wglRealizeLayerPalette", "ptr", param0, "int", param1, "int", param2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4162,7 +4162,7 @@ class OpenGL {
         A_LastError := 0
 
         result := DllCall("OPENGL32.dll\wglSwapLayerBuffers", "ptr", param0, "uint", param1, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Graphics/Printing/Apis.ahk
+++ b/Windows/Win32/Graphics/Printing/Apis.ahk
@@ -7167,7 +7167,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\EnumPrintersA", "uint", Flags, "ptr", Name, "uint", Level, "ptr", pPrinterEnum, "uint", cbBuf, pcbNeededMarshal, pcbNeeded, pcReturnedMarshal, pcReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7194,7 +7194,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\EnumPrintersW", "uint", Flags, "ptr", Name, "uint", Level, "ptr", pPrinterEnum, "uint", cbBuf, pcbNeededMarshal, pcbNeeded, pcReturnedMarshal, pcReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7263,7 +7263,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\OpenPrinterA", "ptr", pPrinterName, "ptr", phPrinter, "ptr", pDefault, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7283,7 +7283,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\OpenPrinterW", "ptr", pPrinterName, "ptr", phPrinter, "ptr", pDefault, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7415,7 +7415,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\EnumJobsA", "ptr", hPrinter, "uint", FirstJob, "uint", NoJobs, "uint", Level, "ptr", pJob, "uint", cbBuf, pcbNeededMarshal, pcbNeeded, pcReturnedMarshal, pcReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7443,7 +7443,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\EnumJobsW", "ptr", hPrinter, "uint", FirstJob, "uint", NoJobs, "uint", Level, "ptr", pJob, "uint", cbBuf, pcbNeededMarshal, pcbNeeded, pcReturnedMarshal, pcReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7505,7 +7505,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\DeletePrinter", "ptr", hPrinter, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7528,7 +7528,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\SetPrinterA", "ptr", hPrinter, "uint", Level, pPrinterMarshal, pPrinter, "uint", Command, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7551,7 +7551,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\SetPrinterW", "ptr", hPrinter, "uint", Level, pPrinterMarshal, pPrinter, "uint", Command, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7575,7 +7575,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\GetPrinterA", "ptr", hPrinter, "uint", Level, "ptr", pPrinter, "uint", cbBuf, pcbNeededMarshal, pcbNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7599,7 +7599,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\GetPrinterW", "ptr", hPrinter, "uint", Level, "ptr", pPrinter, "uint", cbBuf, pcbNeededMarshal, pcbNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7621,7 +7621,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\AddPrinterDriverA", "ptr", pName, "uint", Level, pDriverInfoMarshal, pDriverInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7643,7 +7643,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\AddPrinterDriverW", "ptr", pName, "uint", Level, pDriverInfoMarshal, pDriverInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7707,7 +7707,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\EnumPrinterDriversA", "ptr", pName, "ptr", pEnvironment, "uint", Level, "ptr", pDriverInfo, "uint", cbBuf, pcbNeededMarshal, pcbNeeded, pcReturnedMarshal, pcReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7735,7 +7735,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\EnumPrinterDriversW", "ptr", pName, "ptr", pEnvironment, "uint", Level, "ptr", pDriverInfo, "uint", cbBuf, pcbNeededMarshal, pcbNeeded, pcReturnedMarshal, pcReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8933,7 +8933,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\ClosePrinter", "ptr", hPrinter, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9181,7 +9181,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\AddMonitorA", "ptr", pName, "uint", Level, pMonitorsMarshal, pMonitors, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9203,7 +9203,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\AddMonitorW", "ptr", pName, "uint", Level, pMonitorsMarshal, pMonitors, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9225,7 +9225,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\DeleteMonitorA", "ptr", pName, "ptr", pEnvironment, "ptr", pMonitorName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9247,7 +9247,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\DeleteMonitorW", "ptr", pName, "ptr", pEnvironment, "ptr", pMonitorName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9311,7 +9311,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\AddPortA", "ptr", pName, "ptr", hWnd, "ptr", pMonitorName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9333,7 +9333,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\AddPortW", "ptr", pName, "ptr", hWnd, "ptr", pMonitorName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9389,7 +9389,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\DeletePortA", "ptr", pName, "ptr", hWnd, "ptr", pPortName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9411,7 +9411,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\DeletePortW", "ptr", pName, "ptr", hWnd, "ptr", pPortName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9516,7 +9516,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\SetPortA", "ptr", pName, "ptr", pPortName, "uint", dwLevel, pPortInfoMarshal, pPortInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9540,7 +9540,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\SetPortW", "ptr", pName, "ptr", pPortName, "uint", dwLevel, pPortInfoMarshal, pPortInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9719,7 +9719,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\OpenPrinter2A", "ptr", pPrinterName, "ptr", phPrinter, "ptr", pDefault, "ptr", pOptions, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9740,7 +9740,7 @@ class Printing {
         A_LastError := 0
 
         result := DllCall("winspool.drv\OpenPrinter2W", "ptr", pPrinterName, "ptr", phPrinter, "ptr", pDefault, "ptr", pOptions, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/NetworkManagement/IpHelper/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/IpHelper/Apis.ahk
@@ -2437,7 +2437,7 @@ class IpHelper {
         A_LastError := 0
 
         result := DllCall("IPHLPAPI.dll\IcmpCloseHandle", "ptr", IcmpHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8272,7 +8272,7 @@ class IpHelper {
         A_LastError := 0
 
         result := DllCall("IPHLPAPI.dll\GetRTTAndHopCount", "uint", DestIpAddress, HopCountMarshal, HopCount, "uint", MaxHops, RTTMarshal, RTT, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/NetworkManagement/Snmp/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/Snmp/Apis.ahk
@@ -990,7 +990,7 @@ class Snmp {
         A_LastError := 0
 
         result := DllCall("mgmtapi.dll\SnmpMgrCtl", sessionMarshal, session, "uint", dwCtlCode, lpvInBufferMarshal, lpvInBuffer, "uint", cbInBuffer, lpvOUTBufferMarshal, lpvOUTBuffer, "uint", cbOUTBuffer, lpcbBytesReturnedMarshal, lpcbBytesReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1175,7 +1175,7 @@ class Snmp {
         A_LastError := 0
 
         result := DllCall("mgmtapi.dll\SnmpMgrTrapListen", "ptr", phTrapAvailable, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Networking/Clustering/Apis.ahk
+++ b/Windows/Win32/Networking/Clustering/Apis.ahk
@@ -4661,7 +4661,7 @@ class Clustering {
         A_LastError := 0
 
         result := DllCall("CLUSAPI.dll\CloseClusterGroupSet", "ptr", hGroupSet, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5499,7 +5499,7 @@ class Clustering {
         A_LastError := 0
 
         result := DllCall("CLUSAPI.dll\CloseClusterNode", "ptr", hNode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6906,7 +6906,7 @@ class Clustering {
         A_LastError := 0
 
         result := DllCall("CLUSAPI.dll\CloseClusterGroup", "ptr", hGroup, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7606,7 +7606,7 @@ class Clustering {
         A_LastError := 0
 
         result := DllCall("CLUSAPI.dll\CloseClusterResource", "ptr", hResource, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9512,7 +9512,7 @@ class Clustering {
         A_LastError := 0
 
         result := DllCall("CLUSAPI.dll\GetClusterResourceNetworkName", "ptr", hResource, "ptr", lpBuffer, nSizeMarshal, nSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10010,7 +10010,7 @@ class Clustering {
         A_LastError := 0
 
         result := DllCall("CLUSAPI.dll\CloseClusterNetwork", "ptr", hNetwork, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10661,7 +10661,7 @@ class Clustering {
         A_LastError := 0
 
         result := DllCall("CLUSAPI.dll\CloseClusterNetInterface", "ptr", hNetInterface, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16150,7 +16150,7 @@ class Clustering {
         A_LastError := 0
 
         result := DllCall("RESUTILS.dll\ClusterGetVolumePathName", "ptr", lpszFileName, "ptr", lpszVolumePathName, "uint", cchBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16185,7 +16185,7 @@ class Clustering {
         A_LastError := 0
 
         result := DllCall("RESUTILS.dll\ClusterGetVolumeNameForVolumeMountPoint", "ptr", lpszVolumeMountPoint, "ptr", lpszVolumeName, "uint", cchBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Networking/WinHttp/Apis.ahk
+++ b/Windows/Win32/Networking/WinHttp/Apis.ahk
@@ -3284,7 +3284,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpTimeFromSystemTime", "ptr", pst, "ptr", pwszTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3324,7 +3324,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpTimeToSystemTime", "ptr", pwszTime, "ptr", pst, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3443,7 +3443,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpCrackUrl", "ptr", pwszUrl, "uint", dwUrlLength, "uint", dwFlags, "ptr", lpUrlComponents, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3500,7 +3500,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpCreateUrl", "ptr", lpUrlComponents, "uint", dwFlags, "ptr", pwszUrl, pdwUrlLengthMarshal, pdwUrlLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3516,7 +3516,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpCheckPlatform", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3564,7 +3564,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpGetDefaultProxyConfiguration", "ptr", pProxyInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3612,7 +3612,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpSetDefaultProxyConfiguration", "ptr", pProxyInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3754,7 +3754,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpCloseHandle", hInternetMarshal, hInternet, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3988,7 +3988,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpReadData", hRequestMarshal, hRequest, "ptr", lpBuffer, "uint", dwNumberOfBytesToRead, lpdwNumberOfBytesReadMarshal, lpdwNumberOfBytesRead, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4119,7 +4119,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpWriteData", hRequestMarshal, hRequest, "ptr", lpBuffer, "uint", dwNumberOfBytesToWrite, lpdwNumberOfBytesWrittenMarshal, lpdwNumberOfBytesWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4227,7 +4227,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpQueryDataAvailable", hRequestMarshal, hRequest, lpdwNumberOfBytesAvailableMarshal, lpdwNumberOfBytesAvailable, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4320,7 +4320,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpQueryOption", hInternetMarshal, hInternet, "uint", dwOption, "ptr", lpBuffer, lpdwBufferLengthMarshal, lpdwBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4447,7 +4447,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpSetOption", hInternetMarshal, hInternet, "uint", dwOption, lpBufferMarshal, lpBuffer, "uint", dwBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4538,7 +4538,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpSetTimeouts", hInternetMarshal, hInternet, "int", nResolveTimeout, "int", nConnectTimeout, "int", nSendTimeout, "int", nReceiveTimeout, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4792,7 +4792,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpAddRequestHeaders", hRequestMarshal, hRequest, "ptr", lpszHeaders, "uint", dwHeadersLength, "uint", dwModifiers, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5071,7 +5071,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpSendRequest", hRequestMarshal, hRequest, "ptr", lpszHeaders, "uint", dwHeadersLength, "ptr", lpOptional, "uint", dwOptionalLength, "uint", dwTotalLength, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5238,7 +5238,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpSetCredentials", hRequestMarshal, hRequest, "uint", AuthTargets, "uint", AuthScheme, "ptr", pwszUserName, "ptr", pwszPassword, pAuthParamsMarshal, pAuthParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5447,7 +5447,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpQueryAuthSchemes", hRequestMarshal, hRequest, lpdwSupportedSchemesMarshal, lpdwSupportedSchemes, lpdwFirstSchemeMarshal, lpdwFirstScheme, pdwAuthTargetMarshal, pdwAuthTarget, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5712,7 +5712,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpReceiveResponse", hRequestMarshal, hRequest, lpReservedMarshal, lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5821,7 +5821,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpQueryHeaders", hRequestMarshal, hRequest, "uint", dwInfoLevel, "ptr", pwszName, "ptr", lpBuffer, lpdwBufferLengthMarshal, lpdwBufferLength, lpdwIndexMarshal, lpdwIndex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5962,7 +5962,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpDetectAutoProxyConfigUrl", "uint", dwAutoDetectFlags, ppwstrAutoConfigUrlMarshal, ppwstrAutoConfigUrl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6110,7 +6110,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpGetProxyForUrl", hSessionMarshal, hSession, "ptr", lpcwszUrl, "ptr", pAutoProxyOptions, "ptr", pProxyInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6598,7 +6598,7 @@ class WinHttp {
         A_LastError := 0
 
         result := DllCall("WINHTTP.dll\WinHttpGetIEProxyConfigForCurrentUser", "ptr", pProxyConfig, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Networking/WinInet/Apis.ahk
+++ b/Windows/Win32/Networking/WinInet/Apis.ahk
@@ -4644,7 +4644,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetTimeFromSystemTimeA", "ptr", pst, "uint", dwRFC, "ptr", lpszTime, "uint", cbTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4667,7 +4667,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetTimeFromSystemTimeW", "ptr", pst, "uint", dwRFC, "ptr", lpszTime, "uint", cbTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4690,7 +4690,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetTimeFromSystemTime", "ptr", pst, "uint", dwRFC, "ptr", lpszTime, "uint", cbTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4714,7 +4714,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetTimeToSystemTimeA", "ptr", lpszTime, "ptr", pst, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4738,7 +4738,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetTimeToSystemTimeW", "ptr", lpszTime, "ptr", pst, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4762,7 +4762,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetTimeToSystemTime", "ptr", lpszTime, "ptr", pst, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4788,7 +4788,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetCrackUrlA", "ptr", lpszUrl, "uint", dwUrlLength, "uint", dwFlags, "ptr", lpUrlComponents, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4814,7 +4814,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetCrackUrlW", "ptr", lpszUrl, "uint", dwUrlLength, "uint", dwFlags, "ptr", lpUrlComponents, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4842,7 +4842,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetCreateUrlA", "ptr", lpUrlComponents, "uint", dwFlags, "ptr", lpszUrl, lpdwUrlLengthMarshal, lpdwUrlLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4870,7 +4870,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetCreateUrlW", "ptr", lpUrlComponents, "uint", dwFlags, "ptr", lpszUrl, lpdwUrlLengthMarshal, lpdwUrlLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4951,7 +4951,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetCanonicalizeUrlA", "ptr", lpszUrl, "ptr", lpszBuffer, lpdwBufferLengthMarshal, lpdwBufferLength, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5032,7 +5032,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetCanonicalizeUrlW", "ptr", lpszUrl, "ptr", lpszBuffer, lpdwBufferLengthMarshal, lpdwBufferLength, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5113,7 +5113,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetCombineUrlA", "ptr", lpszBaseUrl, "ptr", lpszRelativeUrl, "ptr", lpszBuffer, lpdwBufferLengthMarshal, lpdwBufferLength, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5194,7 +5194,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetCombineUrlW", "ptr", lpszBaseUrl, "ptr", lpszRelativeUrl, "ptr", lpszBuffer, lpdwBufferLengthMarshal, lpdwBufferLength, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5306,7 +5306,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetCloseHandle", hInternetMarshal, hInternet, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5482,7 +5482,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetReadFile", hFileMarshal, hFile, "ptr", lpBuffer, "uint", dwNumberOfBytesToRead, lpdwNumberOfBytesReadMarshal, lpdwNumberOfBytesRead, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5509,7 +5509,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetReadFileExA", hFileMarshal, hFile, "ptr", lpBuffersOut, "uint", dwFlags, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5536,7 +5536,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetReadFileExW", hFileMarshal, hFile, "ptr", lpBuffersOut, "uint", dwFlags, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5610,7 +5610,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetWriteFile", hFileMarshal, hFile, "ptr", lpBuffer, "uint", dwNumberOfBytesToWrite, lpdwNumberOfBytesWrittenMarshal, lpdwNumberOfBytesWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5639,7 +5639,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetQueryDataAvailable", hFileMarshal, hFile, lpdwNumberOfBytesAvailableMarshal, lpdwNumberOfBytesAvailable, "uint", dwFlags, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5670,7 +5670,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetFindNextFileA", hFindMarshal, hFind, lpvFindDataMarshal, lpvFindData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5701,7 +5701,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetFindNextFileW", hFindMarshal, hFind, lpvFindDataMarshal, lpvFindData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5732,7 +5732,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetQueryOptionA", hInternetMarshal, hInternet, "uint", dwOption, "ptr", lpBuffer, lpdwBufferLengthMarshal, lpdwBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5763,7 +5763,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetQueryOptionW", hInternetMarshal, hInternet, "uint", dwOption, "ptr", lpBuffer, lpdwBufferLengthMarshal, lpdwBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5793,7 +5793,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetSetOptionA", hInternetMarshal, hInternet, "uint", dwOption, lpBufferMarshal, lpBuffer, "uint", dwBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5823,7 +5823,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetSetOptionW", hInternetMarshal, hInternet, "uint", dwOption, lpBufferMarshal, lpBuffer, "uint", dwBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5886,7 +5886,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetLockRequestFile", hInternetMarshal, hInternet, "ptr", lphLockRequestInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5907,7 +5907,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetUnlockRequestFile", "ptr", hLockRequestInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5935,7 +5935,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetGetLastResponseInfoA", lpdwErrorMarshal, lpdwError, "ptr", lpszBuffer, lpdwBufferLengthMarshal, lpdwBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5963,7 +5963,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetGetLastResponseInfoW", lpdwErrorMarshal, lpdwError, "ptr", lpszBuffer, lpdwBufferLengthMarshal, lpdwBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6221,7 +6221,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpGetFileA", hConnectMarshal, hConnect, "ptr", lpszRemoteFile, "ptr", lpszNewFile, "int", fFailIfExists, "uint", dwFlagsAndAttributes, "uint", dwFlags, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6371,7 +6371,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpGetFileW", hConnectMarshal, hConnect, "ptr", lpszRemoteFile, "ptr", lpszNewFile, "int", fFailIfExists, "uint", dwFlagsAndAttributes, "uint", dwFlags, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6399,7 +6399,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpPutFileA", hConnectMarshal, hConnect, "ptr", lpszLocalFile, "ptr", lpszNewRemoteFile, "uint", dwFlags, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6427,7 +6427,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpPutFileW", hConnectMarshal, hConnect, "ptr", lpszLocalFile, "ptr", lpszNewRemoteFile, "uint", dwFlags, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6491,7 +6491,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpDeleteFileA", hConnectMarshal, hConnect, "ptr", lpszFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6515,7 +6515,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpDeleteFileW", hConnectMarshal, hConnect, "ptr", lpszFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6540,7 +6540,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpRenameFileA", hConnectMarshal, hConnect, "ptr", lpszExisting, "ptr", lpszNew, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6565,7 +6565,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpRenameFileW", hConnectMarshal, hConnect, "ptr", lpszExisting, "ptr", lpszNew, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6644,7 +6644,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpCreateDirectoryA", hConnectMarshal, hConnect, "ptr", lpszDirectory, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6669,7 +6669,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpCreateDirectoryW", hConnectMarshal, hConnect, "ptr", lpszDirectory, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6693,7 +6693,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpRemoveDirectoryA", hConnectMarshal, hConnect, "ptr", lpszDirectory, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6717,7 +6717,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpRemoveDirectoryW", hConnectMarshal, hConnect, "ptr", lpszDirectory, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6741,7 +6741,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpSetCurrentDirectoryA", hConnectMarshal, hConnect, "ptr", lpszDirectory, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6765,7 +6765,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpSetCurrentDirectoryW", hConnectMarshal, hConnect, "ptr", lpszDirectory, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6790,7 +6790,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpGetCurrentDirectoryA", hConnectMarshal, hConnect, "ptr", lpszCurrentDirectory, lpdwCurrentDirectoryMarshal, lpdwCurrentDirectory, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6815,7 +6815,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpGetCurrentDirectoryW", hConnectMarshal, hConnect, "ptr", lpszCurrentDirectory, lpdwCurrentDirectoryMarshal, lpdwCurrentDirectory, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6846,7 +6846,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpCommandA", hConnectMarshal, hConnect, "int", fExpectResponse, "uint", dwFlags, "ptr", lpszCommand, "ptr", dwContext, phFtpCommandMarshal, phFtpCommand, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6877,7 +6877,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FtpCommandW", hConnectMarshal, hConnect, "int", fExpectResponse, "uint", dwFlags, "ptr", lpszCommand, "ptr", dwContext, phFtpCommandMarshal, phFtpCommand, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6936,7 +6936,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GopherCreateLocatorA", "ptr", lpszHost, "ushort", nServerPort, "ptr", lpszDisplayString, "ptr", lpszSelectorString, "uint", dwGopherType, "ptr", lpszLocator, lpdwBufferLengthMarshal, lpdwBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6978,7 +6978,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GopherCreateLocatorW", "ptr", lpszHost, "ushort", nServerPort, "ptr", lpszDisplayString, "ptr", lpszSelectorString, "uint", dwGopherType, "ptr", lpszLocator, lpdwBufferLengthMarshal, lpdwBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7002,7 +7002,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GopherGetLocatorTypeA", "ptr", lpszLocator, lpdwGopherTypeMarshal, lpdwGopherType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7026,7 +7026,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GopherGetLocatorTypeW", "ptr", lpszLocator, lpdwGopherTypeMarshal, lpdwGopherType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7215,7 +7215,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GopherGetAttributeA", hConnectMarshal, hConnect, "ptr", lpszLocator, "ptr", lpszAttributeName, lpBufferMarshal, lpBuffer, "uint", dwBufferLength, lpdwCharactersReturnedMarshal, lpdwCharactersReturned, "ptr", lpfnEnumerator, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7260,7 +7260,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GopherGetAttributeW", hConnectMarshal, hConnect, "ptr", lpszLocator, "ptr", lpszAttributeName, lpBufferMarshal, lpBuffer, "uint", dwBufferLength, lpdwCharactersReturnedMarshal, lpdwCharactersReturned, "ptr", lpfnEnumerator, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7426,7 +7426,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\HttpAddRequestHeadersA", hRequestMarshal, hRequest, "ptr", lpszHeaders, "uint", dwHeadersLength, "uint", dwModifiers, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7454,7 +7454,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\HttpAddRequestHeadersW", hRequestMarshal, hRequest, "ptr", lpszHeaders, "uint", dwHeadersLength, "uint", dwModifiers, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7483,7 +7483,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\HttpSendRequestA", hRequestMarshal, hRequest, "ptr", lpszHeaders, "uint", dwHeadersLength, "ptr", lpOptional, "uint", dwOptionalLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7512,7 +7512,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\HttpSendRequestW", hRequestMarshal, hRequest, "ptr", lpszHeaders, "uint", dwHeadersLength, "ptr", lpOptional, "uint", dwOptionalLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7542,7 +7542,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\HttpSendRequestExA", hRequestMarshal, hRequest, "ptr", lpBuffersIn, "ptr", lpBuffersOut, "uint", dwFlags, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7572,7 +7572,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\HttpSendRequestExW", hRequestMarshal, hRequest, "ptr", lpBuffersIn, "ptr", lpBuffersOut, "uint", dwFlags, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7600,7 +7600,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\HttpEndRequestA", hRequestMarshal, hRequest, "ptr", lpBuffersOut, "uint", dwFlags, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7628,7 +7628,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\HttpEndRequestW", hRequestMarshal, hRequest, "ptr", lpBuffersOut, "uint", dwFlags, "ptr", dwContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7662,7 +7662,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\HttpQueryInfoA", hRequestMarshal, hRequest, "uint", dwInfoLevel, "ptr", lpBuffer, lpdwBufferLengthMarshal, lpdwBufferLength, lpdwIndexMarshal, lpdwIndex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7696,7 +7696,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\HttpQueryInfoW", hRequestMarshal, hRequest, "uint", dwInfoLevel, "ptr", lpBuffer, lpdwBufferLengthMarshal, lpdwBufferLength, lpdwIndexMarshal, lpdwIndex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7720,7 +7720,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetSetCookieA", "ptr", lpszUrl, "ptr", lpszCookieName, "ptr", lpszCookieData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7744,7 +7744,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetSetCookieW", "ptr", lpszUrl, "ptr", lpszCookieName, "ptr", lpszCookieData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7824,7 +7824,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetGetCookieA", "ptr", lpszUrl, "ptr", lpszCookieName, "ptr", lpszCookieData, lpdwSizeMarshal, lpdwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7904,7 +7904,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetGetCookieW", "ptr", lpszUrl, "ptr", lpszCookieName, "ptr", lpszCookieData, lpdwSizeMarshal, lpdwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8160,7 +8160,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetGetCookieExA", "ptr", lpszUrl, "ptr", lpszCookieName, "ptr", lpszCookieData, lpdwSizeMarshal, lpdwSize, "uint", dwFlags, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8244,7 +8244,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetGetCookieExW", "ptr", lpszUrl, "ptr", lpszCookieName, "ptr", lpszCookieData, lpdwSizeMarshal, lpdwSize, "uint", dwFlags, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8359,7 +8359,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetCheckConnectionA", "ptr", lpszUrl, "uint", dwFlags, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8389,7 +8389,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetCheckConnectionW", "ptr", lpszUrl, "uint", dwFlags, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8410,7 +8410,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\ResumeSuspendedDownload", hRequestMarshal, hRequest, "uint", dwResultCode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8691,7 +8691,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\CreateUrlCacheEntryA", "ptr", lpszUrlName, "uint", dwExpectedFileSize, "ptr", lpszFileExtension, "ptr", lpszFileName, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8720,7 +8720,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\CreateUrlCacheEntryW", "ptr", lpszUrlName, "uint", dwExpectedFileSize, "ptr", lpszFileExtension, "ptr", lpszFileName, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8884,7 +8884,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\CommitUrlCacheEntryA", "ptr", lpszUrlName, "ptr", lpszLocalFileName, "ptr", ExpireTime, "ptr", LastModifiedTime, "uint", CacheEntryType, lpHeaderInfoMarshal, lpHeaderInfo, "uint", cchHeaderInfo, "ptr", lpszFileExtension, "ptr", lpszOriginalUrl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9048,7 +9048,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\CommitUrlCacheEntryW", "ptr", lpszUrlName, "ptr", lpszLocalFileName, "ptr", ExpireTime, "ptr", LastModifiedTime, "uint", CacheEntryType, "ptr", lpszHeaderInfo, "uint", cchHeaderInfo, "ptr", lpszFileExtension, "ptr", lpszOriginalUrl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9108,7 +9108,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\RetrieveUrlCacheEntryFileA", "ptr", lpszUrlName, "ptr", lpCacheEntryInfo, lpcbCacheEntryInfoMarshal, lpcbCacheEntryInfo, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9168,7 +9168,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\RetrieveUrlCacheEntryFileW", "ptr", lpszUrlName, "ptr", lpCacheEntryInfo, lpcbCacheEntryInfoMarshal, lpcbCacheEntryInfo, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9190,7 +9190,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\UnlockUrlCacheEntryFileA", "ptr", lpszUrlName, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9212,7 +9212,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\UnlockUrlCacheEntryFileW", "ptr", lpszUrlName, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9234,7 +9234,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\UnlockUrlCacheEntryFile", "ptr", lpszUrlName, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9397,7 +9397,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\ReadUrlCacheEntryStream", "ptr", hUrlCacheStream, "uint", dwLocation, "ptr", lpBuffer, lpdwLenMarshal, lpdwLen, "uint", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9437,7 +9437,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\UnlockUrlCacheEntryStream", "ptr", hUrlCacheStream, "uint", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9497,7 +9497,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GetUrlCacheEntryInfoA", "ptr", lpszUrlName, "ptr", lpCacheEntryInfo, lpcbCacheEntryInfoMarshal, lpcbCacheEntryInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9557,7 +9557,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GetUrlCacheEntryInfoW", "ptr", lpszUrlName, "ptr", lpCacheEntryInfo, lpcbCacheEntryInfoMarshal, lpcbCacheEntryInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9608,7 +9608,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FindNextUrlCacheGroup", "ptr", hFind, lpGroupIdMarshal, lpGroupId, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9635,7 +9635,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GetUrlCacheGroupAttributeA", "int64", gid, "uint", dwFlags, "uint", dwAttributes, "ptr", lpGroupInfo, lpcbGroupInfoMarshal, lpcbGroupInfo, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9662,7 +9662,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GetUrlCacheGroupAttributeW", "int64", gid, "uint", dwFlags, "uint", dwAttributes, "ptr", lpGroupInfo, lpcbGroupInfoMarshal, lpcbGroupInfo, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9685,7 +9685,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\SetUrlCacheGroupAttributeA", "int64", gid, "uint", dwFlags, "uint", dwAttributes, "ptr", lpGroupInfo, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9708,7 +9708,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\SetUrlCacheGroupAttributeW", "int64", gid, "uint", dwFlags, "uint", dwAttributes, "ptr", lpGroupInfo, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9770,7 +9770,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GetUrlCacheEntryInfoExA", "ptr", lpszUrl, "ptr", lpCacheEntryInfo, lpcbCacheEntryInfoMarshal, lpcbCacheEntryInfo, "ptr", lpszRedirectUrl, "uint*", lpcbRedirectUrl, "ptr", lpReserved, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9832,7 +9832,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GetUrlCacheEntryInfoExW", "ptr", lpszUrl, "ptr", lpCacheEntryInfo, lpcbCacheEntryInfoMarshal, lpcbCacheEntryInfo, "ptr", lpszRedirectUrl, "uint*", lpcbRedirectUrl, "ptr", lpReserved, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9885,7 +9885,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\SetUrlCacheEntryInfoA", "ptr", lpszUrlName, "ptr", lpCacheEntryInfo, "uint", dwFieldControl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9938,7 +9938,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\SetUrlCacheEntryInfoW", "ptr", lpszUrlName, "ptr", lpCacheEntryInfo, "uint", dwFieldControl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9983,7 +9983,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\DeleteUrlCacheGroup", "int64", GroupId, "uint", dwFlags, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10323,7 +10323,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FindNextUrlCacheEntryExA", "ptr", hEnumHandle, "ptr", lpNextCacheEntryInfo, lpcbCacheEntryInfoMarshal, lpcbCacheEntryInfo, "ptr", lpGroupAttributes, "uint*", lpcbGroupAttributes, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10351,7 +10351,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FindNextUrlCacheEntryExW", "ptr", hEnumHandle, "ptr", lpNextCacheEntryInfo, lpcbCacheEntryInfoMarshal, lpcbCacheEntryInfo, "ptr", lpGroupAttributes, "uint*", lpcbGroupAttributes, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10474,7 +10474,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FindNextUrlCacheEntryA", "ptr", hEnumHandle, "ptr", lpNextCacheEntryInfo, lpcbCacheEntryInfoMarshal, lpcbCacheEntryInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10533,7 +10533,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FindNextUrlCacheEntryW", "ptr", hEnumHandle, "ptr", lpNextCacheEntryInfo, lpcbCacheEntryInfoMarshal, lpcbCacheEntryInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10554,7 +10554,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FindCloseUrlCache", "ptr", hEnumHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10603,7 +10603,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\DeleteUrlCacheEntryA", "ptr", lpszUrlName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10652,7 +10652,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\DeleteUrlCacheEntryW", "ptr", lpszUrlName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10701,7 +10701,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\DeleteUrlCacheEntry", "ptr", lpszUrlName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10964,7 +10964,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetGoOnlineA", "ptr", lpszURL, "ptr", hwndParent, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11028,7 +11028,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetGoOnlineW", "ptr", lpszURL, "ptr", hwndParent, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11092,7 +11092,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetGoOnline", "ptr", lpszURL, "ptr", hwndParent, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11115,7 +11115,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetAutodial", "uint", dwFlags, "ptr", hwndParent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11136,7 +11136,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetAutodialHangup", "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11159,7 +11159,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetGetConnectedState", lpdwFlagsMarshal, lpdwFlags, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11186,7 +11186,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetGetConnectedStateExA", lpdwFlagsMarshal, lpdwFlags, "ptr", lpszConnectionName, "uint", cchNameLen, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11213,7 +11213,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetGetConnectedStateExW", lpdwFlagsMarshal, lpdwFlags, "ptr", lpszConnectionName, "uint", cchNameLen, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11241,7 +11241,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetInitializeAutoProxyDll", "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11264,7 +11264,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\DetectAutoProxyUrl", "ptr", pszAutoProxyUrl, "uint", cchAutoProxyUrl, "uint", dwDetectFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11312,7 +11312,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\InternetGetConnectedStateEx", lpdwFlagsMarshal, lpdwFlags, "ptr", lpszConnectionName, "uint", dwNameLen, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12034,7 +12034,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\CreateUrlCacheContainerA", "ptr", Name, "ptr", lpCachePrefix, "ptr", lpszCachePath, "uint", KBCacheLimit, "uint", dwContainerType, "uint", dwOptions, "ptr", pvBuffer, "uint*", cbBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12063,7 +12063,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\CreateUrlCacheContainerW", "ptr", Name, "ptr", lpCachePrefix, "ptr", lpszCachePath, "uint", KBCacheLimit, "uint", dwContainerType, "uint", dwOptions, "ptr", pvBuffer, "uint*", cbBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12083,7 +12083,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\DeleteUrlCacheContainerA", "ptr", Name, "uint", dwOptions, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12103,7 +12103,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\DeleteUrlCacheContainerW", "ptr", Name, "uint", dwOptions, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12188,7 +12188,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FreeUrlCacheSpaceA", "ptr", lpszCachePath, "uint", dwSize, "uint", dwFilter, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12209,7 +12209,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\FreeUrlCacheSpaceW", "ptr", lpszCachePath, "uint", dwSize, "uint", dwFilter, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12260,7 +12260,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GetUrlCacheConfigInfoA", "ptr", lpCacheConfigInfo, "uint*", lpcbCacheConfigInfo, "uint", dwFieldControl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12285,7 +12285,7 @@ class WinInet {
         A_LastError := 0
 
         result := DllCall("WININET.dll\GetUrlCacheConfigInfoW", "ptr", lpCacheConfigInfo, "uint*", lpcbCacheConfigInfo, "uint", dwFieldControl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Networking/WinSock/Apis.ahk
+++ b/Windows/Win32/Networking/WinSock/Apis.ahk
@@ -11217,7 +11217,7 @@ class WinSock {
         A_LastError := 0
 
         result := DllCall("WS2_32.dll\WSAIsBlocking", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12733,7 +12733,7 @@ class WinSock {
         A_LastError := 0
 
         result := DllCall("WS2_32.dll\WSACloseEvent", "ptr", hEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13133,7 +13133,7 @@ class WinSock {
         A_LastError := 0
 
         result := DllCall("WS2_32.dll\WSAConnectByNameW", "ptr", s, "ptr", nodename, "ptr", servicename, LocalAddressLengthMarshal, LocalAddressLength, "ptr", LocalAddress, RemoteAddressLengthMarshal, RemoteAddressLength, "ptr", RemoteAddress, "ptr", timeout, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13238,7 +13238,7 @@ class WinSock {
         A_LastError := 0
 
         result := DllCall("WS2_32.dll\WSAConnectByNameA", "ptr", s, "ptr", nodename, "ptr", servicename, LocalAddressLengthMarshal, LocalAddressLength, "ptr", LocalAddress, RemoteAddressLengthMarshal, RemoteAddressLength, "ptr", RemoteAddress, "ptr", timeout, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13365,7 +13365,7 @@ class WinSock {
         A_LastError := 0
 
         result := DllCall("WS2_32.dll\WSAConnectByList", "ptr", s, "ptr", SocketAddress, LocalAddressLengthMarshal, LocalAddressLength, "ptr", LocalAddress, RemoteAddressLengthMarshal, RemoteAddressLength, "ptr", RemoteAddress, "ptr", timeout, "ptr", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14372,7 +14372,7 @@ class WinSock {
         A_LastError := 0
 
         result := DllCall("WS2_32.dll\WSAGetOverlappedResult", "ptr", s, "ptr", lpOverlapped, lpcbTransferMarshal, lpcbTransfer, "int", fWait, lpdwFlagsMarshal, lpdwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14449,7 +14449,7 @@ class WinSock {
         A_LastError := 0
 
         result := DllCall("WS2_32.dll\WSAGetQOSByName", "ptr", s, "ptr", lpQOSName, "ptr", lpQOS, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15805,7 +15805,7 @@ class WinSock {
         A_LastError := 0
 
         result := DllCall("WS2_32.dll\WSAResetEvent", "ptr", hEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16807,7 +16807,7 @@ class WinSock {
         A_LastError := 0
 
         result := DllCall("WS2_32.dll\WSASetEvent", "ptr", hEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Security/Apis.ahk
+++ b/Windows/Win32/Security/Apis.ahk
@@ -583,7 +583,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AccessCheck", "ptr", pSecurityDescriptor, "ptr", ClientToken, "uint", DesiredAccess, "ptr", GenericMapping, "ptr", PrivilegeSet, PrivilegeSetLengthMarshal, PrivilegeSetLength, GrantedAccessMarshal, GrantedAccess, AccessStatusMarshal, AccessStatus, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -683,7 +683,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AccessCheckByType", "ptr", pSecurityDescriptor, "ptr", PrincipalSelfSid, "ptr", ClientToken, "uint", DesiredAccess, "ptr", ObjectTypeList, "uint", ObjectTypeListLength, "ptr", GenericMapping, "ptr", PrivilegeSet, PrivilegeSetLengthMarshal, PrivilegeSetLength, GrantedAccessMarshal, GrantedAccess, AccessStatusMarshal, AccessStatus, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -741,7 +741,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AccessCheckByTypeResultList", "ptr", pSecurityDescriptor, "ptr", PrincipalSelfSid, "ptr", ClientToken, "uint", DesiredAccess, "ptr", ObjectTypeList, "uint", ObjectTypeListLength, "ptr", GenericMapping, "ptr", PrivilegeSet, PrivilegeSetLengthMarshal, PrivilegeSetLength, GrantedAccessListMarshal, GrantedAccessList, AccessStatusListMarshal, AccessStatusList, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -975,7 +975,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AddAccessAllowedAce", "ptr", pAcl, "uint", dwAceRevision, "uint", AccessMask, "ptr", pSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1075,7 +1075,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AddAccessAllowedAceEx", "ptr", pAcl, "uint", dwAceRevision, "uint", AceFlags, "uint", AccessMask, "ptr", pSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1178,7 +1178,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AddAccessAllowedObjectAce", "ptr", pAcl, "uint", dwAceRevision, "uint", AceFlags, "uint", AccessMask, "ptr", ObjectTypeGuid, "ptr", InheritedObjectTypeGuid, "ptr", pSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1268,7 +1268,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AddAccessDeniedAce", "ptr", pAcl, "uint", dwAceRevision, "uint", AccessMask, "ptr", pSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1368,7 +1368,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AddAccessDeniedAceEx", "ptr", pAcl, "uint", dwAceRevision, "uint", AceFlags, "uint", AccessMask, "ptr", pSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1471,7 +1471,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AddAccessDeniedObjectAce", "ptr", pAcl, "uint", dwAceRevision, "uint", AceFlags, "uint", AccessMask, "ptr", ObjectTypeGuid, "ptr", InheritedObjectTypeGuid, "ptr", pSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1540,7 +1540,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AddAce", "ptr", pAcl, "uint", dwAceRevision, "uint", dwStartingAceIndex, "ptr", pAceList, "uint", nAceListLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1633,7 +1633,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AddAuditAccessAce", "ptr", pAcl, "uint", dwAceRevision, "uint", dwAccessMask, "ptr", pSid, "int", bAuditSuccess, "int", bAuditFailure, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1735,7 +1735,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AddAuditAccessAceEx", "ptr", pAcl, "uint", dwAceRevision, "uint", AceFlags, "uint", dwAccessMask, "ptr", pSid, "int", bAuditSuccess, "int", bAuditFailure, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1840,7 +1840,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AddAuditAccessObjectAce", "ptr", pAcl, "uint", dwAceRevision, "uint", AceFlags, "uint", AccessMask, "ptr", ObjectTypeGuid, "ptr", InheritedObjectTypeGuid, "ptr", pSid, "int", bAuditSuccess, "int", bAuditFailure, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1926,7 +1926,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AddMandatoryAce", "ptr", pAcl, "uint", dwAceRevision, "uint", AceFlags, "uint", MandatoryPolicy, "ptr", pLabelSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1956,7 +1956,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\AddResourceAttributeAce", "ptr", pAcl, "uint", dwAceRevision, "uint", AceFlags, "uint", AccessMask, "ptr", pSid, "ptr", pAttributeInfo, pReturnLengthMarshal, pReturnLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1982,7 +1982,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\AddScopedPolicyIDAce", "ptr", pAcl, "uint", dwAceRevision, "uint", AceFlags, "uint", AccessMask, "ptr", pSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2018,7 +2018,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AdjustTokenGroups", "ptr", TokenHandle, "int", ResetToDefault, "ptr", NewState, "uint", BufferLength, "ptr", PreviousState, ReturnLengthMarshal, ReturnLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2136,7 +2136,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AdjustTokenPrivileges", "ptr", TokenHandle, "int", DisableAllPrivileges, "ptr", NewState, "uint", BufferLength, "ptr", PreviousState, ReturnLengthMarshal, ReturnLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2175,7 +2175,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AllocateAndInitializeSid", "ptr", pIdentifierAuthority, "char", nSubAuthorityCount, "uint", nSubAuthority0, "uint", nSubAuthority1, "uint", nSubAuthority2, "uint", nSubAuthority3, "uint", nSubAuthority4, "uint", nSubAuthority5, "uint", nSubAuthority6, "uint", nSubAuthority7, pSidMarshal, pSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2195,7 +2195,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AllocateLocallyUniqueId", "ptr", Luid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2259,7 +2259,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CheckTokenMembership", "ptr", TokenHandle, "ptr", SidToCheck, IsMemberMarshal, IsMember, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2287,7 +2287,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CheckTokenCapability", "ptr", TokenHandle, "ptr", CapabilitySidToCheck, HasCapabilityMarshal, HasCapability, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2330,7 +2330,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CheckTokenMembershipEx", "ptr", TokenHandle, "ptr", SidToCheck, "uint", Flags, IsMemberMarshal, IsMember, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2361,7 +2361,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ConvertToAutoInheritPrivateObjectSecurity", "ptr", ParentDescriptor, "ptr", CurrentSecurityDescriptor, "ptr", NewSecurityDescriptor, "ptr", ObjectType, "char", IsDirectoryObject, "ptr", GenericMapping, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2384,7 +2384,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CopySid", "uint", nDestinationSidLength, "ptr", pDestinationSid, "ptr", pSourceSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2431,7 +2431,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CreatePrivateObjectSecurity", "ptr", ParentDescriptor, "ptr", CreatorDescriptor, "ptr", NewDescriptor, "int", IsDirectoryObject, "ptr", Token, "ptr", GenericMapping, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2531,7 +2531,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CreatePrivateObjectSecurityEx", "ptr", ParentDescriptor, "ptr", CreatorDescriptor, "ptr", NewDescriptor, "ptr", ObjectType, "int", IsContainerObject, "uint", AutoInheritFlags, "ptr", Token, "ptr", GenericMapping, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2633,7 +2633,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CreatePrivateObjectSecurityWithMultipleInheritance", "ptr", ParentDescriptor, "ptr", CreatorDescriptor, "ptr", NewDescriptor, ObjectTypesMarshal, ObjectTypes, "uint", GuidCount, "int", IsContainerObject, "uint", AutoInheritFlags, "ptr", Token, "ptr", GenericMapping, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2696,7 +2696,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CreateRestrictedToken", "ptr", ExistingTokenHandle, "uint", Flags, "uint", DisableSidCount, "ptr", SidsToDisable, "uint", DeletePrivilegeCount, "ptr", PrivilegesToDelete, "uint", RestrictedSidCount, "ptr", SidsToRestrict, "ptr", NewTokenHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2721,7 +2721,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CreateWellKnownSid", "int", WellKnownSidType, "ptr", DomainSid, "ptr", pSid, cbSidMarshal, cbSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2744,7 +2744,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\EqualDomainSid", "ptr", pSid1, "ptr", pSid2, pfEqualMarshal, pfEqual, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2766,7 +2766,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\DeleteAce", "ptr", pAcl, "uint", dwAceIndex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2788,7 +2788,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\DestroyPrivateObjectSecurity", "ptr", ObjectDescriptor, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2815,7 +2815,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\DuplicateToken", "ptr", ExistingTokenHandle, "int", ImpersonationLevel, "ptr", DuplicateTokenHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2854,7 +2854,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\DuplicateTokenEx", "ptr", hExistingToken, "uint", dwDesiredAccess, "ptr", lpTokenAttributes, "int", ImpersonationLevel, "int", TokenType, "ptr", phNewToken, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2876,7 +2876,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\EqualPrefixSid", "ptr", pSid1, "ptr", pSid2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2901,7 +2901,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\EqualSid", "ptr", pSid1, "ptr", pSid2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2926,7 +2926,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\FindFirstFreeAce", "ptr", pAcl, pAceMarshal, pAce, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2966,7 +2966,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetAce", "ptr", pAcl, "uint", dwAceIndex, pAceMarshal, pAce, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2999,7 +2999,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetAclInformation", "ptr", pAcl, "ptr", pAclInformation, "uint", nAclInformationLength, "int", dwAclInformationClass, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3028,7 +3028,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetFileSecurityW", "ptr", lpFileName, "uint", RequestedInformation, "ptr", pSecurityDescriptor, "uint", nLength, lpnLengthNeededMarshal, lpnLengthNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3058,7 +3058,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetKernelObjectSecurity", "ptr", Handle, "uint", RequestedInformation, "ptr", pSecurityDescriptor, "uint", nLength, lpnLengthNeededMarshal, lpnLengthNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3105,7 +3105,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetPrivateObjectSecurity", "ptr", ObjectDescriptor, "uint", SecurityInformation, "ptr", ResultantDescriptor, "uint", DescriptorLength, ReturnLengthMarshal, ReturnLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3134,7 +3134,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetSecurityDescriptorControl", "ptr", pSecurityDescriptor, pControlMarshal, pControl, lpdwRevisionMarshal, lpdwRevision, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3175,7 +3175,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetSecurityDescriptorDacl", "ptr", pSecurityDescriptor, lpbDaclPresentMarshal, lpbDaclPresent, pDaclMarshal, pDacl, lpbDaclDefaultedMarshal, lpbDaclDefaulted, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3205,7 +3205,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetSecurityDescriptorGroup", "ptr", pSecurityDescriptor, pGroupMarshal, pGroup, lpbGroupDefaultedMarshal, lpbGroupDefaulted, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3253,7 +3253,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetSecurityDescriptorOwner", "ptr", pSecurityDescriptor, pOwnerMarshal, pOwner, lpbOwnerDefaultedMarshal, lpbOwnerDefaulted, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3330,7 +3330,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetSecurityDescriptorSacl", "ptr", pSecurityDescriptor, lpbSaclPresentMarshal, lpbSaclPresent, pSaclMarshal, pSacl, lpbSaclDefaultedMarshal, lpbSaclDefaulted, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3446,7 +3446,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetTokenInformation", "ptr", TokenHandle, "int", TokenInformationClass, "ptr", TokenInformation, "uint", TokenInformationLength, ReturnLengthMarshal, ReturnLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3470,7 +3470,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetWindowsAccountDomainSid", "ptr", pSid, "ptr", pDomainSid, cbDomainSidMarshal, cbDomainSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3496,7 +3496,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ImpersonateAnonymousToken", "ptr", ThreadHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3524,7 +3524,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ImpersonateLoggedOnUser", "ptr", hToken, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3545,7 +3545,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ImpersonateSelf", "int", ImpersonationLevel, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3572,7 +3572,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\InitializeAcl", "ptr", pAcl, "uint", nAclLength, "uint", dwAclRevision, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3597,7 +3597,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\InitializeSecurityDescriptor", "ptr", pSecurityDescriptor, "uint", dwRevision, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3622,7 +3622,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\InitializeSid", "ptr", Sid, "ptr", pIdentifierAuthority, "char", nSubAuthorityCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3646,7 +3646,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\IsTokenRestricted", "ptr", TokenHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3771,7 +3771,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\MakeAbsoluteSD", "ptr", pSelfRelativeSecurityDescriptor, "ptr", pAbsoluteSecurityDescriptor, lpdwAbsoluteSecurityDescriptorSizeMarshal, lpdwAbsoluteSecurityDescriptorSize, "ptr", pDacl, lpdwDaclSizeMarshal, lpdwDaclSize, "ptr", pSacl, lpdwSaclSizeMarshal, lpdwSaclSize, "ptr", pOwner, lpdwOwnerSizeMarshal, lpdwOwnerSize, "ptr", pPrimaryGroup, lpdwPrimaryGroupSizeMarshal, lpdwPrimaryGroupSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3819,7 +3819,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\MakeSelfRelativeSD", "ptr", pAbsoluteSecurityDescriptor, "ptr", pSelfRelativeSecurityDescriptor, lpdwBufferLengthMarshal, lpdwBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3972,7 +3972,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\PrivilegeCheck", "ptr", ClientToken, "ptr", RequiredPrivileges, pfResultMarshal, pfResult, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4028,7 +4028,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\RevertToSelf", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4061,7 +4061,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetAclInformation", "ptr", pAcl, "ptr", pAclInformation, "uint", nAclInformationLength, "int", dwAclInformationClass, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4110,7 +4110,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetKernelObjectSecurity", "ptr", Handle, "uint", SecurityInformation, "ptr", SecurityDescriptor, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4145,7 +4145,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetPrivateObjectSecurity", "uint", SecurityInformation, "ptr", ModificationDescriptor, "ptr", ObjectsSecurityDescriptor, "ptr", GenericMapping, "ptr", Token, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4182,7 +4182,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetPrivateObjectSecurityEx", "uint", SecurityInformation, "ptr", ModificationDescriptor, "ptr", ObjectsSecurityDescriptor, "uint", AutoInheritFlags, "ptr", GenericMapping, "ptr", Token, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4222,7 +4222,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetSecurityDescriptorControl", "ptr", pSecurityDescriptor, "ushort", ControlBitsOfInterest, "ushort", ControlBitsToSet, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4250,7 +4250,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetSecurityDescriptorDacl", "ptr", pSecurityDescriptor, "int", bDaclPresent, "ptr", pDacl, "int", bDaclDefaulted, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4277,7 +4277,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetSecurityDescriptorGroup", "ptr", pSecurityDescriptor, "ptr", pGroup, "int", bGroupDefaulted, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4304,7 +4304,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetSecurityDescriptorOwner", "ptr", pSecurityDescriptor, "ptr", pOwner, "int", bOwnerDefaulted, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4350,7 +4350,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetSecurityDescriptorSacl", "ptr", pSecurityDescriptor, "int", bSaclPresent, "ptr", pSacl, "int", bSaclDefaulted, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4376,7 +4376,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetTokenInformation", "ptr", TokenHandle, "int", TokenInformationClass, "ptr", TokenInformation, "uint", TokenInformationLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4445,7 +4445,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("api-ms-win-security-base-l1-2-2.dll\DeriveCapabilitySidsFromName", "ptr", CapName, CapabilityGroupSidsMarshal, CapabilityGroupSids, CapabilityGroupSidCountMarshal, CapabilityGroupSidCount, CapabilitySidsMarshal, CapabilitySids, CapabilitySidCountMarshal, CapabilitySidCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4494,7 +4494,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetUserObjectSecurity", "ptr", hObj, pSIRequestedMarshal, pSIRequested, "ptr", pSID, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4526,7 +4526,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetUserObjectSecurity", "ptr", hObj, pSIRequestedMarshal, pSIRequested, "ptr", pSID, "uint", nLength, lpnLengthNeededMarshal, lpnLengthNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4575,7 +4575,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AccessCheckAndAuditAlarmA", "ptr", SubsystemName, HandleIdMarshal, HandleId, "ptr", ObjectTypeName, "ptr", ObjectName, "ptr", SecurityDescriptor, "uint", DesiredAccess, "ptr", GenericMapping, "int", ObjectCreation, GrantedAccessMarshal, GrantedAccess, AccessStatusMarshal, AccessStatus, pfGenerateOnCloseMarshal, pfGenerateOnClose, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4644,7 +4644,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AccessCheckByTypeAndAuditAlarmA", "ptr", SubsystemName, HandleIdMarshal, HandleId, "ptr", ObjectTypeName, "ptr", ObjectName, "ptr", SecurityDescriptor, "ptr", PrincipalSelfSid, "uint", DesiredAccess, "int", AuditType, "uint", Flags, "ptr", ObjectTypeList, "uint", ObjectTypeListLength, "ptr", GenericMapping, "int", ObjectCreation, GrantedAccessMarshal, GrantedAccess, AccessStatusMarshal, AccessStatus, pfGenerateOnCloseMarshal, pfGenerateOnClose, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4702,7 +4702,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AccessCheckByTypeResultListAndAuditAlarmA", "ptr", SubsystemName, HandleIdMarshal, HandleId, "ptr", ObjectTypeName, "ptr", ObjectName, "ptr", SecurityDescriptor, "ptr", PrincipalSelfSid, "uint", DesiredAccess, "int", AuditType, "uint", Flags, "ptr", ObjectTypeList, "uint", ObjectTypeListLength, "ptr", GenericMapping, "int", ObjectCreation, GrantedAccessMarshal, GrantedAccess, AccessStatusListMarshal, AccessStatusList, pfGenerateOnCloseMarshal, pfGenerateOnClose, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4762,7 +4762,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AccessCheckByTypeResultListAndAuditAlarmByHandleA", "ptr", SubsystemName, HandleIdMarshal, HandleId, "ptr", ClientToken, "ptr", ObjectTypeName, "ptr", ObjectName, "ptr", SecurityDescriptor, "ptr", PrincipalSelfSid, "uint", DesiredAccess, "int", AuditType, "uint", Flags, "ptr", ObjectTypeList, "uint", ObjectTypeListLength, "ptr", GenericMapping, "int", ObjectCreation, GrantedAccessMarshal, GrantedAccess, AccessStatusListMarshal, AccessStatusList, pfGenerateOnCloseMarshal, pfGenerateOnClose, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4810,7 +4810,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ObjectOpenAuditAlarmA", "ptr", SubsystemName, HandleIdMarshal, HandleId, "ptr", ObjectTypeName, "ptr", ObjectName, "ptr", pSecurityDescriptor, "ptr", ClientToken, "uint", DesiredAccess, "uint", GrantedAccess, "ptr", Privileges, "int", ObjectCreation, "int", AccessGranted, GenerateOnCloseMarshal, GenerateOnClose, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4842,7 +4842,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ObjectPrivilegeAuditAlarmA", "ptr", SubsystemName, HandleIdMarshal, HandleId, "ptr", ClientToken, "uint", DesiredAccess, "ptr", Privileges, "int", AccessGranted, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4869,7 +4869,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ObjectCloseAuditAlarmA", "ptr", SubsystemName, HandleIdMarshal, HandleId, "int", GenerateOnClose, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4899,7 +4899,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ObjectDeleteAuditAlarmA", "ptr", SubsystemName, HandleIdMarshal, HandleId, "int", GenerateOnClose, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4928,7 +4928,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\PrivilegedServiceAuditAlarmA", "ptr", SubsystemName, "ptr", ServiceName, "ptr", ClientToken, "ptr", Privileges, "int", AccessGranted, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4982,7 +4982,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AddConditionalAce", "ptr", pAcl, "uint", dwAceRevision, "uint", AceFlags, "char", AceType, "uint", AccessMask, "ptr", pSid, "ptr", ConditionStr, ReturnLengthMarshal, ReturnLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5009,7 +5009,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetFileSecurityA", "ptr", lpFileName, "uint", SecurityInformation, "ptr", pSecurityDescriptor, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5039,7 +5039,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetFileSecurityA", "ptr", lpFileName, "uint", RequestedInformation, "ptr", pSecurityDescriptor, "uint", nLength, lpnLengthNeededMarshal, lpnLengthNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5082,7 +5082,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LookupAccountSidA", "ptr", lpSystemName, "ptr", Sid, "ptr", Name, cchNameMarshal, cchName, "ptr", ReferencedDomainName, cchReferencedDomainNameMarshal, cchReferencedDomainName, peUseMarshal, peUse, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5125,7 +5125,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LookupAccountSidW", "ptr", lpSystemName, "ptr", Sid, "ptr", Name, cchNameMarshal, cchName, "ptr", ReferencedDomainName, cchReferencedDomainNameMarshal, cchReferencedDomainName, peUseMarshal, peUse, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5163,7 +5163,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LookupAccountNameA", "ptr", lpSystemName, "ptr", lpAccountName, "ptr", Sid, cbSidMarshal, cbSid, "ptr", ReferencedDomainName, cchReferencedDomainNameMarshal, cchReferencedDomainName, peUseMarshal, peUse, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5201,7 +5201,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LookupAccountNameW", "ptr", lpSystemName, "ptr", lpAccountName, "ptr", Sid, cbSidMarshal, cbSid, "ptr", ReferencedDomainName, cchReferencedDomainNameMarshal, cchReferencedDomainName, peUseMarshal, peUse, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5227,7 +5227,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LookupPrivilegeValueA", "ptr", lpSystemName, "ptr", lpName, "ptr", lpLuid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5253,7 +5253,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LookupPrivilegeValueW", "ptr", lpSystemName, "ptr", lpName, "ptr", lpLuid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5282,7 +5282,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LookupPrivilegeNameA", "ptr", lpSystemName, "ptr", lpLuid, "ptr", lpName, cchNameMarshal, cchName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5311,7 +5311,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LookupPrivilegeNameW", "ptr", lpSystemName, "ptr", lpLuid, "ptr", lpName, cchNameMarshal, cchName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5343,7 +5343,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LookupPrivilegeDisplayNameA", "ptr", lpSystemName, "ptr", lpName, "ptr", lpDisplayName, cchDisplayNameMarshal, cchDisplayName, lpLanguageIdMarshal, lpLanguageId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5375,7 +5375,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LookupPrivilegeDisplayNameW", "ptr", lpSystemName, "ptr", lpName, "ptr", lpDisplayName, cchDisplayNameMarshal, cchDisplayName, lpLanguageIdMarshal, lpLanguageId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5413,7 +5413,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LogonUserA", "ptr", lpszUsername, "ptr", lpszDomain, "ptr", lpszPassword, "uint", dwLogonType, "uint", dwLogonProvider, "ptr", phToken, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5451,7 +5451,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LogonUserW", "ptr", lpszUsername, "ptr", lpszDomain, "ptr", lpszPassword, "uint", dwLogonType, "uint", dwLogonProvider, "ptr", phToken, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5499,7 +5499,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LogonUserExA", "ptr", lpszUsername, "ptr", lpszDomain, "ptr", lpszPassword, "uint", dwLogonType, "uint", dwLogonProvider, "ptr", phToken, ppLogonSidMarshal, ppLogonSid, ppProfileBufferMarshal, ppProfileBuffer, pdwProfileLengthMarshal, pdwProfileLength, "ptr", pQuotaLimits, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5547,7 +5547,7 @@ class Security {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\LogonUserExW", "ptr", lpszUsername, "ptr", lpszDomain, "ptr", lpszPassword, "uint", dwLogonType, "uint", dwLogonProvider, "ptr", phToken, ppLogonSidMarshal, ppLogonSid, ppProfileBufferMarshal, ppProfileBuffer, pdwProfileLengthMarshal, pdwProfileLength, "ptr", pQuotaLimits, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Security/AppLocker/Apis.ahk
+++ b/Windows/Win32/Security/AppLocker/Apis.ahk
@@ -337,7 +337,7 @@ class AppLocker {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SaferGetPolicyInformation", "uint", dwScopeId, "int", SaferPolicyInfoClass, "uint", InfoBufferSize, "ptr", InfoBuffer, InfoBufferRetSizeMarshal, InfoBufferRetSize, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -461,7 +461,7 @@ class AppLocker {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SaferSetPolicyInformation", "uint", dwScopeId, "int", SaferPolicyInfoClass, "uint", InfoBufferSize, "ptr", InfoBuffer, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -595,7 +595,7 @@ class AppLocker {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SaferCreateLevel", "uint", dwScopeId, "uint", dwLevelId, "uint", OpenFlags, "ptr", pLevelHandle, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -615,7 +615,7 @@ class AppLocker {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SaferCloseLevel", "ptr", hLevelHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -641,7 +641,7 @@ class AppLocker {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SaferIdentifyLevel", "uint", dwNumProperties, "ptr", pCodeProperties, "ptr", pLevelHandle, lpReservedMarshal, lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -669,7 +669,7 @@ class AppLocker {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SaferComputeTokenFromLevel", "ptr", LevelHandle, "ptr", InAccessToken, "ptr", OutAccessToken, "uint", dwFlags, lpReservedMarshal, lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -754,7 +754,7 @@ class AppLocker {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SaferGetLevelInformation", "ptr", LevelHandle, "int", dwInfoType, "ptr", lpQueryBuffer, "uint", dwInBufferSize, lpdwOutBufferSizeMarshal, lpdwOutBufferSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -836,7 +836,7 @@ class AppLocker {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SaferSetLevelInformation", "ptr", LevelHandle, "int", dwInfoType, "ptr", lpQueryBuffer, "uint", dwInBufferSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -860,7 +860,7 @@ class AppLocker {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SaferRecordEventLogEntry", "ptr", hLevel, "ptr", szTargetPath, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Security/Authorization/Apis.ahk
+++ b/Windows/Win32/Security/Authorization/Apis.ahk
@@ -1470,7 +1470,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzAccessCheck", "uint", Flags, "ptr", hAuthzClientContext, "ptr", pRequest, "ptr", hAuditEvent, "ptr", pSecurityDescriptor, "ptr", OptionalSecurityDescriptorArray, "uint", OptionalSecurityDescriptorCount, "ptr", pReply, "ptr", phAccessCheckResults, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1548,7 +1548,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzCachedAccessCheck", "uint", Flags, "ptr", hAccessCheckResults, "ptr", pRequest, "ptr", hAuditEvent, "ptr", pReply, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1581,7 +1581,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzOpenObjectAudit", "uint", Flags, "ptr", hAuthzClientContext, "ptr", pRequest, "ptr", hAuditEvent, "ptr", pSecurityDescriptor, "ptr", OptionalSecurityDescriptorArray, "uint", OptionalSecurityDescriptorCount, "ptr", pReply, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1603,7 +1603,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzFreeHandle", "ptr", hAccessCheckResults, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1686,7 +1686,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzInitializeResourceManager", "uint", Flags, "ptr", pfnDynamicAccessCheck, "ptr", pfnComputeDynamicGroups, "ptr", pfnFreeDynamicGroups, "ptr", szResourceManagerName, "ptr", phAuthzResourceManager, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1707,7 +1707,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzInitializeResourceManagerEx", "uint", Flags, "ptr", pAuthzInitInfo, "ptr", phAuthzResourceManager, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1727,7 +1727,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzInitializeRemoteResourceManager", "ptr", pRpcInitInfo, "ptr", phAuthzResourceManager, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1749,7 +1749,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzFreeResourceManager", "ptr", hAuthzResourceManager, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1782,7 +1782,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzInitializeContextFromToken", "uint", Flags, "ptr", TokenHandle, "ptr", hAuthzResourceManager, pExpirationTimeMarshal, pExpirationTime, "ptr", Identifier, DynamicGroupArgsMarshal, DynamicGroupArgs, "ptr", phAuthzClientContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1876,7 +1876,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzInitializeContextFromSid", "uint", Flags, "ptr", UserSid, "ptr", hAuthzResourceManager, pExpirationTimeMarshal, pExpirationTime, "ptr", Identifier, DynamicGroupArgsMarshal, DynamicGroupArgs, "ptr", phAuthzClientContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1906,7 +1906,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzInitializeContextFromAuthzContext", "uint", Flags, "ptr", hAuthzClientContext, pExpirationTimeMarshal, pExpirationTime, "ptr", Identifier, DynamicGroupArgsMarshal, DynamicGroupArgs, "ptr", phNewAuthzClientContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1931,7 +1931,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzInitializeCompoundContext", "ptr", UserContext, "ptr", DeviceContext, "ptr", phCompoundContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1959,7 +1959,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzAddSidsToContext", "ptr", hAuthzClientContext, "ptr", Sids, "uint", SidCount, "ptr", RestrictedSids, "uint", RestrictedSidCount, "ptr", phNewAuthzClientContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1987,7 +1987,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzModifySecurityAttributes", "ptr", hAuthzClientContext, pOperationsMarshal, pOperations, "ptr", pAttributes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2014,7 +2014,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzModifyClaims", "ptr", hAuthzClientContext, "int", ClaimClass, pClaimOperationsMarshal, pClaimOperations, "ptr", pClaims, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2041,7 +2041,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzModifySids", "ptr", hAuthzClientContext, "int", SidClass, pSidOperationsMarshal, pSidOperations, "ptr", pSids, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2066,7 +2066,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzSetAppContainerInformation", "ptr", hAuthzClientContext, "ptr", pAppContainerSid, "uint", CapabilityCount, "ptr", pCapabilitySids, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2095,7 +2095,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzGetInformationFromContext", "ptr", hAuthzClientContext, "int", InfoClass, "uint", BufferSize, pSizeRequiredMarshal, pSizeRequired, BufferMarshal, Buffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2117,7 +2117,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzFreeContext", "ptr", hAuthzClientContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2149,7 +2149,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzInitializeObjectAccessAuditEvent", "uint", Flags, "ptr", hAuditEventType, "ptr", szOperationType, "ptr", szObjectType, "ptr", szObjectName, "ptr", szAdditionalInfo, "ptr", phAuditEvent, "uint", dwAdditionalParameterCount, "CDecl int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2220,7 +2220,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzInitializeObjectAccessAuditEvent2", "uint", Flags, "ptr", hAuditEventType, "ptr", szOperationType, "ptr", szObjectType, "ptr", szObjectName, "ptr", szAdditionalInfo, "ptr", szAdditionalInfo2, "ptr", phAuditEvent, "uint", dwAdditionalParameterCount, "CDecl int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2242,7 +2242,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzFreeAuditEvent", "ptr", hAuditEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2300,7 +2300,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzInstallSecurityEventSource", "uint", dwFlags, "ptr", pRegistration, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2324,7 +2324,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzUninstallSecurityEventSource", "uint", dwFlags, "ptr", szEventSourceName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2349,7 +2349,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzEnumerateSecurityEventSources", "uint", dwFlags, "ptr", Buffer, pdwCountMarshal, pdwCount, pdwLengthMarshal, pdwLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2372,7 +2372,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzRegisterSecurityEventSource", "uint", dwFlags, "ptr", szEventSourceName, "ptr", phEventProvider, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2392,7 +2392,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzUnregisterSecurityEventSource", "uint", dwFlags, "ptr", phEventProvider, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2446,7 +2446,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzReportSecurityEvent", "uint", dwFlags, "ptr", hEventProvider, "uint", dwAuditId, "ptr", pUserSid, "uint", dwCount, "CDecl int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2471,7 +2471,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzReportSecurityEventFromParams", "uint", dwFlags, "ptr", hEventProvider, "uint", dwAuditId, "ptr", pUserSid, "ptr", pParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2495,7 +2495,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzRegisterCapChangeNotification", "ptr", phCapChangeSubscription, "ptr", pfnCapChangeCallback, pCallbackContextMarshal, pCallbackContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2517,7 +2517,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzUnregisterCapChangeNotification", "ptr", hCapChangeSubscription, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2536,7 +2536,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("AUTHZ.dll\AuthzFreeCentralAccessPolicyCache", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4140,7 +4140,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ConvertSidToStringSidA", "ptr", Sid, StringSidMarshal, StringSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4204,7 +4204,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ConvertSidToStringSidW", "ptr", Sid, StringSidMarshal, StringSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4264,7 +4264,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ConvertStringSidToSidA", "ptr", StringSid, SidMarshal, Sid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4324,7 +4324,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ConvertStringSidToSidW", "ptr", StringSid, SidMarshal, Sid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4394,7 +4394,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ConvertStringSecurityDescriptorToSecurityDescriptorA", "ptr", StringSecurityDescriptor, "uint", StringSDRevision, "ptr", SecurityDescriptor, SecurityDescriptorSizeMarshal, SecurityDescriptorSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4464,7 +4464,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ConvertStringSecurityDescriptorToSecurityDescriptorW", "ptr", StringSecurityDescriptor, "uint", StringSDRevision, "ptr", SecurityDescriptor, SecurityDescriptorSizeMarshal, SecurityDescriptorSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4550,7 +4550,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ConvertSecurityDescriptorToStringSecurityDescriptorA", "ptr", SecurityDescriptor, "uint", RequestedStringSDRevision, "uint", SecurityInformation, StringSecurityDescriptorMarshal, StringSecurityDescriptor, StringSecurityDescriptorLenMarshal, StringSecurityDescriptorLen, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4636,7 +4636,7 @@ class Authorization {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ConvertSecurityDescriptorToStringSecurityDescriptorW", "ptr", SecurityDescriptor, "uint", RequestedStringSDRevision, "uint", SecurityInformation, StringSecurityDescriptorMarshal, StringSecurityDescriptor, StringSecurityDescriptorLenMarshal, StringSecurityDescriptorLen, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Security/Authorization/UI/Apis.ahk
+++ b/Windows/Win32/Security/Authorization/UI/Apis.ahk
@@ -192,7 +192,7 @@ class UI {
         A_LastError := 0
 
         result := DllCall("ACLUI.dll\EditSecurity", "ptr", hwndOwner, "ptr", psi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Security/Credentials/Apis.ahk
+++ b/Windows/Win32/Security/Credentials/Apis.ahk
@@ -1079,7 +1079,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredWriteW", "ptr", Credential, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1222,7 +1222,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredWriteA", "ptr", Credential, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1270,7 +1270,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredReadW", "ptr", TargetName, "uint", Type, "uint", Flags, CredentialMarshal, Credential, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1318,7 +1318,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredReadA", "ptr", TargetName, "uint", Type, "uint", Flags, CredentialMarshal, Credential, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1391,7 +1391,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredEnumerateW", "ptr", Filter, "uint", Flags, CountMarshal, Count, CredentialMarshal, Credential, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1464,7 +1464,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredEnumerateA", "ptr", Filter, "uint", Flags, CountMarshal, Count, CredentialMarshal, Credential, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1605,7 +1605,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredWriteDomainCredentialsW", "ptr", TargetInfo, "ptr", Credential, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1746,7 +1746,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredWriteDomainCredentialsA", "ptr", TargetInfo, "ptr", Credential, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1818,7 +1818,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredReadDomainCredentialsW", "ptr", TargetInfo, "uint", Flags, CountMarshal, Count, CredentialMarshal, Credential, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1890,7 +1890,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredReadDomainCredentialsA", "ptr", TargetInfo, "uint", Flags, CountMarshal, Count, CredentialMarshal, Credential, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1937,7 +1937,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredDeleteW", "ptr", TargetName, "uint", Type, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1984,7 +1984,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredDeleteA", "ptr", TargetName, "uint", Type, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2035,7 +2035,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredRenameW", "ptr", OldTargetName, "ptr", NewTargetName, "uint", Type, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2086,7 +2086,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredRenameA", "ptr", OldTargetName, "ptr", NewTargetName, "uint", Type, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2127,7 +2127,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredGetTargetInfoW", "ptr", TargetName, "uint", Flags, TargetInfoMarshal, TargetInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2168,7 +2168,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredGetTargetInfoA", "ptr", TargetName, "uint", Flags, TargetInfoMarshal, TargetInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2202,7 +2202,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredMarshalCredentialW", "int", CredType, CredentialMarshal, Credential, MarshaledCredentialMarshal, MarshaledCredential, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2236,7 +2236,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredMarshalCredentialA", "int", CredType, CredentialMarshal, Credential, MarshaledCredentialMarshal, MarshaledCredential, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2269,7 +2269,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredUnmarshalCredentialW", "ptr", MarshaledCredential, CredTypeMarshal, CredType, CredentialMarshal, Credential, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2302,7 +2302,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredUnmarshalCredentialA", "ptr", MarshaledCredential, CredTypeMarshal, CredType, CredentialMarshal, Credential, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2426,7 +2426,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("credui.dll\CredUnPackAuthenticationBufferW", "uint", dwFlags, "ptr", pAuthBuffer, "uint", cbAuthBuffer, "ptr", pszUserName, pcchMaxUserNameMarshal, pcchMaxUserName, "ptr", pszDomainName, pcchMaxDomainNameMarshal, pcchMaxDomainName, "ptr", pszPassword, pcchMaxPasswordMarshal, pcchMaxPassword, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2522,7 +2522,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("credui.dll\CredUnPackAuthenticationBufferA", "uint", dwFlags, "ptr", pAuthBuffer, "uint", cbAuthBuffer, "ptr", pszUserName, pcchlMaxUserNameMarshal, pcchlMaxUserName, "ptr", pszDomainName, pcchMaxDomainNameMarshal, pcchMaxDomainName, "ptr", pszPassword, pcchMaxPasswordMarshal, pcchMaxPassword, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2632,7 +2632,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("credui.dll\CredPackAuthenticationBufferW", "uint", dwFlags, "ptr", pszUserName, "ptr", pszPassword, "ptr", pPackedCredentials, pcbPackedCredentialsMarshal, pcbPackedCredentials, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2742,7 +2742,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("credui.dll\CredPackAuthenticationBufferA", "uint", dwFlags, "ptr", pszUserName, "ptr", pszPassword, "ptr", pPackedCredentials, pcbPackedCredentialsMarshal, pcbPackedCredentials, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2773,7 +2773,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredProtectW", "int", fAsSelf, "ptr", pszCredentials, "uint", cchCredentials, "ptr", pszProtectedCredentials, pcchMaxCharsMarshal, pcchMaxChars, ProtectionTypeMarshal, ProtectionType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2804,7 +2804,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredProtectA", "int", fAsSelf, "ptr", pszCredentials, "uint", cchCredentials, "ptr", pszProtectedCredentials, pcchMaxCharsMarshal, pcchMaxChars, ProtectionTypeMarshal, ProtectionType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2864,7 +2864,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredUnprotectW", "int", fAsSelf, "ptr", pszProtectedCredentials, "uint", cchProtectedCredentials, "ptr", pszCredentials, pcchMaxCharsMarshal, pcchMaxChars, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2924,7 +2924,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredUnprotectA", "int", fAsSelf, "ptr", pszProtectedCredentials, "uint", cchProtectedCredentials, "ptr", pszCredentials, pcchMaxCharsMarshal, pcchMaxChars, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2949,7 +2949,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredIsProtectedW", "ptr", pszProtectedCredentials, pProtectionTypeMarshal, pProtectionType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2974,7 +2974,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredIsProtectedA", "ptr", pszProtectedCredentials, pProtectionTypeMarshal, pProtectionType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3003,7 +3003,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredFindBestCredentialW", "ptr", TargetName, "uint", Type, "uint", Flags, CredentialMarshal, Credential, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3032,7 +3032,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredFindBestCredentialA", "ptr", TargetName, "uint", Type, "uint", Flags, CredentialMarshal, Credential, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3127,7 +3127,7 @@ class Credentials {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CredGetSessionTypes", "uint", MaximumPersistCount, MaximumPersistMarshal, MaximumPersist, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Security/Cryptography/Apis.ahk
+++ b/Windows/Win32/Security/Cryptography/Apis.ahk
@@ -16597,7 +16597,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptAcquireContextA", phProvMarshal, phProv, "ptr", szContainer, "ptr", szProvider, "uint", dwProvType, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16999,7 +16999,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptAcquireContextW", phProvMarshal, phProv, "ptr", szContainer, "ptr", szProvider, "uint", dwProvType, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17083,7 +17083,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptReleaseContext", "ptr", hProv, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17385,7 +17385,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptGenKey", "ptr", hProv, "uint", Algid, "uint", dwFlags, phKeyMarshal, phKey, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17611,7 +17611,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptDeriveKey", "ptr", hProv, "uint", Algid, "ptr", hBaseData, "uint", dwFlags, phKeyMarshal, phKey, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17695,7 +17695,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptDestroyKey", "ptr", hKey, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17818,7 +17818,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptSetKeyParam", "ptr", hKey, "uint", dwParam, pbDataMarshal, pbData, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17936,7 +17936,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptGetKeyParam", "ptr", hKey, "uint", dwParam, "ptr", pbData, pdwDataLenMarshal, pdwDataLen, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -18058,7 +18058,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptSetHashParam", "ptr", hHash, "uint", dwParam, pbDataMarshal, pbData, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -18231,7 +18231,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptGetHashParam", "ptr", hHash, "uint", dwParam, "ptr", pbData, pdwDataLenMarshal, pdwDataLen, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -18350,7 +18350,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptSetProvParam", "ptr", hProv, "uint", dwParam, pbDataMarshal, pbData, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19030,7 +19030,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptGetProvParam", "ptr", hProv, "uint", dwParam, "ptr", pbData, pdwDataLenMarshal, pdwDataLen, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19111,7 +19111,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptGenRandom", "ptr", hProv, "uint", dwLen, "ptr", pbBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19206,7 +19206,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptGetUserKey", "ptr", hProv, "uint", dwKeySpec, phUserKeyMarshal, phUserKey, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19452,7 +19452,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptExportKey", "ptr", hKey, "ptr", hExpKey, "uint", dwBlobType, "uint", dwFlags, "ptr", pbData, pdwDataLenMarshal, pdwDataLen, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19598,7 +19598,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptImportKey", "ptr", hProv, "ptr", pbData, "uint", dwDataLen, "ptr", hPubKey, "uint", dwFlags, phKeyMarshal, phKey, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19822,7 +19822,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptEncrypt", "ptr", hKey, "ptr", hHash, "int", Final, "uint", dwFlags, "ptr", pbData, pdwDataLenMarshal, pdwDataLen, "uint", dwBufLen, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20037,7 +20037,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptDecrypt", "ptr", hKey, "ptr", hHash, "int", Final, "uint", dwFlags, "ptr", pbData, pdwDataLenMarshal, pdwDataLen, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20172,7 +20172,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptCreateHash", "ptr", hProv, "uint", Algid, "ptr", hKey, "uint", dwFlags, phHashMarshal, phHash, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20354,7 +20354,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptHashData", "ptr", hHash, "ptr", pbData, "uint", dwDataLen, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20507,7 +20507,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptHashSessionKey", "ptr", hHash, "ptr", hKey, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20602,7 +20602,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptDestroyHash", "ptr", hHash, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20807,7 +20807,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptSignHashA", "ptr", hHash, "uint", dwKeySpec, "ptr", szDescription, "uint", dwFlags, "ptr", pbSignature, pdwSigLenMarshal, pdwSigLen, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21012,7 +21012,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptSignHashW", "ptr", hHash, "uint", dwKeySpec, "ptr", szDescription, "uint", dwFlags, "ptr", pbSignature, pdwSigLenMarshal, pdwSigLen, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21187,7 +21187,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptVerifySignatureA", "ptr", hHash, "ptr", pbSignature, "uint", dwSigLen, "ptr", hPubKey, "ptr", szDescription, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21362,7 +21362,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptVerifySignatureW", "ptr", hHash, "ptr", pbSignature, "uint", dwSigLen, "ptr", hPubKey, "ptr", szDescription, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21429,7 +21429,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptSetProviderA", "ptr", pszProvName, "uint", dwProvType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21496,7 +21496,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptSetProviderW", "ptr", pszProvName, "uint", dwProvType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21592,7 +21592,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptSetProviderExA", "ptr", pszProvName, "uint", dwProvType, "uint*", pdwReserved, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21688,7 +21688,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptSetProviderExW", "ptr", pszProvName, "uint", dwProvType, "uint*", pdwReserved, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21836,7 +21836,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptGetDefaultProviderA", "uint", dwProvType, "uint*", pdwReserved, "uint", dwFlags, "ptr", pszProvName, pcbProvNameMarshal, pcbProvName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21984,7 +21984,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptGetDefaultProviderW", "uint", dwProvType, "uint*", pdwReserved, "uint", dwFlags, "ptr", pszProvName, pcbProvNameMarshal, pcbProvName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22078,7 +22078,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptEnumProviderTypesA", "uint", dwIndex, "uint*", pdwReserved, "uint", dwFlags, pdwProvTypeMarshal, pdwProvType, "ptr", szTypeName, pcbTypeNameMarshal, pcbTypeName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22172,7 +22172,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptEnumProviderTypesW", "uint", dwIndex, "uint*", pdwReserved, "uint", dwFlags, pdwProvTypeMarshal, pdwProvType, "ptr", szTypeName, pcbTypeNameMarshal, pcbTypeName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22271,7 +22271,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptEnumProvidersA", "uint", dwIndex, "uint*", pdwReserved, "uint", dwFlags, pdwProvTypeMarshal, pdwProvType, "ptr", szProvName, pcbProvNameMarshal, pcbProvName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22370,7 +22370,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptEnumProvidersW", "uint", dwIndex, "uint*", pdwReserved, "uint", dwFlags, pdwProvTypeMarshal, pdwProvType, "ptr", szProvName, pcbProvNameMarshal, pcbProvName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22412,7 +22412,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptContextAddRef", "ptr", hProv, "uint*", pdwReserved, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22480,7 +22480,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptDuplicateKey", "ptr", hKey, "uint*", pdwReserved, "uint", dwFlags, phKeyMarshal, phKey, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22548,7 +22548,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CryptDuplicateHash", "ptr", hHash, "uint*", pdwReserved, "uint", dwFlags, phHashMarshal, phHash, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -28509,7 +28509,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptFormatObject", "uint", dwCertEncodingType, "uint", dwFormatType, "uint", dwFormatStrType, pFormatStructMarshal, pFormatStruct, "ptr", lpszStructType, "ptr", pbEncoded, "uint", cbEncoded, "ptr", pbFormat, pcbFormatMarshal, pcbFormat, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -28603,7 +28603,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptEncodeObjectEx", "uint", dwCertEncodingType, "ptr", lpszStructType, pvStructInfoMarshal, pvStructInfo, "uint", dwFlags, "ptr", pEncodePara, pvEncodedMarshal, pvEncoded, pcbEncodedMarshal, pcbEncoded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -28697,7 +28697,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptEncodeObject", "uint", dwCertEncodingType, "ptr", lpszStructType, pvStructInfoMarshal, pvStructInfo, "ptr", pbEncoded, pcbEncodedMarshal, pcbEncoded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -28882,7 +28882,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptDecodeObjectEx", "uint", dwCertEncodingType, "ptr", lpszStructType, "ptr", pbEncoded, "uint", cbEncoded, "uint", dwFlags, "ptr", pDecodePara, pvStructInfoMarshal, pvStructInfo, pcbStructInfoMarshal, pcbStructInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -29036,7 +29036,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptDecodeObject", "uint", dwCertEncodingType, "ptr", lpszStructType, "ptr", pbEncoded, "uint", cbEncoded, "uint", dwFlags, "ptr", pvStructInfo, pcbStructInfoMarshal, pcbStructInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -29141,7 +29141,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptGetOIDFunctionAddress", hFuncSetMarshal, hFuncSet, "uint", dwEncodingType, "ptr", pszOID, "uint", dwFlags, ppvFuncAddrMarshal, ppvFuncAddr, phFuncAddrMarshal, phFuncAddr, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -29208,7 +29208,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptGetDefaultOIDDllList", hFuncSetMarshal, hFuncSet, "uint", dwEncodingType, "ptr", pwszDllList, pcchDllListMarshal, pcchDllList, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -29503,7 +29503,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptGetOIDFunctionValue", "uint", dwEncodingType, "ptr", pszFuncName, "ptr", pszOID, "ptr", pwszValueName, pdwValueTypeMarshal, pdwValueType, "ptr", pbValueData, pcbValueDataMarshal, pcbValueData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -29545,7 +29545,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptEnumOIDFunction", "uint", dwEncodingType, "ptr", pszFuncName, "ptr", pszOID, "uint", dwFlags, pvArgMarshal, pvArg, "ptr", pfnEnumOIDFunc, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -30352,7 +30352,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptMsgClose", hCryptMsgMarshal, hCryptMsg, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -30506,7 +30506,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptMsgUpdate", hCryptMsgMarshal, hCryptMsg, "ptr", pbData, "uint", cbData, "int", fFinal, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -31106,7 +31106,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptMsgGetParam", hCryptMsgMarshal, hCryptMsg, "uint", dwParamType, "uint", dwIndex, "ptr", pvData, pcbDataMarshal, pcbData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -31666,7 +31666,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptMsgControl", hCryptMsgMarshal, hCryptMsg, "uint", dwFlags, "uint", dwCtrlType, pvCtrlParaMarshal, pvCtrlPara, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -31800,7 +31800,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptMsgVerifyCountersignatureEncoded", "ptr", hCryptProv, "uint", dwEncodingType, "ptr", pbSignerInfo, "uint", cbSignerInfo, "ptr", pbSignerInfoCountersignature, "uint", cbSignerInfoCountersignature, "ptr", pciCountersigner, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -32001,7 +32001,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptMsgVerifyCountersignatureEncodedEx", "ptr", hCryptProv, "uint", dwEncodingType, "ptr", pbSignerInfo, "uint", cbSignerInfo, "ptr", pbSignerInfoCountersignature, "uint", cbSignerInfoCountersignature, "uint", dwSignerType, pvSignerMarshal, pvSigner, "uint", dwFlags, pvExtraMarshal, pvExtra, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -32078,7 +32078,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptMsgCountersign", hCryptMsgMarshal, hCryptMsg, "uint", dwIndex, "uint", cCountersigners, "ptr", rgCountersigners, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -32184,7 +32184,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptMsgCountersignEncoded", "uint", dwEncodingType, "ptr", pbSignerInfo, "uint", cbSignerInfo, "uint", cCountersigners, "ptr", rgCountersigners, "ptr", pbCountersignature, pcbCountersignatureMarshal, pcbCountersignature, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -32542,7 +32542,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertSaveStore", "ptr", hCertStore, "uint", dwEncodingType, "uint", dwSaveAs, "uint", dwSaveTo, pvSaveToParaMarshal, pvSaveToPara, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -32604,7 +32604,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertCloseStore", "ptr", hCertStore, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -33038,7 +33038,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertVerifySubjectCertificateContext", "ptr", pSubject, "ptr", pIssuer, pdwFlagsMarshal, pdwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -33170,7 +33170,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertSetCertificateContextProperty", "ptr", pCertContext, "uint", dwPropId, "uint", dwFlags, pvDataMarshal, pvData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -33243,7 +33243,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertGetCertificateContextProperty", "ptr", pCertContext, "uint", dwPropId, "ptr", pvData, pcbDataMarshal, pcbData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -33292,7 +33292,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertCreateCTLEntryFromCertificateContextProperties", "ptr", pCertContext, "uint", cOptAttr, "ptr", rgOptAttr, "uint", dwFlags, "ptr", pvReserved, "ptr", pCtlEntry, pcbCtlEntryMarshal, pcbCtlEntry, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -33314,7 +33314,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertSetCertificateContextPropertiesFromCTLEntry", "ptr", pCertContext, "ptr", pCtlEntry, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -34176,7 +34176,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertSetCRLContextProperty", "ptr", pCrlContext, "uint", dwPropId, "uint", dwFlags, pvDataMarshal, pvData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -34596,7 +34596,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertGetCRLContextProperty", "ptr", pCrlContext, "uint", dwPropId, "ptr", pvData, pcbDataMarshal, pcbData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -34783,7 +34783,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertAddEncodedCertificateToStore", "ptr", hCertStore, "uint", dwCertEncodingType, "ptr", pbCertEncoded, "uint", cbCertEncoded, "uint", dwAddDisposition, ppCertContextMarshal, ppCertContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -34955,7 +34955,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertAddCertificateContextToStore", "ptr", hCertStore, "ptr", pCertContext, "uint", dwAddDisposition, ppStoreContextMarshal, ppStoreContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -35199,7 +35199,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertAddSerializedElementToStore", "ptr", hCertStore, "ptr", pbElement, "uint", cbElement, "uint", dwAddDisposition, "uint", dwFlags, "uint", dwContextTypeFlags, pdwContextTypeMarshal, pdwContextType, ppvContextMarshal, ppvContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -35239,7 +35239,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertDeleteCertificateFromStore", "ptr", pCertContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -35396,7 +35396,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertAddEncodedCRLToStore", "ptr", hCertStore, "uint", dwCertEncodingType, "ptr", pbCrlEncoded, "uint", cbCrlEncoded, "uint", dwAddDisposition, ppCrlContextMarshal, ppCrlContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -35544,7 +35544,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertAddCRLContextToStore", "ptr", hCertStore, "ptr", pCrlContext, "uint", dwAddDisposition, ppStoreContextMarshal, ppStoreContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -35583,7 +35583,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertDeleteCRLFromStore", "ptr", pCrlContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -35621,7 +35621,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertSerializeCertificateStoreElement", "ptr", pCertContext, "uint", dwFlags, "ptr", pbElement, pcbElementMarshal, pcbElement, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -35659,7 +35659,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertSerializeCRLStoreElement", "ptr", pCrlContext, "uint", dwFlags, "ptr", pbElement, pcbElementMarshal, pcbElement, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -36042,7 +36042,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertSetCTLContextProperty", "ptr", pCtlContext, "uint", dwPropId, "uint", dwFlags, pvDataMarshal, pvData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -36364,7 +36364,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertGetCTLContextProperty", "ptr", pCtlContext, "uint", dwPropId, "ptr", pvData, pcbDataMarshal, pcbData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -36786,7 +36786,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertAddEncodedCTLToStore", "ptr", hCertStore, "uint", dwMsgAndCertEncodingType, "ptr", pbCtlEncoded, "uint", cbCtlEncoded, "uint", dwAddDisposition, ppCtlContextMarshal, ppCtlContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -36931,7 +36931,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertAddCTLContextToStore", "ptr", hCertStore, "ptr", pCtlContext, "uint", dwAddDisposition, ppStoreContextMarshal, ppStoreContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -36969,7 +36969,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertSerializeCTLStoreElement", "ptr", pCtlContext, "uint", dwFlags, "ptr", pbElement, pcbElementMarshal, pcbElement, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -37008,7 +37008,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertDeleteCTLFromStore", "ptr", pCtlContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -37119,7 +37119,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertAddCertificateLinkToStore", "ptr", hCertStore, "ptr", pCertContext, "uint", dwAddDisposition, ppStoreContextMarshal, ppStoreContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -37241,7 +37241,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertAddCRLLinkToStore", "ptr", hCertStore, "ptr", pCrlContext, "uint", dwAddDisposition, ppStoreContextMarshal, ppStoreContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -37385,7 +37385,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertAddCTLLinkToStore", "ptr", hCertStore, "ptr", pCtlContext, "uint", dwAddDisposition, ppStoreContextMarshal, ppStoreContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -37522,7 +37522,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertControlStore", "ptr", hCertStore, "uint", dwFlags, "uint", dwCtrlType, pvCtrlParaMarshal, pvCtrlPara, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -37587,7 +37587,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertGetStoreProperty", "ptr", hCertStore, "uint", dwPropId, "ptr", pvData, pcbDataMarshal, pcbData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -38143,7 +38143,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertEnumPhysicalStore", pvSystemStoreMarshal, pvSystemStore, "uint", dwFlags, pvArgMarshal, pvArg, "ptr", pfnEnum, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -38206,7 +38206,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertGetEnhancedKeyUsage", "ptr", pCertContext, "uint", dwFlags, "ptr", pUsage, pcbUsageMarshal, pcbUsage, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -38229,7 +38229,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertSetEnhancedKeyUsage", "ptr", pCertContext, "ptr", pUsage, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -38253,7 +38253,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertAddEnhancedKeyUsageIdentifier", "ptr", pCertContext, "ptr", pszUsageIdentifier, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -38277,7 +38277,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertRemoveEnhancedKeyUsageIdentifier", "ptr", pCertContext, "ptr", pszUsageIdentifier, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -38304,7 +38304,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertGetValidUsages", "uint", cCerts, rghCertsMarshal, rghCerts, cNumOIDsMarshal, cNumOIDs, "ptr", rghOIDs, pcbOIDsMarshal, pcbOIDs, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -38375,7 +38375,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptMsgGetAndVerifySigner", hCryptMsgMarshal, hCryptMsg, "uint", cSignerStore, "ptr", rghSignerStore, "uint", dwFlags, ppSignerMarshal, ppSigner, pdwSignerIndexMarshal, pdwSignerIndex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -38424,7 +38424,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptMsgSignCTL", "uint", dwMsgEncodingType, "ptr", pbCtlContent, "uint", cbCtlContent, "ptr", pSignInfo, "uint", dwFlags, "ptr", pbEncoded, pcbEncodedMarshal, pcbEncoded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -38475,7 +38475,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptMsgEncodeAndSignCTL", "uint", dwMsgEncodingType, "ptr", pCtlInfo, "ptr", pSignInfo, "uint", dwFlags, "ptr", pbEncoded, pcbEncodedMarshal, pcbEncoded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -38628,7 +38628,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertVerifyCTLUsage", "uint", dwEncodingType, "uint", dwSubjectType, pvSubjectMarshal, pvSubject, "ptr", pSubjectUsage, "uint", dwFlags, "ptr", pVerifyUsagePara, "ptr", pVerifyUsageStatus, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -38799,7 +38799,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertVerifyRevocation", "uint", dwEncodingType, "uint", dwRevType, "uint", cContext, rgpvContextMarshal, rgpvContext, "uint", dwFlags, "ptr", pRevPara, "ptr", pRevStatus, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -38821,7 +38821,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertCompareIntegerBlob", "ptr", pInt1, "ptr", pInt2, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -38948,7 +38948,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertIsRDNAttrsInCertificateName", "uint", dwCertEncodingType, "uint", dwFlags, "ptr", pCertName, "ptr", pRDN, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -39106,7 +39106,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptVerifyCertificateSignature", "ptr", hCryptProv, "uint", dwCertEncodingType, "ptr", pbEncoded, "uint", cbEncoded, "ptr", pPublicKey, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -39332,7 +39332,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptVerifyCertificateSignatureEx", "ptr", hCryptProv, "uint", dwCertEncodingType, "uint", dwSubjectType, pvSubjectMarshal, pvSubject, "uint", dwIssuerType, pvIssuerMarshal, pvIssuer, "uint", dwFlags, pvExtraMarshal, pvExtra, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -39401,7 +39401,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertIsStrongHashToSign", "ptr", pStrongSignPara, "ptr", pwszCNGHashAlgid, "ptr", pSigningCert, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -39500,7 +39500,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptHashToBeSigned", "ptr", hCryptProv, "uint", dwCertEncodingType, "ptr", pbEncoded, "uint", cbEncoded, "ptr", pbComputedHash, pcbComputedHashMarshal, pcbComputedHash, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -39557,7 +39557,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptHashCertificate", "ptr", hCryptProv, "uint", Algid, "uint", dwFlags, "ptr", pbEncoded, "uint", cbEncoded, "ptr", pbComputedHash, pcbComputedHashMarshal, pcbComputedHash, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -39604,7 +39604,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptHashCertificate2", "ptr", pwszCNGHashAlgid, "uint", dwFlags, "ptr", pvReserved, "ptr", pbEncoded, "uint", cbEncoded, "ptr", pbComputedHash, pcbComputedHashMarshal, pcbComputedHash, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -39698,7 +39698,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptSignCertificate", "ptr", hCryptProvOrNCryptKey, "uint", dwKeySpec, "uint", dwCertEncodingType, "ptr", pbEncodedToBeSigned, "uint", cbEncodedToBeSigned, "ptr", pSignatureAlgorithm, pvHashAuxInfoMarshal, pvHashAuxInfo, "ptr", pbSignature, pcbSignatureMarshal, pcbSignature, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -39877,7 +39877,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptSignAndEncodeCertificate", "ptr", hCryptProvOrNCryptKey, "uint", dwKeySpec, "uint", dwCertEncodingType, "ptr", lpszStructType, pvStructInfoMarshal, pvStructInfo, "ptr", pSignatureAlgorithm, pvHashAuxInfoMarshal, pvHashAuxInfo, "ptr", pbEncoded, pcbEncodedMarshal, pcbEncoded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -40074,7 +40074,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertGetIntendedKeyUsage", "uint", dwCertEncodingType, "ptr", pCertInfo, "ptr", pbKeyUsage, "uint", cbKeyUsage, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -40102,7 +40102,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptInstallDefaultContext", "ptr", hCryptProv, "uint", dwDefaultType, pvDefaultParaMarshal, pvDefaultPara, "uint", dwFlags, "ptr", pvReserved, phDefaultContextMarshal, phDefaultContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -40125,7 +40125,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptUninstallDefaultContext", hDefaultContextMarshal, hDefaultContext, "uint", dwFlags, "ptr", pvReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -40209,7 +40209,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptExportPublicKeyInfo", "ptr", hCryptProvOrNCryptKey, "uint", dwKeySpec, "uint", dwCertEncodingType, "ptr", pInfo, pcbInfoMarshal, pcbInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -40330,7 +40330,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptExportPublicKeyInfoEx", "ptr", hCryptProvOrNCryptKey, "uint", dwKeySpec, "uint", dwCertEncodingType, "ptr", pszPublicKeyObjId, "uint", dwFlags, pvAuxInfoMarshal, pvAuxInfo, "ptr", pInfo, pcbInfoMarshal, pcbInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -40463,7 +40463,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptImportPublicKeyInfo", "ptr", hCryptProv, "uint", dwCertEncodingType, "ptr", pInfo, phKeyMarshal, phKey, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -40532,7 +40532,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptImportPublicKeyInfoEx", "ptr", hCryptProv, "uint", dwCertEncodingType, "ptr", pInfo, "uint", aiKeyAlg, "uint", dwFlags, pvAuxInfoMarshal, pvAuxInfo, phKeyMarshal, phKey, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -40612,7 +40612,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptImportPublicKeyInfoEx2", "uint", dwCertEncodingType, "ptr", pInfo, "uint", dwFlags, pvAuxInfoMarshal, pvAuxInfo, "ptr", phKey, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -40685,7 +40685,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptAcquireCertificatePrivateKey", "ptr", pCert, "uint", dwFlags, pvParametersMarshal, pvParameters, "ptr", phCryptProvOrNCryptKey, pdwKeySpecMarshal, pdwKeySpec, pfCallerFreeProvOrNCryptKeyMarshal, pfCallerFreeProvOrNCryptKey, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -40727,7 +40727,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptFindCertificateKeyProvInfo", "ptr", pCert, "uint", dwFlags, "ptr", pvReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -40783,7 +40783,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptImportPKCS8", "ptr", sPrivateKeyAndParams, "uint", dwFlags, phCryptProvMarshal, phCryptProv, pvAuxInfoMarshal, pvAuxInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -40884,7 +40884,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptExportPKCS8", "ptr", hCryptProv, "uint", dwKeySpec, "ptr", pszPrivateKeyObjId, "uint", dwFlags, pvAuxInfoMarshal, pvAuxInfo, "ptr", pbPrivateKeyBlob, pcbPrivateKeyBlobMarshal, pcbPrivateKeyBlob, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -40973,7 +40973,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptHashPublicKeyInfo", "ptr", hCryptProv, "uint", Algid, "uint", dwFlags, "uint", dwCertEncodingType, "ptr", pInfo, "ptr", pbComputedHash, pcbComputedHashMarshal, pcbComputedHash, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -41186,7 +41186,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertStrToNameA", "uint", dwCertEncodingType, "ptr", pszX500, "uint", dwStrType, "ptr", pvReserved, "ptr", pbEncoded, pcbEncodedMarshal, pcbEncoded, ppszErrorMarshal, ppszError, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -41275,7 +41275,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertStrToNameW", "uint", dwCertEncodingType, "ptr", pszX500, "uint", dwStrType, "ptr", pvReserved, "ptr", pbEncoded, pcbEncodedMarshal, pcbEncoded, ppszErrorMarshal, ppszError, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -41780,7 +41780,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptSignMessage", "ptr", pSignPara, "int", fDetachedSignature, "uint", cToBeSigned, rgpbToBeSignedMarshal, rgpbToBeSigned, rgcbToBeSignedMarshal, rgcbToBeSigned, "ptr", pbSignedBlob, pcbSignedBlobMarshal, pcbSignedBlob, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -41909,7 +41909,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptVerifyMessageSignature", "ptr", pVerifyPara, "uint", dwSignerIndex, "ptr", pbSignedBlob, "uint", cbSignedBlob, "ptr", pbDecoded, pcbDecodedMarshal, pcbDecoded, ppSignerCertMarshal, ppSignerCert, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -42138,7 +42138,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptVerifyDetachedMessageSignature", "ptr", pVerifyPara, "uint", dwSignerIndex, "ptr", pbDetachedSignBlob, "uint", cbDetachedSignBlob, "uint", cToBeSigned, rgpbToBeSignedMarshal, rgpbToBeSigned, rgcbToBeSignedMarshal, rgcbToBeSigned, ppSignerCertMarshal, ppSignerCert, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -42224,7 +42224,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptEncryptMessage", "ptr", pEncryptPara, "uint", cRecipientCert, rgpRecipientCertMarshal, rgpRecipientCert, "ptr", pbToBeEncrypted, "uint", cbToBeEncrypted, "ptr", pbEncryptedBlob, pcbEncryptedBlobMarshal, pcbEncryptedBlob, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -42336,7 +42336,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptDecryptMessage", "ptr", pDecryptPara, "ptr", pbEncryptedBlob, "uint", cbEncryptedBlob, "ptr", pbDecrypted, pcbDecryptedMarshal, pcbDecrypted, ppXchgCertMarshal, ppXchgCert, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -42410,7 +42410,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptSignAndEncryptMessage", "ptr", pSignPara, "ptr", pEncryptPara, "uint", cRecipientCert, rgpRecipientCertMarshal, rgpRecipientCert, "ptr", pbToBeSignedAndEncrypted, "uint", cbToBeSignedAndEncrypted, "ptr", pbSignedAndEncryptedBlob, pcbSignedAndEncryptedBlobMarshal, pcbSignedAndEncryptedBlob, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -42481,7 +42481,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptDecryptAndVerifyMessageSignature", "ptr", pDecryptPara, "ptr", pVerifyPara, "uint", dwSignerIndex, "ptr", pbEncryptedBlob, "uint", cbEncryptedBlob, "ptr", pbDecrypted, pcbDecryptedMarshal, pcbDecrypted, ppXchgCertMarshal, ppXchgCert, ppSignerCertMarshal, ppSignerCert, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -42589,7 +42589,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptDecodeMessage", "uint", dwMsgTypeFlags, "ptr", pDecryptPara, "ptr", pVerifyPara, "uint", dwSignerIndex, "ptr", pbEncodedBlob, "uint", cbEncodedBlob, "uint", dwPrevInnerContentType, pdwMsgTypeMarshal, pdwMsgType, pdwInnerContentTypeMarshal, pdwInnerContentType, "ptr", pbDecoded, pcbDecodedMarshal, pcbDecoded, ppXchgCertMarshal, ppXchgCert, ppSignerCertMarshal, ppSignerCert, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -42682,7 +42682,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptHashMessage", "ptr", pHashPara, "int", fDetachedHash, "uint", cToBeHashed, rgpbToBeHashedMarshal, rgpbToBeHashed, rgcbToBeHashedMarshal, rgcbToBeHashed, "ptr", pbHashedBlob, pcbHashedBlobMarshal, pcbHashedBlob, "ptr", pbComputedHash, pcbComputedHashMarshal, pcbComputedHash, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -42786,7 +42786,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptVerifyMessageHash", "ptr", pHashPara, "ptr", pbHashedBlob, "uint", cbHashedBlob, "ptr", pbToBeHashed, pcbToBeHashedMarshal, pcbToBeHashed, "ptr", pbComputedHash, pcbComputedHashMarshal, pcbComputedHash, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -42885,7 +42885,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptVerifyDetachedMessageHash", "ptr", pHashPara, "ptr", pbDetachedHashBlob, "uint", cbDetachedHashBlob, "uint", cToBeHashed, rgpbToBeHashedMarshal, rgpbToBeHashed, rgcbToBeHashedMarshal, rgcbToBeHashed, "ptr", pbComputedHash, pcbComputedHashMarshal, pcbComputedHash, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -42969,7 +42969,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptSignMessageWithKey", "ptr", pSignPara, "ptr", pbToBeSigned, "uint", cbToBeSigned, "ptr", pbSignedBlob, pcbSignedBlobMarshal, pcbSignedBlob, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -43086,7 +43086,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptVerifyMessageSignatureWithKey", "ptr", pVerifyPara, "ptr", pPublicKeyInfo, "ptr", pbSignedBlob, "uint", cbSignedBlob, "ptr", pbDecoded, pcbDecodedMarshal, pcbDecoded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -43259,7 +43259,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertAddEncodedCertificateToSystemStoreA", "ptr", szCertStoreName, "ptr", pbCertEncoded, "uint", cbCertEncoded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -43282,7 +43282,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertAddEncodedCertificateToSystemStoreW", "ptr", szCertStoreName, "ptr", pbCertEncoded, "uint", cbCertEncoded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -43444,7 +43444,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptQueryObject", "uint", dwObjectType, pvObjectMarshal, pvObject, "uint", dwExpectedContentTypeFlags, "uint", dwExpectedFormatTypeFlags, "uint", dwFlags, pdwMsgAndCertEncodingTypeMarshal, pdwMsgAndCertEncodingType, pdwContentTypeMarshal, pdwContentType, pdwFormatTypeMarshal, pdwFormatType, "ptr", phCertStore, phMsgMarshal, phMsg, ppvContextMarshal, ppvContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -44101,7 +44101,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPTNET.dll\CryptGetObjectUrl", "ptr", pszUrlOid, pvParaMarshal, pvPara, "uint", dwFlags, "ptr", pUrlArray, pcbUrlArrayMarshal, pcbUrlArray, "ptr", pUrlInfo, pcbUrlInfoMarshal, pcbUrlInfo, "ptr", pvReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -44220,7 +44220,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptGetKeyIdentifierProperty", "ptr", pKeyIdentifier, "uint", dwPropId, "uint", dwFlags, "ptr", pwszComputerName, "ptr", pvReserved, "ptr", pvData, pcbDataMarshal, pcbData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -44299,7 +44299,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptSetKeyIdentifierProperty", "ptr", pKeyIdentifier, "uint", dwPropId, "uint", dwFlags, "ptr", pwszComputerName, "ptr", pvReserved, pvDataMarshal, pvData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -44353,7 +44353,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptEnumKeyIdentifierProperties", "ptr", pKeyIdentifier, "uint", dwPropId, "uint", dwFlags, "ptr", pwszComputerName, "ptr", pvReserved, pvArgMarshal, pvArg, "ptr", pfnEnum, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -44399,7 +44399,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptCreateKeyIdentifierFromCSP", "uint", dwCertEncodingType, "ptr", pszPubKeyOID, "ptr", pPubKeyStruc, "uint", cbPubKeyStruc, "uint", dwFlags, "ptr", pvReserved, "ptr", pbHash, pcbHashMarshal, pcbHash, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -44423,7 +44423,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertCreateCertificateChainEngine", "ptr", pConfig, "ptr", phChainEngine, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -44458,7 +44458,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertResyncCertificateChainEngine", "ptr", hChainEngine, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -44705,7 +44705,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertGetCertificateChain", "ptr", hChainEngine, "ptr", pCertContext, "ptr", pTime, "ptr", hAdditionalStore, "ptr", pChainPara, "uint", dwFlags, "ptr", pvReserved, ppChainContextMarshal, ppChainContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -45001,7 +45001,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptStringToBinaryA", "ptr", pszString, "uint", cchString, "uint", dwFlags, "ptr", pbBinary, pcbBinaryMarshal, pcbBinary, pdwSkipMarshal, pdwSkip, pdwFlagsMarshal, pdwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -45049,7 +45049,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptStringToBinaryW", "ptr", pszString, "uint", cchString, "uint", dwFlags, "ptr", pbBinary, pcbBinaryMarshal, pcbBinary, pdwSkipMarshal, pdwSkip, pdwFlagsMarshal, pdwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -45256,7 +45256,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\PFXExportCertStoreEx", "ptr", hStore, "ptr", pPFX, "ptr", szPassword, pvParaMarshal, pvPara, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -45317,7 +45317,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\PFXExportCertStore", "ptr", hStore, "ptr", pPFX, "ptr", szPassword, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -45625,7 +45625,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertRetrieveLogoOrBiometricInfo", "ptr", pCertContext, "ptr", lpszLogoOrBiometricType, "uint", dwRetrievalFlags, "uint", dwTimeout, "uint", dwFlags, "ptr", pvReserved, ppbDataMarshal, ppbData, pcbDataMarshal, pcbData, ppwszMimeTypeMarshal, ppwszMimeType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -45765,7 +45765,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CertSelectCertificateChains", "ptr", pSelectionContext, "uint", dwFlags, "ptr", pChainParameters, "uint", cCriteria, "ptr", rgpCriteria, "ptr", hStore, pcSelectionMarshal, pcSelection, pprgpSelectionMarshal, pprgpSelection, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -45867,7 +45867,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptRetrieveTimeStamp", "ptr", wszUrl, "uint", dwRetrievalFlags, "uint", dwTimeout, "ptr", pszHashId, "ptr", pPara, "ptr", pbData, "uint", cbData, ppTsContextMarshal, ppTsContext, ppTsSignerMarshal, ppTsSigner, "ptr", phStore, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -45905,7 +45905,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptVerifyTimeStampSignature", "ptr", pbTSContentInfo, "uint", cbTSContentInfo, "ptr", pbData, "uint", cbData, "ptr", hAdditionalStore, ppTsContextMarshal, ppTsContext, ppTsSignerMarshal, ppTsSigner, "ptr", phStore, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -45995,7 +45995,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptProtectData", "ptr", pDataIn, "ptr", szDataDescr, "ptr", pOptionalEntropy, "ptr", pvReserved, "ptr", pPromptStruct, "uint", dwFlags, "ptr", pDataOut, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -46053,7 +46053,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptUnprotectData", "ptr", pDataIn, ppszDataDescrMarshal, ppszDataDescr, "ptr", pOptionalEntropy, "ptr", pvReserved, "ptr", pPromptStruct, "uint", dwFlags, "ptr", pDataOut, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -46128,7 +46128,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptUpdateProtectedState", "ptr", pOldSid, "ptr", pwszOldPassword, "uint", dwFlags, pdwSuccessCountMarshal, pdwSuccessCount, pdwFailureCountMarshal, pdwFailureCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -46188,7 +46188,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptProtectMemory", pDataInMarshal, pDataIn, "uint", cbDataIn, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -46248,7 +46248,7 @@ class Cryptography {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptUnprotectMemory", pDataInMarshal, pDataIn, "uint", cbDataIn, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Security/Cryptography/Catalog/Apis.ahk
+++ b/Windows/Win32/Security/Cryptography/Catalog/Apis.ahk
@@ -217,7 +217,7 @@ class Catalog {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\CryptCATPersistStore", "ptr", hCatalog, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -838,7 +838,7 @@ class Catalog {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\CryptCATAdminAcquireContext", phCatAdminMarshal, phCatAdmin, "ptr", pgSubsystem, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -911,7 +911,7 @@ class Catalog {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\CryptCATAdminAcquireContext2", phCatAdminMarshal, phCatAdmin, "ptr", pgSubsystem, "ptr", pwszHashAlgorithm, "ptr", pStrongHashPolicy, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1061,7 +1061,7 @@ class Catalog {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\CryptCATAdminCalcHashFromFileHandle2", "ptr", hCatAdmin, "ptr", hFile, pcbHashMarshal, pcbHash, "ptr", pbHash, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1109,7 +1109,7 @@ class Catalog {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\CryptCATAdminRemoveCatalog", "ptr", hCatAdmin, "ptr", pwszCatalogFile, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1130,7 +1130,7 @@ class Catalog {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\CryptCATCatalogInfoFromContext", "ptr", hCatInfo, "ptr", psCatInfo, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1154,7 +1154,7 @@ class Catalog {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\CryptCATAdminResolveCatalogPath", "ptr", hCatAdmin, "ptr", pwszCatalogFile, "ptr", psCatInfo, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Security/Cryptography/Sip/Apis.ahk
+++ b/Windows/Win32/Security/Cryptography/Sip/Apis.ahk
@@ -184,7 +184,7 @@ class Sip {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\CryptSIPGetSignedDataMsg", "ptr", pSubjectInfo, pdwEncodingTypeMarshal, pdwEncodingType, "uint", dwIndex, pcbSignedDataMsgMarshal, pcbSignedDataMsg, pbSignedDataMsgMarshal, pbSignedDataMsg, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -260,7 +260,7 @@ class Sip {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\CryptSIPPutSignedDataMsg", "ptr", pSubjectInfo, "uint", dwEncodingType, pdwIndexMarshal, pdwIndex, "uint", cbSignedDataMsg, pbSignedDataMsgMarshal, pbSignedDataMsg, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -348,7 +348,7 @@ class Sip {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\CryptSIPCreateIndirectData", "ptr", pSubjectInfo, pcbIndirectDataMarshal, pcbIndirectData, "ptr", pIndirectData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -400,7 +400,7 @@ class Sip {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\CryptSIPVerifyIndirectData", "ptr", pSubjectInfo, "ptr", pIndirectData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -420,7 +420,7 @@ class Sip {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\CryptSIPRemoveSignedDataMsg", "ptr", pSubjectInfo, "uint", dwIndex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -441,7 +441,7 @@ class Sip {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptSIPLoad", "ptr", pgSubject, "uint", dwFlags, "ptr", pSipDispatch, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -465,7 +465,7 @@ class Sip {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptSIPRetrieveSubjectGuid", "ptr", FileName, "ptr", hFileIn, "ptr", pgSubject, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -510,7 +510,7 @@ class Sip {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptSIPRetrieveSubjectGuidForCatalogFile", "ptr", FileName, "ptr", hFileIn, "ptr", pgSubject, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -527,7 +527,7 @@ class Sip {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptSIPAddProvider", "ptr", psNewProv, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -544,7 +544,7 @@ class Sip {
         A_LastError := 0
 
         result := DllCall("CRYPT32.dll\CryptSIPRemoveProvider", "ptr", pgProv, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Security/Cryptography/UI/Apis.ahk
+++ b/Windows/Win32/Security/Cryptography/UI/Apis.ahk
@@ -679,7 +679,7 @@ class UI {
         A_LastError := 0
 
         result := DllCall("CRYPTUI.dll\CryptUIDlgViewCertificateW", "ptr", pCertViewInfo, pfPropertiesChangedMarshal, pfPropertiesChanged, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -702,7 +702,7 @@ class UI {
         A_LastError := 0
 
         result := DllCall("CRYPTUI.dll\CryptUIDlgViewCertificateA", "ptr", pCertViewInfo, pfPropertiesChangedMarshal, pfPropertiesChanged, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -733,7 +733,7 @@ class UI {
         A_LastError := 0
 
         result := DllCall("CRYPTUI.dll\CryptUIWizExport", "uint", dwFlags, "ptr", hwndParent, "ptr", pwszWizardTitle, "ptr", pExportInfo, pvoidMarshal, pvoid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -761,7 +761,7 @@ class UI {
         A_LastError := 0
 
         result := DllCall("CRYPTUI.dll\CryptUIWizImport", "uint", dwFlags, "ptr", hwndParent, "ptr", pwszWizardTitle, "ptr", pImportSrc, "ptr", hDestCertStore, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Security/Isolation/Apis.ahk
+++ b/Windows/Win32/Security/Isolation/Apis.ahk
@@ -39,7 +39,7 @@ class Isolation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetAppContainerNamedObjectPath", "ptr", Token, "ptr", AppContainerSid, "uint", ObjectPathLength, "ptr", ObjectPath, ReturnLengthMarshal, ReturnLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Security/WinTrust/Apis.ahk
+++ b/Windows/Win32/Security/WinTrust/Apis.ahk
@@ -1399,7 +1399,7 @@ class WinTrust {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\WintrustAddActionID", "ptr", pgActionID, "uint", fdwFlags, "ptr", psProvInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1526,7 +1526,7 @@ class WinTrust {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\WintrustAddDefaultForUsage", "ptr", pszUsageOID, "ptr", psDefUsage, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1547,7 +1547,7 @@ class WinTrust {
         A_LastError := 0
 
         result := DllCall("WINTRUST.dll\WintrustGetDefaultForUsage", "uint", dwAction, "ptr", pszUsageOID, "ptr", psUsage, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Storage/Compression/Apis.ahk
+++ b/Windows/Win32/Storage/Compression/Apis.ahk
@@ -44,7 +44,7 @@ class Compression {
         A_LastError := 0
 
         result := DllCall("Cabinet.dll\CreateCompressor", "uint", Algorithm, "ptr", AllocationRoutines, "ptr", CompressorHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -66,7 +66,7 @@ class Compression {
         A_LastError := 0
 
         result := DllCall("Cabinet.dll\SetCompressorInformation", "ptr", CompressorHandle, "int", CompressInformationClass, "ptr", CompressInformation, "ptr", CompressInformationSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -88,7 +88,7 @@ class Compression {
         A_LastError := 0
 
         result := DllCall("Cabinet.dll\QueryCompressorInformation", "ptr", CompressorHandle, "int", CompressInformationClass, "ptr", CompressInformation, "ptr", CompressInformationSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -114,7 +114,7 @@ class Compression {
         A_LastError := 0
 
         result := DllCall("Cabinet.dll\Compress", "ptr", CompressorHandle, "ptr", UncompressedData, "ptr", UncompressedDataSize, "ptr", CompressedBuffer, "ptr", CompressedBufferSize, CompressedDataSizeMarshal, CompressedDataSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -133,7 +133,7 @@ class Compression {
         A_LastError := 0
 
         result := DllCall("Cabinet.dll\ResetCompressor", "ptr", CompressorHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -152,7 +152,7 @@ class Compression {
         A_LastError := 0
 
         result := DllCall("Cabinet.dll\CloseCompressor", "ptr", CompressorHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -171,7 +171,7 @@ class Compression {
         A_LastError := 0
 
         result := DllCall("Cabinet.dll\CreateDecompressor", "uint", Algorithm, "ptr", AllocationRoutines, "ptr", DecompressorHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -193,7 +193,7 @@ class Compression {
         A_LastError := 0
 
         result := DllCall("Cabinet.dll\SetDecompressorInformation", "ptr", DecompressorHandle, "int", CompressInformationClass, "ptr", CompressInformation, "ptr", CompressInformationSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -215,7 +215,7 @@ class Compression {
         A_LastError := 0
 
         result := DllCall("Cabinet.dll\QueryDecompressorInformation", "ptr", DecompressorHandle, "int", CompressInformationClass, "ptr", CompressInformation, "ptr", CompressInformationSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -241,7 +241,7 @@ class Compression {
         A_LastError := 0
 
         result := DllCall("Cabinet.dll\Decompress", "ptr", DecompressorHandle, "ptr", CompressedData, "ptr", CompressedDataSize, "ptr", UncompressedBuffer, "ptr", UncompressedBufferSize, UncompressedDataSizeMarshal, UncompressedDataSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -260,7 +260,7 @@ class Compression {
         A_LastError := 0
 
         result := DllCall("Cabinet.dll\ResetDecompressor", "ptr", DecompressorHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -279,7 +279,7 @@ class Compression {
         A_LastError := 0
 
         result := DllCall("Cabinet.dll\CloseDecompressor", "ptr", DecompressorHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/Storage/FileSystem/Apis.ahk
+++ b/Windows/Win32/Storage/FileSystem/Apis.ahk
@@ -1674,7 +1674,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateDirectoryA", "ptr", lpPathName, "ptr", lpSecurityAttributes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1744,7 +1744,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateDirectoryW", "ptr", lpPathName, "ptr", lpSecurityAttributes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2670,7 +2670,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DefineDosDeviceW", "uint", dwFlags, "ptr", lpDeviceName, "ptr", lpTargetPath, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2700,7 +2700,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DeleteFileA", "ptr", lpFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2730,7 +2730,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DeleteFileW", "ptr", lpFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2753,7 +2753,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DeleteVolumeMountPointW", "ptr", lpszVolumeMountPoint, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2773,7 +2773,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FileTimeToLocalFileTime", "ptr", lpFileTime, "ptr", lpLocalFileTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2795,7 +2795,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindClose", "ptr", hFindFile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2818,7 +2818,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindCloseChangeNotification", "ptr", hChangeHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3241,7 +3241,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindNextChangeNotification", "ptr", hChangeHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3273,7 +3273,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindNextFileA", "ptr", hFindFile, "ptr", lpFindFileData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3305,7 +3305,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindNextFileW", "ptr", hFindFile, "ptr", lpFindFileData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3335,7 +3335,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindNextVolumeW", "ptr", hFindVolume, "ptr", lpszVolumeName, "uint", cchBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3358,7 +3358,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindVolumeClose", "ptr", hFindVolume, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3389,7 +3389,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FlushFileBuffers", "ptr", hFile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3431,7 +3431,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetDiskFreeSpaceA", "ptr", lpRootPathName, lpSectorsPerClusterMarshal, lpSectorsPerCluster, lpBytesPerSectorMarshal, lpBytesPerSector, lpNumberOfFreeClustersMarshal, lpNumberOfFreeClusters, lpTotalNumberOfClustersMarshal, lpTotalNumberOfClusters, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3473,7 +3473,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetDiskFreeSpaceW", "ptr", lpRootPathName, lpSectorsPerClusterMarshal, lpSectorsPerCluster, lpBytesPerSectorMarshal, lpBytesPerSector, lpNumberOfFreeClustersMarshal, lpNumberOfFreeClusters, lpTotalNumberOfClustersMarshal, lpTotalNumberOfClusters, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3528,7 +3528,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetDiskFreeSpaceExA", "ptr", lpDirectoryName, lpFreeBytesAvailableToCallerMarshal, lpFreeBytesAvailableToCaller, lpTotalNumberOfBytesMarshal, lpTotalNumberOfBytes, lpTotalNumberOfFreeBytesMarshal, lpTotalNumberOfFreeBytes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3583,7 +3583,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetDiskFreeSpaceExW", "ptr", lpDirectoryName, lpFreeBytesAvailableToCallerMarshal, lpFreeBytesAvailableToCaller, lpTotalNumberOfBytesMarshal, lpTotalNumberOfBytes, lpTotalNumberOfFreeBytesMarshal, lpTotalNumberOfFreeBytes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3960,7 +3960,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetFileAttributesExA", "ptr", lpFileName, "int", fInfoLevelId, lpFileInformationMarshal, lpFileInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4019,7 +4019,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetFileAttributesExW", "ptr", lpFileName, "int", fInfoLevelId, lpFileInformationMarshal, lpFileInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4047,7 +4047,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetFileInformationByHandle", "ptr", hFile, "ptr", lpFileInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4113,7 +4113,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetFileSizeEx", "ptr", hFile, lpFileSizeMarshal, lpFileSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4414,7 +4414,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetFileTime", "ptr", hFile, "ptr", lpCreationTime, "ptr", lpLastAccessTime, "ptr", lpLastWriteTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5084,7 +5084,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetVolumeInformationByHandleW", "ptr", hFile, "ptr", lpVolumeNameBuffer, "uint", nVolumeNameSize, lpVolumeSerialNumberMarshal, lpVolumeSerialNumber, lpMaximumComponentLengthMarshal, lpMaximumComponentLength, lpFileSystemFlagsMarshal, lpFileSystemFlags, "ptr", lpFileSystemNameBuffer, "uint", nFileSystemNameSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5412,7 +5412,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetVolumeInformationW", "ptr", lpRootPathName, "ptr", lpVolumeNameBuffer, "uint", nVolumeNameSize, lpVolumeSerialNumberMarshal, lpVolumeSerialNumber, lpMaximumComponentLengthMarshal, lpMaximumComponentLength, lpFileSystemFlagsMarshal, lpFileSystemFlags, "ptr", lpFileSystemNameBuffer, "uint", nFileSystemNameSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5440,7 +5440,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetVolumePathNameW", "ptr", lpszFileName, "ptr", lpszVolumePathName, "uint", cchBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5464,7 +5464,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\LocalFileTimeToFileTime", "ptr", lpLocalFileTime, "ptr", lpFileTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5491,7 +5491,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\LockFile", "ptr", hFile, "uint", dwFileOffsetLow, "uint", dwFileOffsetHigh, "uint", nNumberOfBytesToLockLow, "uint", nNumberOfBytesToLockHigh, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5521,7 +5521,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\LockFileEx", "ptr", hFile, "uint", dwFlags, "uint", dwReserved, "uint", nNumberOfBytesToLockLow, "uint", nNumberOfBytesToLockHigh, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5640,7 +5640,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadFile", "ptr", hFile, "ptr", lpBuffer, "uint", nNumberOfBytesToRead, lpNumberOfBytesReadMarshal, lpNumberOfBytesRead, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5722,7 +5722,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadFileEx", "ptr", hFile, "ptr", lpBuffer, "uint", nNumberOfBytesToRead, "ptr", lpOverlapped, "ptr", lpCompletionRoutine, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5809,7 +5809,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadFileScatter", "ptr", hFile, "ptr", aSegmentArray, "uint", nNumberOfBytesToRead, "uint*", lpReserved, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5840,7 +5840,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\RemoveDirectoryA", "ptr", lpPathName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5871,7 +5871,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\RemoveDirectoryW", "ptr", lpPathName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5896,7 +5896,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetEndOfFile", "ptr", hFile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6039,7 +6039,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFileAttributesA", "ptr", lpFileName, "uint", dwFileAttributes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6182,7 +6182,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFileAttributesW", "ptr", lpFileName, "uint", dwFileAttributes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6219,7 +6219,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFileInformationByHandle", "ptr", hFile, "int", FileInformationClass, "ptr", lpFileInformation, "uint", dwBufferSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6332,7 +6332,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFilePointerEx", "ptr", hFile, "int64", liDistanceToMove, lpNewFilePointerMarshal, lpNewFilePointer, "uint", dwMoveMethod, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6379,7 +6379,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFileTime", "ptr", hFile, "ptr", lpCreationTime, "ptr", lpLastAccessTime, "ptr", lpLastWriteTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6408,7 +6408,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFileValidData", "ptr", hFile, "int64", ValidDataLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6436,7 +6436,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\UnlockFile", "ptr", hFile, "uint", dwFileOffsetLow, "uint", dwFileOffsetHigh, "uint", nNumberOfBytesToUnlockLow, "uint", nNumberOfBytesToUnlockHigh, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6470,7 +6470,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\UnlockFileEx", "ptr", hFile, "uint", dwReserved, "uint", nNumberOfBytesToUnlockLow, "uint", nNumberOfBytesToUnlockHigh, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6555,7 +6555,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteFile", "ptr", hFile, "ptr", lpBuffer, "uint", nNumberOfBytesToWrite, lpNumberOfBytesWrittenMarshal, lpNumberOfBytesWritten, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6644,7 +6644,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteFileEx", "ptr", hFile, "ptr", lpBuffer, "uint", nNumberOfBytesToWrite, "ptr", lpOverlapped, "ptr", lpCompletionRoutine, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6729,7 +6729,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteFileGather", "ptr", hFile, "ptr", aSegmentArray, "uint", nNumberOfBytesToWrite, "uint*", lpReserved, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6784,7 +6784,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetVolumeNameForVolumeMountPointW", "ptr", lpszVolumeMountPoint, "ptr", lpszVolumeName, "uint", cchBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6821,7 +6821,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetVolumePathNamesForVolumeNameW", "ptr", lpszVolumeName, "ptr", lpszVolumePathNames, "uint", cchBufferLength, lpcchReturnLengthMarshal, lpcchReturnLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6922,7 +6922,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFileIoOverlappedRange", "ptr", FileHandle, OverlappedRangeStartMarshal, OverlappedRangeStart, "uint", Length, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7100,7 +7100,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindNextStreamW", "ptr", hFindStream, lpFindStreamDataMarshal, lpFindStreamData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7214,7 +7214,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindNextFileNameW", "ptr", hFindStream, StringLengthMarshal, StringLength, "ptr", LinkName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7542,7 +7542,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetVolumeInformationA", "ptr", lpRootPathName, "ptr", lpVolumeNameBuffer, "uint", nVolumeNameSize, lpVolumeSerialNumberMarshal, lpVolumeSerialNumber, lpMaximumComponentLengthMarshal, lpMaximumComponentLength, lpFileSystemFlagsMarshal, lpFileSystemFlags, "ptr", lpFileSystemNameBuffer, "uint", nFileSystemNameSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9566,7 +9566,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("VERSION.dll\GetFileVersionInfoA", "ptr", lptstrFilename, "uint", dwHandle, "uint", dwLen, "ptr", lpData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9608,7 +9608,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("VERSION.dll\GetFileVersionInfoW", "ptr", lptstrFilename, "uint", dwHandle, "uint", dwLen, "ptr", lpData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9820,7 +9820,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("VERSION.dll\GetFileVersionInfoExA", "uint", dwFlags, "ptr", lpwstrFilename, "uint", dwHandle, "uint", dwLen, "ptr", lpData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9904,7 +9904,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("VERSION.dll\GetFileVersionInfoExW", "uint", dwFlags, "ptr", lpwstrFilename, "uint", dwHandle, "uint", dwLen, "ptr", lpData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10304,7 +10304,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\DeleteLogByHandle", "ptr", hLog, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10340,7 +10340,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\DeleteLogFile", "ptr", pszLogFileName, pvReservedMarshal, pvReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10383,7 +10383,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\AddLogContainer", "ptr", hLog, pcbContainerMarshal, pcbContainer, "ptr", pwszContainerPath, pReservedMarshal, pReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10429,7 +10429,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\AddLogContainerSet", "ptr", hLog, "ushort", cContainer, pcbContainerMarshal, pcbContainer, rgwszContainerPathMarshal, rgwszContainerPath, pReservedMarshal, pReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10464,7 +10464,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\RemoveLogContainer", "ptr", hLog, "ptr", pwszContainerPath, "int", fForce, pReservedMarshal, pReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10506,7 +10506,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\RemoveLogContainerSet", "ptr", hLog, "ushort", cContainer, rgwszContainerPathMarshal, rgwszContainerPath, "int", fForce, pReservedMarshal, pReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10541,7 +10541,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\SetLogArchiveTail", "ptr", hLog, "ptr", plsnArchiveTail, pReservedMarshal, pReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10570,7 +10570,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\SetEndOfLog", "ptr", hLog, "ptr", plsnEnd, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10597,7 +10597,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\TruncateLog", pvMarshalMarshal, pvMarshal, "ptr", plsnEnd, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10680,7 +10680,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\CreateLogContainerScanContext", "ptr", hLog, "uint", cFromContainer, "uint", cContainers, "char", eScanMode, "ptr", pcxScan, "ptr", pOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10762,7 +10762,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\ScanLogContainers", "ptr", pcxScan, "char", eScanMode, pReservedMarshal, pReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10794,7 +10794,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\AlignReservedLog", pvMarshalMarshal, pvMarshal, "uint", cReservedRecords, rgcbReservationMarshal, rgcbReservation, pcbAlignReservationMarshal, pcbAlignReservation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10824,7 +10824,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\AllocReservedLog", pvMarshalMarshal, pvMarshal, "uint", cReservedRecords, pcbAdjustmentMarshal, pcbAdjustment, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10868,7 +10868,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\FreeReservedLog", pvMarshalMarshal, pvMarshal, "uint", cReservedRecords, pcbAdjustmentMarshal, pcbAdjustment, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10901,7 +10901,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\GetLogFileInformation", "ptr", hLog, "ptr", pinfoBuffer, cbBufferMarshal, cbBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10926,7 +10926,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\SetLogArchiveMode", "ptr", hLog, "int", eMode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10968,7 +10968,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\ReadLogRestartArea", pvMarshalMarshal, pvMarshal, ppvRestartBufferMarshal, ppvRestartBuffer, pcbRestartBufferMarshal, pcbRestartBuffer, "ptr", plsn, ppvContextMarshal, ppvContext, "ptr", pOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11003,7 +11003,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\ReadPreviousLogRestartArea", pvReadContextMarshal, pvReadContext, ppvRestartBufferMarshal, ppvRestartBuffer, pcbRestartBufferMarshal, pcbRestartBuffer, "ptr", plsnRestart, "ptr", pOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11041,7 +11041,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\WriteLogRestartArea", pvMarshalMarshal, pvMarshal, pvRestartBufferMarshal, pvRestartBuffer, "uint", cbRestartBuffer, "ptr", plsnBase, "uint", fFlags, pcbWrittenMarshal, pcbWritten, "ptr", plsnNext, "ptr", pOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11091,7 +11091,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\AdvanceLogBase", pvMarshalMarshal, pvMarshal, "ptr", plsnBase, "uint", fFlags, "ptr", pOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11116,7 +11116,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\CloseAndResetLogFile", "ptr", hLog, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11177,7 +11177,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\CreateLogMarshallingArea", "ptr", hLog, "ptr", pfnAllocBuffer, "ptr", pfnFreeBuffer, pvBlockAllocContextMarshal, pvBlockAllocContext, "uint", cbMarshallingBuffer, "uint", cMaxWriteBuffers, "uint", cMaxReadBuffers, ppvMarshalMarshal, ppvMarshal, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11200,7 +11200,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\DeleteLogMarshallingArea", pvMarshalMarshal, pvMarshal, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11245,7 +11245,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\ReserveAndAppendLog", pvMarshalMarshal, pvMarshal, "ptr", rgWriteEntries, "uint", cWriteEntries, "ptr", plsnUndoNext, "ptr", plsnPrevious, "uint", cReserveRecords, rgcbReservationMarshal, rgcbReservation, "uint", fFlags, "ptr", plsn, "ptr", pOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11291,7 +11291,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\ReserveAndAppendLogAligned", pvMarshalMarshal, pvMarshal, "ptr", rgWriteEntries, "uint", cWriteEntries, "uint", cbEntryAlignment, "ptr", plsnUndoNext, "ptr", plsnPrevious, "uint", cReserveRecords, rgcbReservationMarshal, rgcbReservation, "uint", fFlags, "ptr", plsn, "ptr", pOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11317,7 +11317,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\FlushLogBuffers", pvMarshalMarshal, pvMarshal, "ptr", pOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11349,7 +11349,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\FlushLogToLsn", pvMarshalContextMarshal, pvMarshalContext, "ptr", plsnFlush, "ptr", plsnLastFlushed, "ptr", pOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11439,7 +11439,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\ReadLogRecord", pvMarshalMarshal, pvMarshal, "ptr", plsnFirst, "int", eContextMode, ppvReadBufferMarshal, ppvReadBuffer, pcbReadBufferMarshal, pcbReadBuffer, peRecordTypeMarshal, peRecordType, "ptr", plsnUndoNext, "ptr", plsnPrevious, ppvReadContextMarshal, ppvReadContext, "ptr", pOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11520,7 +11520,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\ReadNextLogRecord", pvReadContextMarshal, pvReadContext, ppvBufferMarshal, ppvBuffer, pcbBufferMarshal, pcbBuffer, peRecordTypeMarshal, peRecordType, "ptr", plsnUser, "ptr", plsnUndoNext, "ptr", plsnPrevious, "ptr", plsnRecord, "ptr", pOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11543,7 +11543,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\TerminateReadLog", pvCursorContextMarshal, pvCursorContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11599,7 +11599,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\PrepareLogArchive", "ptr", hLog, "ptr", pszBaseLogFileName, "uint", cLen, "ptr", plsnLow, "ptr", plsnHigh, pcActualLengthMarshal, pcActualLength, poffBaseLogFileDataMarshal, poffBaseLogFileData, pcbBaseLogFileLengthMarshal, pcbBaseLogFileLength, "ptr", plsnBase, "ptr", plsnLast, "ptr", plsnCurrentArchiveTail, ppvArchiveContextMarshal, ppvArchiveContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11636,7 +11636,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\ReadLogArchiveMetadata", pvArchiveContextMarshal, pvArchiveContext, "uint", cbOffset, "uint", cbBytesToRead, pbReadBufferMarshal, pbReadBuffer, pcbBytesReadMarshal, pcbBytesRead, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11669,7 +11669,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\GetNextLogArchiveExtent", pvArchiveContextMarshal, pvArchiveContext, "ptr", rgadExtent, "uint", cDescriptors, pcDescriptorsReturnedMarshal, pcDescriptorsReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11692,7 +11692,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\TerminateLogArchive", pvArchiveContextMarshal, pvArchiveContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11736,7 +11736,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\ValidateLog", "ptr", pszLogFileName, "ptr", psaLogFile, "ptr", pinfoBuffer, pcbBufferMarshal, pcbBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11776,7 +11776,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\GetLogContainerName", "ptr", hLog, "uint", cidLogicalContainer, "ptr", pwstrContainerName, "uint", cLenContainerName, pcActualLenContainerNameMarshal, pcActualLenContainerName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11812,7 +11812,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\GetLogIoStatistics", "ptr", hLog, pvStatsBufferMarshal, pvStatsBuffer, "uint", cbStatsBuffer, "int", eStatsClass, pcbStatsWrittenMarshal, pcbStatsWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11836,7 +11836,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\RegisterManageableLogClient", "ptr", hLog, "ptr", pCallbacks, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11859,7 +11859,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\DeregisterManageableLogClient", "ptr", hLog, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11883,7 +11883,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\ReadLogNotification", "ptr", hLog, "ptr", pNotification, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11906,7 +11906,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\InstallLogPolicy", "ptr", hLog, "ptr", pPolicy, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11929,7 +11929,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\RemoveLogPolicy", "ptr", hLog, "int", ePolicyType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11956,7 +11956,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\QueryLogPolicy", "ptr", hLog, "int", ePolicyType, "ptr", pPolicyBuffer, pcbPolicyBufferMarshal, pcbPolicyBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11983,7 +11983,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\SetLogFileSizeWithPolicy", "ptr", hLog, pDesiredSizeMarshal, pDesiredSize, pResultingSizeMarshal, pResultingSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12006,7 +12006,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\HandleLogFull", "ptr", hLog, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12031,7 +12031,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\LogTailAdvanceFailure", "ptr", hLog, "uint", dwReason, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12056,7 +12056,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("clfsw32.dll\RegisterForLogWriteNotification", "ptr", hLog, "uint", cbThreshold, "int", fEnable, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12210,7 +12210,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\EncryptionDisable", "ptr", DirPath, "int", Disable, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13287,7 +13287,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("txfw32.dll\TxfLogCreateFileReadContext", "ptr", LogPath, "ptr", BeginningLsn, "ptr", EndingLsn, "ptr", TxfFileId, TxfLogContextMarshal, TxfLogContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13332,7 +13332,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("txfw32.dll\TxfLogDestroyReadContext", TxfLogContextMarshal, TxfLogContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13416,7 +13416,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("txfw32.dll\TxfLogReadRecords", TxfLogContextMarshal, TxfLogContext, "uint", BufferLength, "ptr", Buffer, BytesUsedMarshal, BytesUsed, RecordCountMarshal, RecordCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13595,7 +13595,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\CommitTransaction", "ptr", TransactionHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13621,7 +13621,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\CommitTransactionAsync", "ptr", TransactionHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13642,7 +13642,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\RollbackTransaction", "ptr", TransactionHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13663,7 +13663,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\RollbackTransactionAsync", "ptr", TransactionHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13688,7 +13688,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\GetTransactionId", "ptr", TransactionHandle, "ptr", TransactionId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13724,7 +13724,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\GetTransactionInformation", "ptr", TransactionHandle, OutcomeMarshal, Outcome, IsolationLevelMarshal, IsolationLevel, IsolationFlagsMarshal, IsolationFlags, TimeoutMarshal, Timeout, "uint", BufferLength, "ptr", Description, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13753,7 +13753,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\SetTransactionInformation", "ptr", TransactionHandle, "uint", IsolationLevel, "uint", IsolationFlags, "uint", Timeout, "ptr", Description, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13870,7 +13870,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\RenameTransactionManager", "ptr", LogFileName, "ptr", ExistingTransactionManagerGuid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13898,7 +13898,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\RollforwardTransactionManager", "ptr", TransactionManagerHandle, TmVirtualClockMarshal, TmVirtualClock, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13924,7 +13924,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\RecoverTransactionManager", "ptr", TransactionManagerHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13951,7 +13951,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\GetCurrentClockTransactionManager", "ptr", TransactionManagerHandle, TmVirtualClockMarshal, TmVirtualClock, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13976,7 +13976,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\GetTransactionManagerId", "ptr", TransactionManagerHandle, "ptr", TransactionManagerId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14073,7 +14073,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\RecoverResourceManager", "ptr", ResourceManagerHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14108,7 +14108,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\GetNotificationResourceManager", "ptr", ResourceManagerHandle, "ptr", TransactionNotification, "uint", NotificationLength, "uint", dwMilliseconds, ReturnLengthMarshal, ReturnLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14143,7 +14143,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\GetNotificationResourceManagerAsync", "ptr", ResourceManagerHandle, "ptr", TransactionNotification, "uint", TransactionNotificationLength, ReturnLengthMarshal, ReturnLength, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14169,7 +14169,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\SetResourceManagerCompletionPort", "ptr", ResourceManagerHandle, "ptr", IoCompletionPortHandle, "ptr", CompletionKey, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14279,7 +14279,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\RecoverEnlistment", "ptr", EnlistmentHandle, EnlistmentKeyMarshal, EnlistmentKey, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14308,7 +14308,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\GetEnlistmentRecoveryInformation", "ptr", EnlistmentHandle, "uint", BufferSize, BufferMarshal, Buffer, BufferUsedMarshal, BufferUsed, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14333,7 +14333,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\GetEnlistmentId", "ptr", EnlistmentHandle, "ptr", EnlistmentId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14360,7 +14360,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\SetEnlistmentRecoveryInformation", "ptr", EnlistmentHandle, "uint", BufferSize, BufferMarshal, Buffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14388,7 +14388,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\PrepareEnlistment", "ptr", EnlistmentHandle, TmVirtualClockMarshal, TmVirtualClock, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14416,7 +14416,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\PrePrepareEnlistment", "ptr", EnlistmentHandle, TmVirtualClockMarshal, TmVirtualClock, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14448,7 +14448,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\CommitEnlistment", "ptr", EnlistmentHandle, TmVirtualClockMarshal, TmVirtualClock, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14477,7 +14477,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\RollbackEnlistment", "ptr", EnlistmentHandle, TmVirtualClockMarshal, TmVirtualClock, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14508,7 +14508,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\PrePrepareComplete", "ptr", EnlistmentHandle, TmVirtualClockMarshal, TmVirtualClock, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14539,7 +14539,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\PrepareComplete", "ptr", EnlistmentHandle, TmVirtualClockMarshal, TmVirtualClock, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14570,7 +14570,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\ReadOnlyEnlistment", "ptr", EnlistmentHandle, TmVirtualClockMarshal, TmVirtualClock, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14601,7 +14601,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\CommitComplete", "ptr", EnlistmentHandle, TmVirtualClockMarshal, TmVirtualClock, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14630,7 +14630,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\RollbackComplete", "ptr", EnlistmentHandle, TmVirtualClockMarshal, TmVirtualClock, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14661,7 +14661,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ktmw32.dll\SinglePhaseReject", "ptr", EnlistmentHandle, TmVirtualClockMarshal, TmVirtualClock, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16381,7 +16381,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Wow64DisableWow64FsRedirection", OldValueMarshal, OldValue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16403,7 +16403,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Wow64RevertWow64FsRedirection", OlValueMarshal, OlValue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16520,7 +16520,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetBinaryTypeA", "ptr", lpApplicationName, lpBinaryTypeMarshal, lpBinaryType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16637,7 +16637,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetBinaryTypeW", "ptr", lpApplicationName, lpBinaryTypeMarshal, lpBinaryType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16846,7 +16846,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFileCompletionNotificationModes", "ptr", FileHandle, "char", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16908,7 +16908,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFileShortNameA", "ptr", hFile, "ptr", lpShortName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16970,7 +16970,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFileShortNameW", "ptr", hFile, "ptr", lpShortName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -18889,7 +18889,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\EncryptFileA", "ptr", lpFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -18916,7 +18916,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\EncryptFileW", "ptr", lpFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -18943,7 +18943,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\DecryptFileA", "ptr", lpFileName, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -18970,7 +18970,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\DecryptFileW", "ptr", lpFileName, "uint", dwReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19106,7 +19106,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\FileEncryptionStatusA", "ptr", lpFileName, lpStatusMarshal, lpStatus, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19242,7 +19242,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\FileEncryptionStatusW", "ptr", lpFileName, lpStatusMarshal, lpStatus, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19648,7 +19648,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\BackupRead", "ptr", hFile, "ptr", lpBuffer, "uint", nNumberOfBytesToRead, lpNumberOfBytesReadMarshal, lpNumberOfBytesRead, "int", bAbort, "int", bProcessSecurity, lpContextMarshal, lpContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19683,7 +19683,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\BackupSeek", "ptr", hFile, "uint", dwLowBytesToSeek, "uint", dwHighBytesToSeek, lpdwLowByteSeekedMarshal, lpdwLowByteSeeked, lpdwHighByteSeekedMarshal, lpdwHighByteSeeked, lpContextMarshal, lpContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19744,7 +19744,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\BackupWrite", "ptr", hFile, "ptr", lpBuffer, "uint", nNumberOfBytesToWrite, lpNumberOfBytesWrittenMarshal, lpNumberOfBytesWritten, "int", bAbort, "int", bProcessSecurity, lpContextMarshal, lpContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19855,7 +19855,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetSearchPathMode", "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19938,7 +19938,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateDirectoryExA", "ptr", lpTemplateDirectory, "ptr", lpNewDirectory, "ptr", lpSecurityAttributes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20021,7 +20021,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateDirectoryExW", "ptr", lpTemplateDirectory, "ptr", lpNewDirectory, "ptr", lpSecurityAttributes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20115,7 +20115,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateDirectoryTransactedA", "ptr", lpTemplateDirectory, "ptr", lpNewDirectory, "ptr", lpSecurityAttributes, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20209,7 +20209,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateDirectoryTransactedW", "ptr", lpTemplateDirectory, "ptr", lpNewDirectory, "ptr", lpSecurityAttributes, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20243,7 +20243,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\RemoveDirectoryTransactedA", "ptr", lpPathName, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20277,7 +20277,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\RemoveDirectoryTransactedW", "ptr", lpPathName, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20401,7 +20401,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DefineDosDeviceA", "uint", dwFlags, "ptr", lpDeviceName, "ptr", lpTargetPath, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21458,7 +21458,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFileAttributesTransactedA", "ptr", lpFileName, "uint", dwFileAttributes, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21502,7 +21502,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFileAttributesTransactedW", "ptr", lpFileName, "uint", dwFileAttributes, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21568,7 +21568,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetFileAttributesTransactedA", "ptr", lpFileName, "int", fInfoLevelId, lpFileInformationMarshal, lpFileInformation, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21634,7 +21634,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetFileAttributesTransactedW", "ptr", lpFileName, "int", fInfoLevelId, lpFileInformationMarshal, lpFileInformation, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21749,7 +21749,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DeleteFileTransactedA", "ptr", lpFileName, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21782,7 +21782,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DeleteFileTransactedW", "ptr", lpFileName, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21816,7 +21816,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CheckNameLegalDOS8Dot3A", "ptr", lpName, "ptr", lpOemName, "uint", OemNameSize, pbNameContainsSpacesMarshal, pbNameContainsSpaces, pbNameLegalMarshal, pbNameLegal, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -21850,7 +21850,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CheckNameLegalDOS8Dot3W", "ptr", lpName, "ptr", lpOemName, "uint", OemNameSize, pbNameContainsSpacesMarshal, pbNameContainsSpaces, pbNameLegalMarshal, pbNameLegal, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22046,7 +22046,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CopyFileA", "ptr", lpExistingFileName, "ptr", lpNewFileName, "int", bFailIfExists, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22094,7 +22094,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CopyFileW", "ptr", lpExistingFileName, "ptr", lpNewFileName, "int", bFailIfExists, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22249,7 +22249,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CopyFileExA", "ptr", lpExistingFileName, "ptr", lpNewFileName, "ptr", lpProgressRoutine, lpDataMarshal, lpData, pbCancelMarshal, pbCancel, "uint", dwCopyFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22404,7 +22404,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CopyFileExW", "ptr", lpExistingFileName, "ptr", lpNewFileName, "ptr", lpProgressRoutine, lpDataMarshal, lpData, pbCancelMarshal, pbCancel, "uint", dwCopyFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22534,7 +22534,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CopyFileTransactedA", "ptr", lpExistingFileName, "ptr", lpNewFileName, "ptr", lpProgressRoutine, lpDataMarshal, lpData, pbCancelMarshal, pbCancel, "uint", dwCopyFlags, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22664,7 +22664,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CopyFileTransactedW", "ptr", lpExistingFileName, "ptr", lpNewFileName, "ptr", lpProgressRoutine, lpDataMarshal, lpData, pbCancelMarshal, pbCancel, "uint", dwCopyFlags, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22816,7 +22816,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\MoveFileA", "ptr", lpExistingFileName, "ptr", lpNewFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22857,7 +22857,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\MoveFileW", "ptr", lpExistingFileName, "ptr", lpNewFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22917,7 +22917,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\MoveFileExA", "ptr", lpExistingFileName, "ptr", lpNewFileName, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -22977,7 +22977,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\MoveFileExW", "ptr", lpExistingFileName, "ptr", lpNewFileName, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23058,7 +23058,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\MoveFileWithProgressA", "ptr", lpExistingFileName, "ptr", lpNewFileName, "ptr", lpProgressRoutine, lpDataMarshal, lpData, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23139,7 +23139,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\MoveFileWithProgressW", "ptr", lpExistingFileName, "ptr", lpNewFileName, "ptr", lpProgressRoutine, lpDataMarshal, lpData, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23199,7 +23199,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\MoveFileTransactedA", "ptr", lpExistingFileName, "ptr", lpNewFileName, "ptr", lpProgressRoutine, lpDataMarshal, lpData, "uint", dwFlags, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23259,7 +23259,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\MoveFileTransactedW", "ptr", lpExistingFileName, "ptr", lpNewFileName, "ptr", lpProgressRoutine, lpDataMarshal, lpData, "uint", dwFlags, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23383,7 +23383,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReplaceFileA", "ptr", lpReplacedFileName, "ptr", lpReplacementFileName, "ptr", lpBackupFileName, "uint", dwReplaceFlags, "ptr", lpExclude, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23507,7 +23507,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReplaceFileW", "ptr", lpReplacedFileName, "ptr", lpReplacementFileName, "ptr", lpBackupFileName, "uint", dwReplaceFlags, "ptr", lpExclude, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23552,7 +23552,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateHardLinkA", "ptr", lpFileName, "ptr", lpExistingFileName, "ptr", lpSecurityAttributes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23597,7 +23597,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateHardLinkW", "ptr", lpFileName, "ptr", lpExistingFileName, "ptr", lpSecurityAttributes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23637,7 +23637,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateHardLinkTransactedA", "ptr", lpFileName, "ptr", lpExistingFileName, "ptr", lpSecurityAttributes, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23677,7 +23677,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateHardLinkTransactedW", "ptr", lpFileName, "ptr", lpExistingFileName, "ptr", lpSecurityAttributes, "ptr", hTransaction, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23802,7 +23802,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetVolumeLabelA", "ptr", lpRootPathName, "ptr", lpVolumeName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23831,7 +23831,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetVolumeLabelW", "ptr", lpRootPathName, "ptr", lpVolumeName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23882,7 +23882,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFileBandwidthReservation", "ptr", hFile, "uint", nPeriodMilliseconds, "uint", nBytesPerPeriod, "int", bDiscardable, lpTransferSizeMarshal, lpTransferSize, lpNumOutstandingRequestsMarshal, lpNumOutstandingRequests, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23925,7 +23925,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetFileBandwidthReservation", "ptr", hFile, lpPeriodMillisecondsMarshal, lpPeriodMilliseconds, lpBytesPerPeriodMarshal, lpBytesPerPeriod, pDiscardableMarshal, pDiscardable, lpTransferSizeMarshal, lpTransferSize, lpNumOutstandingRequestsMarshal, lpNumOutstandingRequests, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23976,7 +23976,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadDirectoryChangesW", "ptr", hDirectory, "ptr", lpBuffer, "uint", nBufferLength, "int", bWatchSubtree, "uint", dwNotifyFilter, lpBytesReturnedMarshal, lpBytesReturned, "ptr", lpOverlapped, "ptr", lpCompletionRoutine, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -24032,7 +24032,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadDirectoryChangesExW", "ptr", hDirectory, "ptr", lpBuffer, "uint", nBufferLength, "int", bWatchSubtree, "uint", dwNotifyFilter, lpBytesReturnedMarshal, lpBytesReturned, "ptr", lpOverlapped, "ptr", lpCompletionRoutine, "int", ReadDirectoryNotifyInformationClass, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -24090,7 +24090,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindNextVolumeA", "ptr", hFindVolume, "ptr", lpszVolumeName, "uint", cchBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -24178,7 +24178,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindNextVolumeMountPointA", "ptr", hFindVolumeMountPoint, "ptr", lpszVolumeMountPoint, "uint", cchBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -24208,7 +24208,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindNextVolumeMountPointW", "ptr", hFindVolumeMountPoint, "ptr", lpszVolumeMountPoint, "uint", cchBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -24231,7 +24231,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindVolumeMountPointClose", "ptr", hFindVolumeMountPoint, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -24261,7 +24261,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetVolumeMountPointA", "ptr", lpszVolumeMountPoint, "ptr", lpszVolumeName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -24291,7 +24291,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetVolumeMountPointW", "ptr", lpszVolumeMountPoint, "ptr", lpszVolumeName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -24314,7 +24314,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DeleteVolumeMountPointA", "ptr", lpszVolumeMountPoint, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -24339,7 +24339,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetVolumeNameForVolumeMountPointA", "ptr", lpszVolumeMountPoint, "ptr", lpszVolumeName, "uint", cchBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -24372,7 +24372,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetVolumePathNameA", "ptr", lpszFileName, "ptr", lpszVolumePathName, "uint", cchBufferLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -24409,7 +24409,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetVolumePathNamesForVolumeNameA", "ptr", lpszVolumeName, "ptr", lpszVolumePathNames, "uint", cchBufferLength, lpcchReturnLengthMarshal, lpcchReturnLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -24442,7 +24442,7 @@ class FileSystem {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetFileInformationByHandleEx", "ptr", hFile, "int", FileInformationClass, "ptr", lpFileInformation, "uint", dwBufferSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Antimalware/Apis.ahk
+++ b/Windows/Win32/System/Antimalware/Apis.ahk
@@ -176,7 +176,7 @@ class Antimalware {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\InstallELAMCertificateInfo", "ptr", ELAMFile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/ApplicationInstallationAndServicing/Apis.ahk
+++ b/Windows/Win32/System/ApplicationInstallationAndServicing/Apis.ahk
@@ -28785,7 +28785,7 @@ class ApplicationInstallationAndServicing {
         A_LastError := 0
 
         result := DllCall("sfc.dll\SfcGetNextProtectedFile", "ptr", RpcHandle, "ptr", ProtFileData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -29719,7 +29719,7 @@ class ApplicationInstallationAndServicing {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ZombifyActCtx", "ptr", hActCtx, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -29747,7 +29747,7 @@ class ApplicationInstallationAndServicing {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ActivateActCtx", "ptr", hActCtx, lpCookieMarshal, lpCookie, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -29819,7 +29819,7 @@ class ApplicationInstallationAndServicing {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DeactivateActCtx", "uint", dwFlags, "ptr", ulCookie, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -29842,7 +29842,7 @@ class ApplicationInstallationAndServicing {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetCurrentActCtx", "ptr", lphActCtx, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -29905,7 +29905,7 @@ class ApplicationInstallationAndServicing {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindActCtxSectionStringA", "uint", dwFlags, "ptr", lpExtensionGuid, "uint", ulSectionId, "ptr", lpStringToFind, "ptr", ReturnedData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -29968,7 +29968,7 @@ class ApplicationInstallationAndServicing {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindActCtxSectionStringW", "uint", dwFlags, "ptr", lpExtensionGuid, "uint", ulSectionId, "ptr", lpStringToFind, "ptr", ReturnedData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -30033,7 +30033,7 @@ class ApplicationInstallationAndServicing {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FindActCtxSectionGuid", "uint", dwFlags, "ptr", lpExtensionGuid, "uint", ulSectionId, "ptr", lpGuidToFind, "ptr", ReturnedData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -30242,7 +30242,7 @@ class ApplicationInstallationAndServicing {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryActCtxW", "uint", dwFlags, "ptr", hActCtx, pvSubInstanceMarshal, pvSubInstance, "uint", ulInfoClass, "ptr", pvBuffer, "ptr", cbBuffer, pcbWrittenOrRequiredMarshal, pcbWrittenOrRequired, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -30279,7 +30279,7 @@ class ApplicationInstallationAndServicing {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryActCtxSettingsW", "uint", dwFlags, "ptr", hActCtx, "ptr", settingsNameSpace, "ptr", settingName, "ptr", pvBuffer, "ptr", dwBuffer, pdwWrittenOrRequiredMarshal, pdwWrittenOrRequired, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Console/Apis.ahk
+++ b/Windows/Win32/System/Console/Apis.ahk
@@ -489,7 +489,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\AllocConsole", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -517,7 +517,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FreeConsole", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -533,7 +533,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\AttachConsole", "uint", dwProcessId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -584,7 +584,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetConsoleMode", "ptr", hConsoleHandle, lpModeMarshal, lpMode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -603,7 +603,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleMode", "ptr", hConsoleHandle, "uint", dwMode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -624,7 +624,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNumberOfConsoleInputEvents", "ptr", hConsoleInput, lpNumberOfEventsMarshal, lpNumberOfEvents, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -647,7 +647,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadConsoleInputA", "ptr", hConsoleInput, "ptr", lpBuffer, "uint", nLength, lpNumberOfEventsReadMarshal, lpNumberOfEventsRead, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -670,7 +670,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadConsoleInputW", "ptr", hConsoleInput, "ptr", lpBuffer, "uint", nLength, lpNumberOfEventsReadMarshal, lpNumberOfEventsRead, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -693,7 +693,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\PeekConsoleInputA", "ptr", hConsoleInput, "ptr", lpBuffer, "uint", nLength, lpNumberOfEventsReadMarshal, lpNumberOfEventsRead, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -716,7 +716,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\PeekConsoleInputW", "ptr", hConsoleInput, "ptr", lpBuffer, "uint", nLength, lpNumberOfEventsReadMarshal, lpNumberOfEventsRead, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -741,7 +741,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadConsoleA", "ptr", hConsoleInput, lpBufferMarshal, lpBuffer, "uint", nNumberOfCharsToRead, lpNumberOfCharsReadMarshal, lpNumberOfCharsRead, "ptr", pInputControl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -766,7 +766,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadConsoleW", "ptr", hConsoleInput, lpBufferMarshal, lpBuffer, "uint", nNumberOfCharsToRead, lpNumberOfCharsReadMarshal, lpNumberOfCharsRead, "ptr", pInputControl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -792,7 +792,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteConsoleA", "ptr", hConsoleOutput, "ptr", lpBuffer, "uint", nNumberOfCharsToWrite, lpNumberOfCharsWrittenMarshal, lpNumberOfCharsWritten, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -818,7 +818,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteConsoleW", "ptr", hConsoleOutput, "ptr", lpBuffer, "uint", nNumberOfCharsToWrite, lpNumberOfCharsWrittenMarshal, lpNumberOfCharsWritten, "ptr", lpReserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -835,7 +835,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleCtrlHandler", "ptr", HandlerRoutine, "int", Add, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -924,7 +924,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FillConsoleOutputCharacterA", "ptr", hConsoleOutput, "char", cCharacter, "uint", nLength, "ptr", dwWriteCoord, lpNumberOfCharsWrittenMarshal, lpNumberOfCharsWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -948,7 +948,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FillConsoleOutputCharacterW", "ptr", hConsoleOutput, "char", cCharacter, "uint", nLength, "ptr", dwWriteCoord, lpNumberOfCharsWrittenMarshal, lpNumberOfCharsWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -972,7 +972,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FillConsoleOutputAttribute", "ptr", hConsoleOutput, "ushort", wAttribute, "uint", nLength, "ptr", dwWriteCoord, lpNumberOfAttrsWrittenMarshal, lpNumberOfAttrsWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -989,7 +989,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GenerateConsoleCtrlEvent", "uint", dwCtrlEvent, "uint", dwProcessGroupId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1028,7 +1028,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleActiveScreenBuffer", "ptr", hConsoleOutput, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1046,7 +1046,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FlushConsoleInputBuffer", "ptr", hConsoleInput, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1062,7 +1062,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleCP", "uint", wCodePageID, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1078,7 +1078,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleOutputCP", "uint", wCodePageID, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1097,7 +1097,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetConsoleCursorInfo", "ptr", hConsoleOutput, "ptr", lpConsoleCursorInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1116,7 +1116,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleCursorInfo", "ptr", hConsoleOutput, "ptr", lpConsoleCursorInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1135,7 +1135,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetConsoleScreenBufferInfo", "ptr", hConsoleOutput, "ptr", lpConsoleScreenBufferInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1154,7 +1154,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetConsoleScreenBufferInfoEx", "ptr", hConsoleOutput, "ptr", lpConsoleScreenBufferInfoEx, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1173,7 +1173,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleScreenBufferInfoEx", "ptr", hConsoleOutput, "ptr", lpConsoleScreenBufferInfoEx, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1192,7 +1192,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleScreenBufferSize", "ptr", hConsoleOutput, "ptr", dwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1211,7 +1211,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleCursorPosition", "ptr", hConsoleOutput, "ptr", dwCursorPosition, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1248,7 +1248,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleTextAttribute", "ptr", hConsoleOutput, "ushort", wAttributes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1268,7 +1268,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleWindowInfo", "ptr", hConsoleOutput, "int", bAbsolute, "ptr", lpConsoleWindow, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1293,7 +1293,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteConsoleOutputCharacterA", "ptr", hConsoleOutput, "ptr", lpCharacter, "uint", nLength, "ptr", dwWriteCoord, lpNumberOfCharsWrittenMarshal, lpNumberOfCharsWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1318,7 +1318,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteConsoleOutputCharacterW", "ptr", hConsoleOutput, "ptr", lpCharacter, "uint", nLength, "ptr", dwWriteCoord, lpNumberOfCharsWrittenMarshal, lpNumberOfCharsWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1343,7 +1343,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteConsoleOutputAttribute", "ptr", hConsoleOutput, lpAttributeMarshal, lpAttribute, "uint", nLength, "ptr", dwWriteCoord, lpNumberOfAttrsWrittenMarshal, lpNumberOfAttrsWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1368,7 +1368,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadConsoleOutputCharacterA", "ptr", hConsoleOutput, "ptr", lpCharacter, "uint", nLength, "ptr", dwReadCoord, lpNumberOfCharsReadMarshal, lpNumberOfCharsRead, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1393,7 +1393,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadConsoleOutputCharacterW", "ptr", hConsoleOutput, "ptr", lpCharacter, "uint", nLength, "ptr", dwReadCoord, lpNumberOfCharsReadMarshal, lpNumberOfCharsRead, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1418,7 +1418,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadConsoleOutputAttribute", "ptr", hConsoleOutput, lpAttributeMarshal, lpAttribute, "uint", nLength, "ptr", dwReadCoord, lpNumberOfAttrsReadMarshal, lpNumberOfAttrsRead, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1441,7 +1441,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteConsoleInputA", "ptr", hConsoleInput, "ptr", lpBuffer, "uint", nLength, lpNumberOfEventsWrittenMarshal, lpNumberOfEventsWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1464,7 +1464,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteConsoleInputW", "ptr", hConsoleInput, "ptr", lpBuffer, "uint", nLength, lpNumberOfEventsWrittenMarshal, lpNumberOfEventsWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1486,7 +1486,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ScrollConsoleScreenBufferA", "ptr", hConsoleOutput, "ptr", lpScrollRectangle, "ptr", lpClipRectangle, "ptr", dwDestinationOrigin, "ptr", lpFill, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1508,7 +1508,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ScrollConsoleScreenBufferW", "ptr", hConsoleOutput, "ptr", lpScrollRectangle, "ptr", lpClipRectangle, "ptr", dwDestinationOrigin, "ptr", lpFill, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1530,7 +1530,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteConsoleOutputA", "ptr", hConsoleOutput, "ptr", lpBuffer, "ptr", dwBufferSize, "ptr", dwBufferCoord, "ptr", lpWriteRegion, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1552,7 +1552,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteConsoleOutputW", "ptr", hConsoleOutput, "ptr", lpBuffer, "ptr", dwBufferSize, "ptr", dwBufferCoord, "ptr", lpWriteRegion, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1574,7 +1574,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadConsoleOutputA", "ptr", hConsoleOutput, "ptr", lpBuffer, "ptr", dwBufferSize, "ptr", dwBufferCoord, "ptr", lpReadRegion, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1596,7 +1596,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadConsoleOutputW", "ptr", hConsoleOutput, "ptr", lpBuffer, "ptr", dwBufferSize, "ptr", dwBufferCoord, "ptr", lpReadRegion, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1690,7 +1690,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleTitleA", "ptr", lpConsoleTitle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1708,7 +1708,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleTitleW", "ptr", lpConsoleTitle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1726,7 +1726,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNumberOfConsoleMouseButtons", lpNumberOfMouseButtonsMarshal, lpNumberOfMouseButtons, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1765,7 +1765,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetCurrentConsoleFont", "ptr", hConsoleOutput, "int", bMaximumWindow, "ptr", lpConsoleCurrentFont, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1785,7 +1785,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetCurrentConsoleFontEx", "ptr", hConsoleOutput, "int", bMaximumWindow, "ptr", lpConsoleCurrentFontEx, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1805,7 +1805,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetCurrentConsoleFontEx", "ptr", hConsoleOutput, "int", bMaximumWindow, "ptr", lpConsoleCurrentFontEx, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1821,7 +1821,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetConsoleSelectionInfo", "ptr", lpConsoleSelectionInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1837,7 +1837,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetConsoleHistoryInfo", "ptr", lpConsoleHistoryInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1853,7 +1853,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleHistoryInfo", "ptr", lpConsoleHistoryInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1871,7 +1871,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetConsoleDisplayMode", lpModeFlagsMarshal, lpModeFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1891,7 +1891,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetConsoleDisplayMode", "ptr", hConsoleOutput, "uint", dwFlags, "ptr", lpNewScreenBufferDimensions, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1923,7 +1923,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\AddConsoleAliasA", "ptr", Source, "ptr", Target, "ptr", ExeName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1945,7 +1945,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\AddConsoleAliasW", "ptr", Source, "ptr", Target, "ptr", ExeName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2844,7 +2844,7 @@ class Console {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetStdHandle", "uint", nStdHandle, "ptr", hHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/DataExchange/Apis.ahk
+++ b/Windows/Win32/System/DataExchange/Apis.ahk
@@ -419,7 +419,7 @@ class DataExchange {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DdeSetQualityOfService", "ptr", hwndClient, "ptr", pqosNew, "ptr", pqosPrev, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -449,7 +449,7 @@ class DataExchange {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ImpersonateDdeClientWindow", "ptr", hWndClient, "ptr", hWndServer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -976,7 +976,7 @@ class DataExchange {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DdeImpersonateClient", "ptr", hConv, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1787,7 +1787,7 @@ class DataExchange {
         A_LastError := 0
 
         result := DllCall("USER32.dll\OpenClipboard", "ptr", hWndNewOwner, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1807,7 +1807,7 @@ class DataExchange {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CloseClipboard", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2147,7 +2147,7 @@ class DataExchange {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EmptyClipboard", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2170,7 +2170,7 @@ class DataExchange {
         A_LastError := 0
 
         result := DllCall("USER32.dll\IsClipboardFormatAvailable", "uint", format, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2238,7 +2238,7 @@ class DataExchange {
         A_LastError := 0
 
         result := DllCall("USER32.dll\AddClipboardFormatListener", "ptr", hwnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2261,7 +2261,7 @@ class DataExchange {
         A_LastError := 0
 
         result := DllCall("USER32.dll\RemoveClipboardFormatListener", "ptr", hwnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2291,7 +2291,7 @@ class DataExchange {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetUpdatedClipboardFormats", lpuiFormatsMarshal, lpuiFormats, "uint", cFormats, pcFormatsOutMarshal, pcFormatsOut, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Diagnostics/Debug/Apis.ahk
+++ b/Windows/Win32/System/Diagnostics/Debug/Apis.ahk
@@ -1876,7 +1876,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReadProcessMemory", "ptr", hProcess, lpBaseAddressMarshal, lpBaseAddress, "ptr", lpBuffer, "ptr", nSize, lpNumberOfBytesReadMarshal, lpNumberOfBytesRead, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1905,7 +1905,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteProcessMemory", "ptr", hProcess, lpBaseAddressMarshal, lpBaseAddress, "ptr", lpBuffer, "ptr", nSize, lpNumberOfBytesWrittenMarshal, lpNumberOfBytesWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1930,7 +1930,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetThreadContext", "ptr", hThread, "ptr", lpContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1961,7 +1961,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetThreadContext", "ptr", hThread, "ptr", lpContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1985,7 +1985,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FlushInstructionCache", "ptr", hProcess, "ptr", lpBaseAddress, "ptr", dwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2011,7 +2011,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Wow64GetThreadContext", "ptr", hThread, "ptr", lpContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2035,7 +2035,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Wow64SetThreadContext", "ptr", hThread, "ptr", lpContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2147,7 +2147,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\GetImageConfigInformation", "ptr", LoadedImage, "ptr", ImageConfigInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2171,7 +2171,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\SetImageConfigInformation", "ptr", LoadedImage, "ptr", ImageConfigInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2509,7 +2509,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ContinueDebugEvent", "uint", dwProcessId, "uint", dwThreadId, "int", dwContinueStatus, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2531,7 +2531,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WaitForDebugEvent", "ptr", lpDebugEvent, "uint", dwMilliseconds, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2553,7 +2553,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DebugActiveProcess", "uint", dwProcessId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2573,7 +2573,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DebugActiveProcessStop", "uint", dwProcessId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2597,7 +2597,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CheckRemoteDebuggerPresent", "ptr", hProcess, pbDebuggerPresentMarshal, pbDebuggerPresent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2619,7 +2619,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WaitForDebugEventEx", "ptr", lpDebugEvent, "uint", dwMilliseconds, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2724,7 +2724,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Beep", "uint", dwFreq, "uint", dwDuration, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3134,7 +3134,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetThreadErrorMode", "uint", dwNewMode, lpOldModeMarshal, lpOldMode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3302,7 +3302,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetThreadWaitChain", WctHandleMarshal, WctHandle, "ptr", Context, "uint", Flags, "uint", ThreadId, NodeCountMarshal, NodeCount, "ptr", NodeInfoArray, IsCycleMarshal, IsCycle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3369,7 +3369,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\MiniDumpWriteDump", "ptr", hProcess, "uint", ProcessId, "ptr", hFile, "int", DumpType, "ptr", ExceptionParam, "ptr", UserStreamParam, "ptr", CallbackParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3421,7 +3421,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\BindImage", "ptr", ImageName, "ptr", DllPath, "ptr", SymbolPath, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3450,7 +3450,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\BindImageEx", "uint", Flags, "ptr", ImageName, "ptr", DllPath, "ptr", SymbolPath, "ptr", StatusRoutine, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3490,7 +3490,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\ReBaseImage", "ptr", CurrentImageName, "ptr", SymbolPath, "int", fReBase, "int", fRebaseSysfileOk, "int", fGoingDown, "uint", CheckImageSize, OldImageSizeMarshal, OldImageSize, OldImageBaseMarshal, OldImageBase, NewImageSizeMarshal, NewImageSize, NewImageBaseMarshal, NewImageBase, "uint", TimeStamp, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3530,7 +3530,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\ReBaseImage64", "ptr", CurrentImageName, "ptr", SymbolPath, "int", fReBase, "int", fRebaseSysfileOk, "int", fGoingDown, "uint", CheckImageSize, OldImageSizeMarshal, OldImageSize, OldImageBaseMarshal, OldImageBase, NewImageSizeMarshal, NewImageSize, NewImageBaseMarshal, NewImageBase, "uint", TimeStamp, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3735,7 +3735,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\ImageGetDigestStream", "ptr", FileHandle, "uint", DigestLevel, "ptr", DigestFunction, DigestHandleMarshal, DigestHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3761,7 +3761,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\ImageAddCertificate", "ptr", FileHandle, "ptr", Certificate, IndexMarshal, Index, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3784,7 +3784,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\ImageRemoveCertificate", "ptr", FileHandle, "uint", Index, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3813,7 +3813,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\ImageEnumerateCertificates", "ptr", FileHandle, "ushort", TypeFilter, CertificateCountMarshal, CertificateCount, IndicesMarshal, Indices, "uint", IndexCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3840,7 +3840,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\ImageGetCertificateData", "ptr", FileHandle, "uint", CertificateIndex, "ptr", Certificate, RequiredLengthMarshal, RequiredLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3864,7 +3864,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\ImageGetCertificateHeader", "ptr", FileHandle, "uint", CertificateIndex, "ptr", Certificateheader, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3919,7 +3919,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\ImageUnload", "ptr", LoadedImage, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3948,7 +3948,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\MapAndLoad", "ptr", ImageName, "ptr", DllPath, "ptr", LoadedImage, "int", DotDll, "int", ReadOnly, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3970,7 +3970,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\UnMapAndLoad", "ptr", LoadedImage, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3994,7 +3994,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\TouchFileTimes", "ptr", FileHandle, "ptr", pSystemTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4022,7 +4022,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("imagehlp.dll\UpdateDebugInfoFile", "ptr", ImageFileName, "ptr", SymbolPath, "ptr", DebugFilePath, "ptr", NtHeaders, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4250,7 +4250,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymFindFileInPath", "ptr", hprocess, "ptr", SearchPathA, "ptr", FileName, idMarshal, id, "uint", two, "uint", three, "uint", flags, "ptr", FoundFile, "ptr", callback, contextMarshal, context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4285,7 +4285,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymFindFileInPathW", "ptr", hprocess, "ptr", SearchPathA, "ptr", FileName, idMarshal, id, "uint", two, "uint", three, "uint", flags, "ptr", FoundFile, "ptr", callback, contextMarshal, context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4537,7 +4537,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SearchTreeForFile", "ptr", RootPath, "ptr", InputPathName, "ptr", OutputPathBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4562,7 +4562,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SearchTreeForFileW", "ptr", RootPath, "ptr", InputPathName, "ptr", OutputPathBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4597,7 +4597,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\EnumDirTree", "ptr", hProcess, "ptr", RootPath, "ptr", InputPathName, "ptr", OutputPathBuffer, "ptr", cb, dataMarshal, data, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4632,7 +4632,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\EnumDirTreeW", "ptr", hProcess, "ptr", RootPath, "ptr", InputPathName, "ptr", OutputPathBuffer, "ptr", cb, dataMarshal, data, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4654,7 +4654,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\MakeSureDirectoryPathExists", "ptr", DirPath, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5537,7 +5537,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSetParentWindow", "ptr", hwnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5671,7 +5671,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetOmaps", "ptr", hProcess, "uint", BaseOfDll, OmapToMarshal, OmapTo, cOmapToMarshal, cOmapTo, OmapFromMarshal, OmapFrom, cOmapFromMarshal, cOmapFrom, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6040,7 +6040,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymCleanup", "ptr", hProcess, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6124,7 +6124,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymMatchString", "ptr", string, "ptr", expression, "int", fCase, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6167,7 +6167,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymMatchStringW", "ptr", string, "ptr", expression, "int", fCase, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6201,7 +6201,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumSourceFiles", "ptr", hProcess, "uint", ModBase, "ptr", Mask, "ptr", cbSrcFiles, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6235,7 +6235,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumSourceFilesW", "ptr", hProcess, "uint", ModBase, "ptr", Mask, "ptr", cbSrcFiles, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6262,7 +6262,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumerateModules64", "ptr", hProcess, "ptr", EnumModulesCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6289,7 +6289,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumerateModulesW64", "ptr", hProcess, "ptr", EnumModulesCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6316,7 +6316,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumerateModules", "ptr", hProcess, "ptr", EnumModulesCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6342,7 +6342,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\EnumerateLoadedModulesEx", "ptr", hProcess, "ptr", EnumLoadedModulesCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6368,7 +6368,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\EnumerateLoadedModulesExW", "ptr", hProcess, "ptr", EnumLoadedModulesCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6394,7 +6394,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\EnumerateLoadedModules64", "ptr", hProcess, "ptr", EnumLoadedModulesCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6420,7 +6420,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\EnumerateLoadedModulesW64", "ptr", hProcess, "ptr", EnumLoadedModulesCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6446,7 +6446,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\EnumerateLoadedModules", "ptr", hProcess, "ptr", EnumLoadedModulesCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6553,7 +6553,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetModuleInfo64", "ptr", hProcess, "uint", qwAddr, "ptr", ModuleInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6580,7 +6580,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetModuleInfoW64", "ptr", hProcess, "uint", qwAddr, "ptr", ModuleInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6607,7 +6607,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetModuleInfo", "ptr", hProcess, "uint", dwAddr, "ptr", ModuleInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6634,7 +6634,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetModuleInfoW", "ptr", hProcess, "uint", dwAddr, "ptr", ModuleInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6714,7 +6714,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumLines", "ptr", hProcess, "uint", Base, "ptr", Obj, "ptr", File, "ptr", EnumLinesCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6746,7 +6746,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumLinesW", "ptr", hProcess, "uint", Base, "ptr", Obj, "ptr", File, "ptr", EnumLinesCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6776,7 +6776,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLineFromAddr64", "ptr", hProcess, "uint", qwAddr, pdwDisplacementMarshal, pdwDisplacement, "ptr", Line64, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6806,7 +6806,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLineFromAddrW64", "ptr", hProcess, "uint", dwAddr, pdwDisplacementMarshal, pdwDisplacement, "ptr", Line, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6838,7 +6838,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLineFromInlineContext", "ptr", hProcess, "uint", qwAddr, "uint", InlineContext, "uint", qwModuleBaseAddress, pdwDisplacementMarshal, pdwDisplacement, "ptr", Line64, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6870,7 +6870,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLineFromInlineContextW", "ptr", hProcess, "uint", dwAddr, "uint", InlineContext, "uint", qwModuleBaseAddress, pdwDisplacementMarshal, pdwDisplacement, "ptr", Line, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6905,7 +6905,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumSourceLines", "ptr", hProcess, "uint", Base, "ptr", Obj, "ptr", File, "uint", Line, "uint", Flags, "ptr", EnumLinesCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6940,7 +6940,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumSourceLinesW", "ptr", hProcess, "uint", Base, "ptr", Obj, "ptr", File, "uint", Line, "uint", Flags, "ptr", EnumLinesCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7088,7 +7088,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymQueryInlineTrace", "ptr", hProcess, "uint", StartAddress, "uint", StartContext, "uint", StartRetAddress, "uint", CurAddress, CurContextMarshal, CurContext, CurFrameIndexMarshal, CurFrameIndex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7118,7 +7118,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLineFromAddr", "ptr", hProcess, "uint", dwAddr, pdwDisplacementMarshal, pdwDisplacement, "ptr", Line, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7150,7 +7150,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLineFromName64", "ptr", hProcess, "ptr", ModuleName, "ptr", FileName, "uint", dwLineNumber, plDisplacementMarshal, plDisplacement, "ptr", Line, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7182,7 +7182,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLineFromNameW64", "ptr", hProcess, "ptr", ModuleName, "ptr", FileName, "uint", dwLineNumber, plDisplacementMarshal, plDisplacement, "ptr", Line, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7214,7 +7214,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLineFromName", "ptr", hProcess, "ptr", ModuleName, "ptr", FileName, "uint", dwLineNumber, plDisplacementMarshal, plDisplacement, "ptr", Line, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7238,7 +7238,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLineNext64", "ptr", hProcess, "ptr", Line, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7262,7 +7262,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLineNextW64", "ptr", hProcess, "ptr", Line, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7286,7 +7286,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLineNext", "ptr", hProcess, "ptr", Line, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7310,7 +7310,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLinePrev64", "ptr", hProcess, "ptr", Line, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7334,7 +7334,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLinePrevW64", "ptr", hProcess, "ptr", Line, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7358,7 +7358,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetLinePrev", "ptr", hProcess, "ptr", Line, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7417,7 +7417,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymMatchFileName", "ptr", FileName, "ptr", Match, FileNameStopMarshal, FileNameStop, MatchStopMarshal, MatchStop, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7445,7 +7445,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymMatchFileNameW", "ptr", FileName, "ptr", Match, FileNameStopMarshal, FileNameStop, MatchStopMarshal, MatchStop, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7477,7 +7477,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSourceFile", "ptr", hProcess, "uint", Base, "ptr", Params, "ptr", FileSpec, "ptr", FilePath, "uint", Size, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7509,7 +7509,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSourceFileW", "ptr", hProcess, "uint", Base, "ptr", Params, "ptr", FileSpec, "ptr", FilePath, "uint", Size, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7541,7 +7541,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSourceFileToken", "ptr", hProcess, "uint", Base, "ptr", FileSpec, TokenMarshal, Token, SizeMarshal, Size, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7599,7 +7599,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSourceFileChecksumW", "ptr", hProcess, "uint", Base, "ptr", FileSpec, pCheckSumTypeMarshal, pCheckSumType, pChecksumMarshal, pChecksum, "uint", checksumSize, pActualBytesWrittenMarshal, pActualBytesWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7633,7 +7633,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSourceFileChecksum", "ptr", hProcess, "uint", Base, "ptr", FileSpec, pCheckSumTypeMarshal, pCheckSumType, pChecksumMarshal, pChecksum, "uint", checksumSize, pActualBytesWrittenMarshal, pActualBytesWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7665,7 +7665,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSourceFileTokenW", "ptr", hProcess, "uint", Base, "ptr", FileSpec, TokenMarshal, Token, SizeMarshal, Size, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7721,7 +7721,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSourceFileFromToken", "ptr", hProcess, TokenMarshal, Token, "ptr", Params, "ptr", FilePath, "uint", Size, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7775,7 +7775,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSourceFileFromTokenW", "ptr", hProcess, TokenMarshal, Token, "ptr", Params, "ptr", FilePath, "uint", Size, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7830,7 +7830,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSourceVarFromToken", "ptr", hProcess, TokenMarshal, Token, "ptr", Params, "ptr", VarName, "ptr", Value, "uint", Size, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7863,7 +7863,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSourceVarFromTokenW", "ptr", hProcess, TokenMarshal, Token, "ptr", Params, "ptr", VarName, "ptr", Value, "uint", Size, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7888,7 +7888,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumSourceFileTokens", "ptr", hProcess, "uint", Base, "ptr", Callback, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7928,7 +7928,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymInitialize", "ptr", hProcess, "ptr", UserSearchPath, "int", fInvadeProcess, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7968,7 +7968,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymInitializeW", "ptr", hProcess, "ptr", UserSearchPath, "int", fInvadeProcess, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7993,7 +7993,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSearchPath", "ptr", hProcess, "ptr", SearchPathA, "uint", SearchPathLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8018,7 +8018,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSearchPathW", "ptr", hProcess, "ptr", SearchPathA, "uint", SearchPathLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8042,7 +8042,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSetSearchPath", "ptr", hProcess, "ptr", SearchPathA, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8066,7 +8066,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSetSearchPathW", "ptr", hProcess, "ptr", SearchPathA, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8167,7 +8167,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymUnloadModule64", "ptr", hProcess, "uint", BaseOfDll, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8190,7 +8190,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymUnloadModule", "ptr", hProcess, "uint", BaseOfDll, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8214,7 +8214,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymUnDName64", "ptr", sym, "ptr", UnDecName, "uint", UnDecNameLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8238,7 +8238,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymUnDName", "ptr", sym, "ptr", UnDecName, "uint", UnDecNameLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8262,7 +8262,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymRegisterCallback64", "ptr", hProcess, "ptr", CallbackFunction, "uint", UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8286,7 +8286,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymRegisterCallbackW64", "ptr", hProcess, "ptr", CallbackFunction, "uint", UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8310,7 +8310,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymRegisterFunctionEntryCallback64", "ptr", hProcess, "ptr", CallbackFunction, "uint", UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8336,7 +8336,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymRegisterCallback", "ptr", hProcess, "ptr", CallbackFunction, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8362,7 +8362,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymRegisterFunctionEntryCallback", "ptr", hProcess, "ptr", CallbackFunction, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8389,7 +8389,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSetContext", "ptr", hProcess, "ptr", StackFrame, ContextMarshal, Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8413,7 +8413,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSetScopeFromAddr", "ptr", hProcess, "uint", Address, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8437,7 +8437,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSetScopeFromInlineContext", "ptr", hProcess, "uint", Address, "uint", InlineContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8461,7 +8461,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSetScopeFromIndex", "ptr", hProcess, "uint", BaseOfDll, "uint", Index, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8484,7 +8484,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumProcesses", "ptr", EnumProcessesCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8513,7 +8513,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymFromAddr", "ptr", hProcess, "uint", Address, DisplacementMarshal, Displacement, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8542,7 +8542,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymFromAddrW", "ptr", hProcess, "uint", Address, DisplacementMarshal, Displacement, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8575,7 +8575,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymFromInlineContext", "ptr", hProcess, "uint", Address, "uint", InlineContext, DisplacementMarshal, Displacement, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8608,7 +8608,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymFromInlineContextW", "ptr", hProcess, "uint", Address, "uint", InlineContext, DisplacementMarshal, Displacement, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8634,7 +8634,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymFromToken", "ptr", hProcess, "uint", Base, "uint", Token, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8660,7 +8660,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymFromTokenW", "ptr", hProcess, "uint", Base, "uint", Token, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8685,7 +8685,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymNext", "ptr", hProcess, "ptr", si, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8710,7 +8710,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymNextW", "ptr", hProcess, "ptr", siw, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8735,7 +8735,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymPrev", "ptr", hProcess, "ptr", si, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8760,7 +8760,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymPrevW", "ptr", hProcess, "ptr", siw, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8786,7 +8786,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymFromName", "ptr", hProcess, "ptr", Name, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8812,7 +8812,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymFromNameW", "ptr", hProcess, "ptr", Name, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8918,7 +8918,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumSymbols", "ptr", hProcess, "uint", BaseOfDll, "ptr", Mask, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9056,7 +9056,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumSymbolsEx", "ptr", hProcess, "uint", BaseOfDll, "ptr", Mask, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "uint", Options, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9162,7 +9162,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumSymbolsW", "ptr", hProcess, "uint", BaseOfDll, "ptr", Mask, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9300,7 +9300,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumSymbolsExW", "ptr", hProcess, "uint", BaseOfDll, "ptr", Mask, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "uint", Options, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9328,7 +9328,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumSymbolsForAddr", "ptr", hProcess, "uint", Address, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9356,7 +9356,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumSymbolsForAddrW", "ptr", hProcess, "uint", Address, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9445,7 +9445,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSearch", "ptr", hProcess, "uint", BaseOfDll, "uint", Index, "uint", SymTag, "ptr", Mask, "uint", Address, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "uint", Options, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9534,7 +9534,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSearchW", "ptr", hProcess, "uint", BaseOfDll, "uint", Index, "uint", SymTag, "ptr", Mask, "uint", Address, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "uint", Options, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9561,7 +9561,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetScope", "ptr", hProcess, "uint", BaseOfDll, "uint", Index, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9588,7 +9588,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetScopeW", "ptr", hProcess, "uint", BaseOfDll, "uint", Index, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9615,7 +9615,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymFromIndex", "ptr", hProcess, "uint", BaseOfDll, "uint", Index, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9642,7 +9642,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymFromIndexW", "ptr", hProcess, "uint", BaseOfDll, "uint", Index, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9671,7 +9671,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetTypeInfo", "ptr", hProcess, "uint", ModBase, "uint", TypeId, "int", GetType, pInfoMarshal, pInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9695,7 +9695,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetTypeInfoEx", "ptr", hProcess, "uint", ModBase, "ptr", Params, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9723,7 +9723,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumTypes", "ptr", hProcess, "uint", BaseOfDll, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9751,7 +9751,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumTypesW", "ptr", hProcess, "uint", BaseOfDll, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9781,7 +9781,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumTypesByName", "ptr", hProcess, "uint", BaseOfDll, "ptr", mask, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9811,7 +9811,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumTypesByNameW", "ptr", hProcess, "uint", BaseOfDll, "ptr", mask, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9838,7 +9838,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetTypeFromName", "ptr", hProcess, "uint", BaseOfDll, "ptr", Name, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9865,7 +9865,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetTypeFromNameW", "ptr", hProcess, "uint", BaseOfDll, "ptr", Name, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9893,7 +9893,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymAddSymbol", "ptr", hProcess, "uint", BaseOfDll, "ptr", Name, "uint", Address, "uint", Size, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9921,7 +9921,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymAddSymbolW", "ptr", hProcess, "uint", BaseOfDll, "ptr", Name, "uint", Address, "uint", Size, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9948,7 +9948,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymDeleteSymbol", "ptr", hProcess, "uint", BaseOfDll, "ptr", Name, "uint", Address, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9975,7 +9975,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymDeleteSymbolW", "ptr", hProcess, "uint", BaseOfDll, "ptr", Name, "uint", Address, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9998,7 +9998,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymRefreshModuleList", "ptr", hProcess, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10025,7 +10025,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymAddSourceStream", "ptr", hProcess, "uint", Base, "ptr", StreamFile, "ptr", Buffer, "ptr", Size, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10073,7 +10073,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymAddSourceStreamW", "ptr", hProcess, "uint", Base, "ptr", FileSpec, "ptr", Buffer, "ptr", Size, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10094,7 +10094,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSrvIsStoreW", "ptr", hProcess, "ptr", path, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10115,7 +10115,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSrvIsStore", "ptr", hProcess, "ptr", path, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10267,7 +10267,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSrvGetFileIndexes", "ptr", File, "ptr", Id, Val1Marshal, Val1, Val2Marshal, Val2, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10295,7 +10295,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSrvGetFileIndexesW", "ptr", File, "ptr", Id, Val1Marshal, Val1, Val2Marshal, Val2, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10328,7 +10328,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSrvGetFileIndexStringW", "ptr", hProcess, "ptr", SrvPath, "ptr", File, "ptr", Index, "ptr", Size, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10361,7 +10361,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSrvGetFileIndexString", "ptr", hProcess, "ptr", SrvPath, "ptr", File, "ptr", Index, "ptr", Size, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10385,7 +10385,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSrvGetFileIndexInfo", "ptr", File, "ptr", Info, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10409,7 +10409,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymSrvGetFileIndexInfoW", "ptr", File, "ptr", Info, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10559,7 +10559,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSymbolFile", "ptr", hProcess, "ptr", SymPath, "ptr", ImageFile, "uint", Type, "ptr", SymbolFile, "ptr", cSymbolFile, "ptr", DbgFile, "ptr", cDbgFile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10593,7 +10593,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSymbolFileW", "ptr", hProcess, "ptr", SymPath, "ptr", ImageFile, "uint", Type, "ptr", SymbolFile, "ptr", cSymbolFile, "ptr", DbgFile, "ptr", cDbgFile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10653,7 +10653,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSymFromAddr64", "ptr", hProcess, "uint", qwAddr, pdwDisplacementMarshal, pdwDisplacement, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10681,7 +10681,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSymFromAddr", "ptr", hProcess, "uint", dwAddr, pdwDisplacementMarshal, pdwDisplacement, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10707,7 +10707,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSymFromName64", "ptr", hProcess, "ptr", Name, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10733,7 +10733,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSymFromName", "ptr", hProcess, "ptr", Name, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10827,7 +10827,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumerateSymbols64", "ptr", hProcess, "uint", BaseOfDll, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10856,7 +10856,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumerateSymbolsW64", "ptr", hProcess, "uint", BaseOfDll, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10885,7 +10885,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumerateSymbols", "ptr", hProcess, "uint", BaseOfDll, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10914,7 +10914,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymEnumerateSymbolsW", "ptr", hProcess, "uint", BaseOfDll, "ptr", EnumSymbolsCallback, UserContextMarshal, UserContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11010,7 +11010,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSymNext64", "ptr", hProcess, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11034,7 +11034,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSymNext", "ptr", hProcess, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11058,7 +11058,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSymPrev64", "ptr", hProcess, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11082,7 +11082,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("dbghelp.dll\SymGetSymPrev", "ptr", hProcess, "ptr", Symbol, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11247,7 +11247,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("USER32.dll\MessageBeep", "uint", uType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11284,7 +11284,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetThreadSelectorEntry", "ptr", hThread, "uint", dwSelector, "ptr", lpSelectorEntry, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11312,7 +11312,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Wow64GetThreadSelectorEntry", "ptr", hThread, "uint", dwSelector, "ptr", lpSelectorEntry, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11332,7 +11332,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DebugSetProcessKillOnExit", "int", KillOnExit, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11354,7 +11354,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DebugBreakProcess", "ptr", Process, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11622,7 +11622,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CopyContext", "ptr", Destination, "uint", ContextFlags, "ptr", Source, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11671,7 +11671,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\InitializeContext", "ptr", Buffer, "uint", ContextFlags, ContextMarshal, Context, ContextLengthMarshal, ContextLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11721,7 +11721,7 @@ class Debug {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\InitializeContext2", "ptr", Buffer, "uint", ContextFlags, ContextMarshal, Context, ContextLengthMarshal, ContextLength, "uint", XStateCompactionMask, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Diagnostics/ToolHelp/Apis.ahk
+++ b/Windows/Win32/System/Diagnostics/ToolHelp/Apis.ahk
@@ -69,7 +69,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Heap32ListFirst", "ptr", hSnapshot, "ptr", lphl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -92,7 +92,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Heap32ListNext", "ptr", hSnapshot, "ptr", lphl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -113,7 +113,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Heap32First", "ptr", lphe, "uint", th32ProcessID, "ptr", th32HeapID, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -133,7 +133,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Heap32Next", "ptr", lphe, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -176,7 +176,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Process32FirstW", "ptr", hSnapshot, "ptr", lppe, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -199,7 +199,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Process32NextW", "ptr", hSnapshot, "ptr", lppe, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -222,7 +222,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Process32First", "ptr", hSnapshot, "ptr", lppe, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -245,7 +245,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Process32Next", "ptr", hSnapshot, "ptr", lppe, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -268,7 +268,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Thread32First", "ptr", hSnapshot, "ptr", lpte, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -291,7 +291,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Thread32Next", "ptr", hSnapshot, "ptr", lpte, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -314,7 +314,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Module32FirstW", "ptr", hSnapshot, "ptr", lpme, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -337,7 +337,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Module32NextW", "ptr", hSnapshot, "ptr", lpme, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -360,7 +360,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Module32First", "ptr", hSnapshot, "ptr", lpme, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -383,7 +383,7 @@ class ToolHelp {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\Module32Next", "ptr", hSnapshot, "ptr", lpme, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Environment/Apis.ahk
+++ b/Windows/Win32/System/Environment/Apis.ahk
@@ -178,7 +178,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FreeEnvironmentStringsA", "ptr", penv, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -201,7 +201,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FreeEnvironmentStringsW", "ptr", penv, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -286,7 +286,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetEnvironmentVariableA", "ptr", lpName, "ptr", lpValue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -316,7 +316,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetEnvironmentVariableW", "ptr", lpName, "ptr", lpValue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -499,7 +499,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\CreateEnvironmentBlock", lpEnvironmentMarshal, lpEnvironment, "ptr", hToken, "int", bInherit, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -523,7 +523,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\DestroyEnvironmentBlock", lpEnvironmentMarshal, lpEnvironment, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -561,7 +561,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\ExpandEnvironmentStringsForUserA", "ptr", hToken, "ptr", lpSrc, "ptr", lpDest, "uint", dwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -599,7 +599,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\ExpandEnvironmentStringsForUserW", "ptr", hToken, "ptr", lpSrc, "ptr", lpDest, "uint", dwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -665,7 +665,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\IsEnclaveTypeSupported", "uint", flEnclaveType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -841,7 +841,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\LoadEnclaveData", "ptr", hProcess, lpAddressMarshal, lpAddress, "ptr", lpBuffer, "ptr", nSize, "uint", flProtect, "ptr", lpPageInformation, "uint", dwInfoLength, lpNumberOfBytesWrittenMarshal, lpNumberOfBytesWritten, lpEnclaveErrorMarshal, lpEnclaveError, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -919,7 +919,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\InitializeEnclave", "ptr", hProcess, lpAddressMarshal, lpAddress, "ptr", lpEnclaveInformation, "uint", dwInfoLength, lpEnclaveErrorMarshal, lpEnclaveError, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -960,7 +960,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("api-ms-win-core-enclave-l1-1-1.dll\LoadEnclaveImageW", lpEnclaveAddressMarshal, lpEnclaveAddress, "ptr", lpImageName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -988,7 +988,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("vertdll.dll\CallEnclave", "ptr", lpRoutine, lpParameterMarshal, lpParameter, "int", fWaitForThread, lpReturnValueMarshal, lpReturnValue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1009,7 +1009,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("vertdll.dll\TerminateEnclave", lpAddressMarshal, lpAddress, "int", fWait, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1049,7 +1049,7 @@ class Environment {
         A_LastError := 0
 
         result := DllCall("api-ms-win-core-enclave-l1-1-1.dll\DeleteEnclave", lpAddressMarshal, lpAddress, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/ErrorReporting/Apis.ahk
+++ b/Windows/Win32/System/ErrorReporting/Apis.ahk
@@ -1564,7 +1564,7 @@ class ErrorReporting {
         A_LastError := 0
 
         result := DllCall("faultrep.dll\AddERExcludedApplicationA", "ptr", szApplication, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1585,7 +1585,7 @@ class ErrorReporting {
         A_LastError := 0
 
         result := DllCall("faultrep.dll\AddERExcludedApplicationW", "ptr", wszApplication, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/EventLog/Apis.ahk
+++ b/Windows/Win32/System/EventLog/Apis.ahk
@@ -107,7 +107,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtClose", "ptr", Object, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -183,7 +183,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtCancel", "ptr", Object, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -281,7 +281,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtNext", "ptr", ResultSet, "uint", EventsSize, EventsMarshal, Events, "uint", Timeout, "uint", Flags, ReturnedMarshal, Returned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -335,7 +335,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtSeek", "ptr", ResultSet, "int64", Position, "ptr", Bookmark, "uint", Timeout, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -454,7 +454,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtRender", "ptr", Context, "ptr", Fragment, "uint", Flags, "uint", BufferSize, "ptr", Buffer, BufferUsedMarshal, BufferUsed, PropertyCountMarshal, PropertyCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -518,7 +518,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtFormatMessage", "ptr", PublisherMetadata, "ptr", Event, "uint", MessageId, "uint", ValueCount, "ptr", Values, "uint", Flags, "uint", BufferSize, "ptr", Buffer, BufferUsedMarshal, BufferUsed, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -594,7 +594,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtGetLogInfo", "ptr", Log, "int", PropertyId, "uint", PropertyValueBufferSize, "ptr", PropertyValueBuffer, PropertyValueBufferUsedMarshal, PropertyValueBufferUsed, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -647,7 +647,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtClearLog", "ptr", Session, "ptr", ChannelPath, "ptr", TargetFilePath, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -702,7 +702,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtExportLog", "ptr", Session, "ptr", Path, "ptr", Query, "ptr", TargetFilePath, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -754,7 +754,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtArchiveExportedLog", "ptr", Session, "ptr", LogFilePath, "uint", Locale, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -828,7 +828,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtNextChannelPath", "ptr", ChannelEnum, "uint", ChannelPathBufferSize, "ptr", ChannelPathBuffer, ChannelPathBufferUsedMarshal, ChannelPathBufferUsed, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -899,7 +899,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtSaveChannelConfig", "ptr", ChannelConfig, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -952,7 +952,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtSetChannelConfigProperty", "ptr", ChannelConfig, "int", PropertyId, "uint", Flags, "ptr", PropertyValue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1007,7 +1007,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtGetChannelConfigProperty", "ptr", ChannelConfig, "int", PropertyId, "uint", Flags, "uint", PropertyValueBufferSize, "ptr", PropertyValueBuffer, PropertyValueBufferUsedMarshal, PropertyValueBufferUsed, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1081,7 +1081,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtNextPublisherId", "ptr", PublisherEnum, "uint", PublisherIdBufferSize, "ptr", PublisherIdBuffer, PublisherIdBufferUsedMarshal, PublisherIdBufferUsed, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1161,7 +1161,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtGetPublisherMetadataProperty", "ptr", PublisherMetadata, "int", PropertyId, "uint", Flags, "uint", PublisherMetadataPropertyBufferSize, "ptr", PublisherMetadataPropertyBuffer, PublisherMetadataPropertyBufferUsedMarshal, PublisherMetadataPropertyBufferUsed, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1256,7 +1256,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtGetEventMetadataProperty", "ptr", EventMetadata, "int", PropertyId, "uint", Flags, "uint", EventMetadataPropertyBufferSize, "ptr", EventMetadataPropertyBuffer, EventMetadataPropertyBufferUsedMarshal, EventMetadataPropertyBufferUsed, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1305,7 +1305,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtGetObjectArraySize", "ptr", ObjectArray, ObjectArraySizeMarshal, ObjectArraySize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1359,7 +1359,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtGetObjectArrayProperty", "ptr", ObjectArray, "uint", PropertyId, "uint", ArrayIndex, "uint", Flags, "uint", PropertyValueBufferSize, "ptr", PropertyValueBuffer, PropertyValueBufferUsedMarshal, PropertyValueBufferUsed, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1413,7 +1413,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtGetQueryInfo", "ptr", QueryOrSubscription, "int", PropertyId, "uint", PropertyValueBufferSize, "ptr", PropertyValueBuffer, PropertyValueBufferUsedMarshal, PropertyValueBufferUsed, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1482,7 +1482,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtUpdateBookmark", "ptr", Bookmark, "ptr", Event, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1536,7 +1536,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("wevtapi.dll\EvtGetEventInfo", "ptr", Event, "int", PropertyId, "uint", PropertyValueBufferSize, "ptr", PropertyValueBuffer, PropertyValueBufferUsedMarshal, PropertyValueBufferUsed, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1566,7 +1566,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ClearEventLogA", "ptr", hEventLog, "ptr", lpBackupFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1596,7 +1596,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ClearEventLogW", "ptr", hEventLog, "ptr", lpBackupFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1621,7 +1621,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\BackupEventLogA", "ptr", hEventLog, "ptr", lpBackupFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1646,7 +1646,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\BackupEventLogW", "ptr", hEventLog, "ptr", lpBackupFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1671,7 +1671,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CloseEventLog", "ptr", hEventLog, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1695,7 +1695,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\DeregisterEventSource", "ptr", hEventLog, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1722,7 +1722,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\NotifyChangeEventLog", "ptr", hEventLog, "ptr", hEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1750,7 +1750,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetNumberOfEventLogRecords", "ptr", hEventLog, NumberOfRecordsMarshal, NumberOfRecords, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1778,7 +1778,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetOldestEventLogRecord", "ptr", hEventLog, OldestRecordMarshal, OldestRecord, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1983,7 +1983,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ReadEventLogA", "ptr", hEventLog, "uint", dwReadFlags, "uint", dwRecordOffset, "ptr", lpBuffer, "uint", nNumberOfBytesToRead, pnBytesReadMarshal, pnBytesRead, pnMinNumberOfBytesNeededMarshal, pnMinNumberOfBytesNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2022,7 +2022,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ReadEventLogW", "ptr", hEventLog, "uint", dwReadFlags, "uint", dwRecordOffset, "ptr", lpBuffer, "uint", nNumberOfBytesToRead, pnBytesReadMarshal, pnBytesRead, pnMinNumberOfBytesNeededMarshal, pnMinNumberOfBytesNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2130,7 +2130,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ReportEventA", "ptr", hEventLog, "ushort", wType, "ushort", wCategory, "uint", dwEventID, "ptr", lpUserSid, "ushort", wNumStrings, "uint", dwDataSize, lpStringsMarshal, lpStrings, "ptr", lpRawData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2238,7 +2238,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ReportEventW", "ptr", hEventLog, "ushort", wType, "ushort", wCategory, "uint", dwEventID, "ptr", lpUserSid, "ushort", wNumStrings, "uint", dwDataSize, lpStringsMarshal, lpStrings, "ptr", lpRawData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2291,7 +2291,7 @@ class EventLog {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetEventLogInformation", "ptr", hEventLog, "uint", dwInfoLevel, "ptr", lpBuffer, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/EventNotificationService/Apis.ahk
+++ b/Windows/Win32/System/EventNotificationService/Apis.ahk
@@ -126,7 +126,7 @@ class EventNotificationService {
         A_LastError := 0
 
         result := DllCall("SensApi.dll\IsDestinationReachableA", "ptr", lpszDestination, "ptr", lpQOCInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -186,7 +186,7 @@ class EventNotificationService {
         A_LastError := 0
 
         result := DllCall("SensApi.dll\IsDestinationReachableW", "ptr", lpszDestination, "ptr", lpQOCInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -236,7 +236,7 @@ class EventNotificationService {
         A_LastError := 0
 
         result := DllCall("SensApi.dll\IsNetworkAlive", lpdwFlagsMarshal, lpdwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/GroupPolicy/Apis.ahk
+++ b/Windows/Win32/System/GroupPolicy/Apis.ahk
@@ -532,7 +532,7 @@ class GroupPolicy {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\RefreshPolicy", "int", bMachine, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -553,7 +553,7 @@ class GroupPolicy {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\RefreshPolicyEx", "int", bMachine, "uint", dwOptions, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -596,7 +596,7 @@ class GroupPolicy {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\LeaveCriticalPolicySection", "ptr", hSection, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -620,7 +620,7 @@ class GroupPolicy {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\RegisterGPNotification", "ptr", hEvent, "int", bMachine, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -643,7 +643,7 @@ class GroupPolicy {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\UnregisterGPNotification", "ptr", hEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -691,7 +691,7 @@ class GroupPolicy {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\GetGPOListA", "ptr", hToken, "ptr", lpName, "ptr", lpHostName, "ptr", lpComputerName, "uint", dwFlags, pGPOListMarshal, pGPOList, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -739,7 +739,7 @@ class GroupPolicy {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\GetGPOListW", "ptr", hToken, "ptr", lpName, "ptr", lpHostName, "ptr", lpComputerName, "uint", dwFlags, pGPOListMarshal, pGPOList, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -762,7 +762,7 @@ class GroupPolicy {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\FreeGPOListA", "ptr", pGPOList, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -785,7 +785,7 @@ class GroupPolicy {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\FreeGPOListW", "ptr", pGPOList, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/IO/Apis.ahk
+++ b/Windows/Win32/System/IO/Apis.ahk
@@ -99,7 +99,7 @@ class IO {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetQueuedCompletionStatus", "ptr", CompletionPort, lpNumberOfBytesTransferredMarshal, lpNumberOfBytesTransferred, lpCompletionKeyMarshal, lpCompletionKey, lpOverlappedMarshal, lpOverlapped, "uint", dwMilliseconds, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -154,7 +154,7 @@ class IO {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetQueuedCompletionStatusEx", "ptr", CompletionPort, "ptr", lpCompletionPortEntries, "uint", ulCount, ulNumEntriesRemovedMarshal, ulNumEntriesRemoved, "uint", dwMilliseconds, "int", fAlertable, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -182,7 +182,7 @@ class IO {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\PostQueuedCompletionStatus", "ptr", CompletionPort, "uint", dwNumberOfBytesTransferred, "ptr", dwCompletionKey, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -271,7 +271,7 @@ class IO {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DeviceIoControl", "ptr", hDevice, "uint", dwIoControlCode, "ptr", lpInBuffer, "uint", nInBufferSize, "ptr", lpOutBuffer, "uint", nOutBufferSize, lpBytesReturnedMarshal, lpBytesReturned, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -314,7 +314,7 @@ class IO {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetOverlappedResult", "ptr", hFile, "ptr", lpOverlapped, lpNumberOfBytesTransferredMarshal, lpNumberOfBytesTransferred, "int", bWait, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -356,7 +356,7 @@ class IO {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CancelIoEx", "ptr", hFile, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -380,7 +380,7 @@ class IO {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CancelIo", "ptr", hFile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -435,7 +435,7 @@ class IO {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetOverlappedResultEx", "ptr", hFile, "ptr", lpOverlapped, lpNumberOfBytesTransferredMarshal, lpNumberOfBytesTransferred, "uint", dwMilliseconds, "int", bAlertable, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -461,7 +461,7 @@ class IO {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CancelSynchronousIo", "ptr", hThread, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -490,7 +490,7 @@ class IO {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\BindIoCompletionCallback", "ptr", FileHandle, "ptr", Function, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/JobObjects/Apis.ahk
+++ b/Windows/Win32/System/JobObjects/Apis.ahk
@@ -37,7 +37,7 @@ class JobObjects {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\IsProcessInJob", "ptr", ProcessHandle, "ptr", JobHandle, ResultMarshal, Result, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -151,7 +151,7 @@ class JobObjects {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\AssignProcessToJobObject", "ptr", hJob, "ptr", hProcess, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -182,7 +182,7 @@ class JobObjects {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\TerminateJobObject", "ptr", hJob, "uint", uExitCode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -211,7 +211,7 @@ class JobObjects {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetInformationJobObject", "ptr", hJob, "int", JobObjectInformationClass, "ptr", lpJobObjectInformation, "uint", cbJobObjectInformationLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -270,7 +270,7 @@ class JobObjects {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryInformationJobObject", "ptr", hJob, "int", JobObjectInformationClass, "ptr", lpJobObjectInformation, "uint", cbJobObjectInformationLength, lpReturnLengthMarshal, lpReturnLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -328,7 +328,7 @@ class JobObjects {
         A_LastError := 0
 
         result := DllCall("USER32.dll\UserHandleGrantAccess", "ptr", hUserHandle, "ptr", hJob, "int", bGrant, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/LibraryLoader/Apis.ahk
+++ b/Windows/Win32/System/LibraryLoader/Apis.ahk
@@ -104,7 +104,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DisableThreadLibraryCalls", "ptr", hLibModule, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -350,7 +350,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetModuleHandleExA", "uint", dwFlags, "ptr", lpModuleName, "ptr", phModule, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -383,7 +383,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetModuleHandleExW", "uint", dwFlags, "ptr", lpModuleName, "ptr", phModule, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -644,7 +644,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\RemoveDllDirectory", CookieMarshal, Cookie, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -664,7 +664,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetDefaultDllDirectories", "uint", DirectoryFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -764,7 +764,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumResourceLanguagesExA", "ptr", hModule, "ptr", lpType, "ptr", lpName, "ptr", lpEnumFunc, "ptr", lParam, "uint", dwFlags, "ushort", LangId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -864,7 +864,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumResourceLanguagesExW", "ptr", hModule, "ptr", lpType, "ptr", lpName, "ptr", lpEnumFunc, "ptr", lParam, "uint", dwFlags, "ushort", LangId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -945,7 +945,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumResourceNamesExA", "ptr", hModule, "ptr", lpType, "ptr", lpEnumFunc, "ptr", lParam, "uint", dwFlags, "ushort", LangId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1026,7 +1026,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumResourceNamesExW", "ptr", hModule, "ptr", lpType, "ptr", lpEnumFunc, "ptr", lParam, "uint", dwFlags, "ushort", LangId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1103,7 +1103,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumResourceTypesExA", "ptr", hModule, "ptr", lpEnumFunc, "ptr", lParam, "uint", dwFlags, "ushort", LangId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1180,7 +1180,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumResourceTypesExW", "ptr", hModule, "ptr", lpEnumFunc, "ptr", lParam, "uint", dwFlags, "ushort", LangId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1349,7 +1349,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumResourceNamesA", "ptr", hModule, "ptr", lpType, "ptr", lpEnumFunc, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1408,7 +1408,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("api-ms-win-core-libraryloader-l2-1-0.dll\QueryOptionalDelayLoadedAPI", "ptr", hParentModule, "ptr", lpDllName, "ptr", lpProcName, "uint", Reserved, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1611,7 +1611,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumResourceTypesA", "ptr", hModule, "ptr", lpEnumFunc, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1644,7 +1644,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumResourceTypesW", "ptr", hModule, "ptr", lpEnumFunc, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1685,7 +1685,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumResourceLanguagesA", "ptr", hModule, "ptr", lpType, "ptr", lpName, "ptr", lpEnumFunc, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1726,7 +1726,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnumResourceLanguagesW", "ptr", hModule, "ptr", lpType, "ptr", lpName, "ptr", lpEnumFunc, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1824,7 +1824,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\UpdateResourceA", "ptr", hUpdate, "ptr", lpType, "ptr", lpName, "ushort", wLanguage, "ptr", lpData, "uint", cb, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1870,7 +1870,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\UpdateResourceW", "ptr", hUpdate, "ptr", lpType, "ptr", lpName, "ushort", wLanguage, "ptr", lpData, "uint", cb, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1896,7 +1896,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EndUpdateResourceA", "ptr", hUpdate, "int", fDiscard, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1922,7 +1922,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EndUpdateResourceW", "ptr", hUpdate, "int", fDiscard, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1944,7 +1944,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetDllDirectoryA", "ptr", lpPathName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1966,7 +1966,7 @@ class LibraryLoader {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetDllDirectoryW", "ptr", lpPathName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Mailslots/Apis.ahk
+++ b/Windows/Win32/System/Mailslots/Apis.ahk
@@ -184,7 +184,7 @@ class Mailslots {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetMailslotInfo", "ptr", hMailslot, lpMaxMessageSizeMarshal, lpMaxMessageSize, lpNextSizeMarshal, lpNextSize, lpMessageCountMarshal, lpMessageCount, lpReadTimeoutMarshal, lpReadTimeout, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -240,7 +240,7 @@ class Mailslots {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetMailslotInfo", "ptr", hMailslot, "uint", lReadTimeout, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Memory/Apis.ahk
+++ b/Windows/Win32/System/Memory/Apis.ahk
@@ -119,7 +119,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\HeapDestroy", "ptr", hHeap, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -264,7 +264,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\HeapFree", "ptr", hHeap, "uint", dwFlags, lpMemMarshal, lpMem, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -435,7 +435,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\HeapSetInformation", "ptr", HeapHandle, "int", HeapInformationClass, "ptr", HeapInformation, "ptr", HeapInformationLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -556,7 +556,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\HeapLock", "ptr", hHeap, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -580,7 +580,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\HeapUnlock", "ptr", hHeap, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -621,7 +621,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\HeapWalk", "ptr", hHeap, "ptr", lpEntry, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -685,7 +685,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\HeapQueryInformation", "ptr", HeapHandle, "int", HeapInformationClass, "ptr", HeapInformation, "ptr", HeapInformationLength, ReturnLengthMarshal, ReturnLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -771,7 +771,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\VirtualProtect", lpAddressMarshal, lpAddress, "ptr", dwSize, "uint", flNewProtect, lpflOldProtectMarshal, lpflOldProtect, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -811,7 +811,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\VirtualFree", lpAddressMarshal, lpAddress, "ptr", dwSize, "uint", dwFreeType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -944,7 +944,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\VirtualProtectEx", "ptr", hProcess, lpAddressMarshal, lpAddress, "ptr", dwSize, "uint", flNewProtect, lpflOldProtectMarshal, lpflOldProtect, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1229,7 +1229,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\VirtualFreeEx", "ptr", hProcess, lpAddressMarshal, lpAddress, "ptr", dwSize, "uint", dwFreeType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1252,7 +1252,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FlushViewOfFile", lpBaseAddressMarshal, lpBaseAddress, "ptr", dwNumberOfBytesToFlush, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1276,7 +1276,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\UnmapViewOfFile", "ptr", lpBaseAddress, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1465,7 +1465,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetProcessWorkingSetSizeEx", "ptr", hProcess, "ptr", dwMinimumWorkingSetSize, "ptr", dwMaximumWorkingSetSize, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1488,7 +1488,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\VirtualLock", lpAddressMarshal, lpAddress, "ptr", dwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1511,7 +1511,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\VirtualUnlock", lpAddressMarshal, lpAddress, "ptr", dwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1647,7 +1647,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryMemoryResourceNotification", "ptr", ResourceNotificationHandle, ResourceStateMarshal, ResourceState, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1702,7 +1702,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetSystemFileCacheSize", lpMinimumFileCacheSizeMarshal, lpMinimumFileCacheSize, lpMaximumFileCacheSizeMarshal, lpMaximumFileCacheSize, lpFlagsMarshal, lpFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1787,7 +1787,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetSystemFileCacheSize", "ptr", MinimumFileCacheSize, "ptr", MaximumFileCacheSize, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1923,7 +1923,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\PrefetchVirtualMemory", "ptr", hProcess, "ptr", NumberOfEntries, "ptr", VirtualAddresses, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2060,7 +2060,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\UnmapViewOfFileEx", "ptr", BaseAddress, "uint", UnmapFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2107,7 +2107,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\AllocateUserPhysicalPages", "ptr", hProcess, NumberOfPagesMarshal, NumberOfPages, PageArrayMarshal, PageArray, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2140,7 +2140,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FreeUserPhysicalPages", "ptr", hProcess, NumberOfPagesMarshal, NumberOfPages, PageArrayMarshal, PageArray, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2192,7 +2192,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\MapUserPhysicalPages", VirtualAddressMarshal, VirtualAddress, "ptr", NumberOfPages, PageArrayMarshal, PageArray, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2242,7 +2242,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\AllocateUserPhysicalPagesNuma", "ptr", hProcess, NumberOfPagesMarshal, NumberOfPages, PageArrayMarshal, PageArray, "uint", nndPreferred, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2341,7 +2341,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetMemoryErrorHandlingCapabilities", CapabilitiesMarshal, Capabilities, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2381,7 +2381,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\UnregisterBadMemoryNotification", RegistrationHandleMarshal, RegistrationHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2458,7 +2458,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("api-ms-win-core-memory-l1-1-3.dll\SetProcessValidCallTargets", "ptr", hProcess, VirtualAddressMarshal, VirtualAddress, "ptr", RegionSize, "uint", NumberOfOffsets, "ptr", OffsetInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2582,7 +2582,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("api-ms-win-core-memory-l1-1-3.dll\VirtualProtectFromApp", AddressMarshal, Address, "ptr", Size, "uint", NewProtection, OldProtectionMarshal, OldProtection, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2648,7 +2648,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("api-ms-win-core-memory-l1-1-4.dll\QueryVirtualMemoryInformation", "ptr", Process, VirtualAddressMarshal, VirtualAddress, "int", MemoryInformationClass, "ptr", MemoryInformation, "ptr", MemoryInformationSize, ReturnSizeMarshal, ReturnSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2721,7 +2721,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("api-ms-win-core-memory-l1-1-5.dll\UnmapViewOfFile2", "ptr", Process, "ptr", BaseAddress, "uint", UnmapFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3434,7 +3434,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GlobalUnlock", "ptr", hMem, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3668,7 +3668,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\LocalUnlock", "ptr", hMem, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4069,7 +4069,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\IsBadCodePtr", "ptr", lpfn, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4151,7 +4151,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\MapUserPhysicalPagesScatter", VirtualAddressesMarshal, VirtualAddresses, "ptr", NumberOfPages, PageArrayMarshal, PageArray, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4174,7 +4174,7 @@ class Memory {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\AddSecureMemoryCacheCallback", "ptr", pfnCallBack, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Performance/Apis.ahk
+++ b/Windows/Win32/System/Performance/Apis.ahk
@@ -987,7 +987,7 @@ class Performance {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryPerformanceCounter", lpPerformanceCountMarshal, lpPerformanceCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1008,7 +1008,7 @@ class Performance {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryPerformanceFrequency", lpFrequencyMarshal, lpFrequency, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Pipes/Apis.ahk
+++ b/Windows/Win32/System/Pipes/Apis.ahk
@@ -55,7 +55,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreatePipe", "ptr", hReadPipe, "ptr", hWritePipe, "ptr", lpPipeAttributes, "uint", nSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -95,7 +95,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ConnectNamedPipe", "ptr", hNamedPipe, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -118,7 +118,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DisconnectNamedPipe", "ptr", hNamedPipe, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -223,7 +223,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetNamedPipeHandleState", "ptr", hNamedPipe, lpModeMarshal, lpMode, lpMaxCollectionCountMarshal, lpMaxCollectionCount, lpCollectDataTimeoutMarshal, lpCollectDataTimeout, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -257,7 +257,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\PeekNamedPipe", "ptr", hNamedPipe, "ptr", lpBuffer, "uint", nBufferSize, lpBytesReadMarshal, lpBytesRead, lpTotalBytesAvailMarshal, lpTotalBytesAvail, lpBytesLeftThisMessageMarshal, lpBytesLeftThisMessage, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -324,7 +324,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\TransactNamedPipe", "ptr", hNamedPipe, "ptr", lpInBuffer, "uint", nInBufferSize, "ptr", lpOutBuffer, "uint", nOutBufferSize, lpBytesReadMarshal, lpBytesRead, "ptr", lpOverlapped, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -684,7 +684,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ImpersonateNamedPipeClient", "ptr", hNamedPipe, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -721,7 +721,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNamedPipeInfo", "ptr", hNamedPipe, lpFlagsMarshal, lpFlags, lpOutBufferSizeMarshal, lpOutBufferSize, lpInBufferSizeMarshal, lpInBufferSize, lpMaxInstancesMarshal, lpMaxInstances, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1182,7 +1182,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNamedPipeHandleStateA", "ptr", hNamedPipe, lpStateMarshal, lpState, lpCurInstancesMarshal, lpCurInstances, lpMaxCollectionCountMarshal, lpMaxCollectionCount, lpCollectDataTimeoutMarshal, lpCollectDataTimeout, "ptr", lpUserName, "uint", nMaxUserNameSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1257,7 +1257,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CallNamedPipeA", "ptr", lpNamedPipeName, "ptr", lpInBuffer, "uint", nInBufferSize, "ptr", lpOutBuffer, "uint", nOutBufferSize, lpBytesReadMarshal, lpBytesRead, "uint", nTimeOut, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1285,7 +1285,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WaitNamedPipeA", "ptr", lpNamedPipeName, "uint", nTimeOut, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1310,7 +1310,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNamedPipeClientComputerNameA", "ptr", Pipe, "ptr", ClientComputerName, "uint", ClientComputerNameLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1336,7 +1336,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNamedPipeClientProcessId", "ptr", Pipe, ClientProcessIdMarshal, ClientProcessId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1362,7 +1362,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNamedPipeClientSessionId", "ptr", Pipe, ClientSessionIdMarshal, ClientSessionId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1388,7 +1388,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNamedPipeServerProcessId", "ptr", Pipe, ServerProcessIdMarshal, ServerProcessId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1414,7 +1414,7 @@ class Pipes {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNamedPipeServerSessionId", "ptr", Pipe, ServerSessionIdMarshal, ServerSessionId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Power/Apis.ahk
+++ b/Windows/Win32/System/Power/Apis.ahk
@@ -3827,7 +3827,7 @@ class Power {
         A_LastError := 0
 
         result := DllCall("USER32.dll\UnregisterPowerSettingNotification", "ptr", Handle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3876,7 +3876,7 @@ class Power {
         A_LastError := 0
 
         result := DllCall("USER32.dll\UnregisterSuspendResumeNotification", "ptr", Handle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3985,7 +3985,7 @@ class Power {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\PowerSetRequest", "ptr", PowerRequest, "int", RequestType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4008,7 +4008,7 @@ class Power {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\PowerClearRequest", "ptr", PowerRequest, "int", RequestType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4050,7 +4050,7 @@ class Power {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetSystemPowerState", "int", fSuspend, "int", fForce, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4071,7 +4071,7 @@ class Power {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetSystemPowerStatus", "ptr", lpSystemPowerStatus, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/ProcessStatus/Apis.ahk
+++ b/Windows/Win32/System/ProcessStatus/Apis.ahk
@@ -34,7 +34,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\EnumProcesses", "ptr", lpidProcess, "uint", cb, lpcbNeededMarshal, lpcbNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -62,7 +62,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\EnumProcessModules", "ptr", hProcess, "ptr", lphModule, "uint", cb, lpcbNeededMarshal, lpcbNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -90,7 +90,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\EnumProcessModulesEx", "ptr", hProcess, "ptr", lphModule, "uint", cb, lpcbNeededMarshal, lpcbNeeded, "uint", dwFilterFlag, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -240,7 +240,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\GetModuleInformation", "ptr", hProcess, "ptr", hModule, "ptr", lpmodinfo, "uint", cb, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -262,7 +262,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\EmptyWorkingSet", "ptr", hProcess, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -284,7 +284,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\InitializeProcessForWsWatch", "ptr", hProcess, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -318,7 +318,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\GetWsChanges", "ptr", hProcess, "ptr", lpWatchInfo, "uint", cb, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -349,7 +349,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\GetWsChangesEx", "ptr", hProcess, "ptr", lpWatchInfoEx, cbMarshal, cb, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -429,7 +429,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\EnumDeviceDrivers", "ptr", lpImageBase, "uint", cb, lpcbNeededMarshal, lpcbNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -571,7 +571,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\QueryWorkingSet", "ptr", hProcess, "ptr", pv, "uint", cb, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -594,7 +594,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\QueryWorkingSetEx", "ptr", hProcess, "ptr", pv, "uint", cb, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -622,7 +622,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\GetProcessMemoryInfo", "ptr", Process, "ptr", ppsmemCounters, "uint", cb, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -645,7 +645,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\GetPerformanceInfo", "ptr", pPerformanceInformation, "uint", cb, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -668,7 +668,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\EnumPageFilesW", "ptr", pCallBackRoutine, pContextMarshal, pContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -691,7 +691,7 @@ class ProcessStatus {
         A_LastError := 0
 
         result := DllCall("PSAPI.dll\EnumPageFilesA", "ptr", pCallBackRoutine, pContextMarshal, pContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/RemoteDesktop/Apis.ahk
+++ b/Windows/Win32/System/RemoteDesktop/Apis.ahk
@@ -1289,7 +1289,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSStopRemoteControlSession", "uint", LogonId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1316,7 +1316,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSStartRemoteControlSessionW", "ptr", pTargetServerName, "uint", TargetLogonId, "char", HotkeyVk, "ushort", HotkeyModifiers, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1343,7 +1343,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSStartRemoteControlSessionA", "ptr", pTargetServerName, "uint", TargetLogonId, "char", HotkeyVk, "ushort", HotkeyModifiers, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1372,7 +1372,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSConnectSessionA", "uint", LogonId, "uint", TargetLogonId, "ptr", pPassword, "int", bWait, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1401,7 +1401,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSConnectSessionW", "uint", LogonId, "uint", TargetLogonId, "ptr", pPassword, "int", bWait, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1435,7 +1435,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSEnumerateServersW", "ptr", pDomainName, "uint", Reserved, "uint", Version, ppServerInfoMarshal, ppServerInfo, pCountMarshal, pCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1469,7 +1469,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSEnumerateServersA", "ptr", pDomainName, "uint", Reserved, "uint", Version, ppServerInfoMarshal, ppServerInfo, pCountMarshal, pCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1599,7 +1599,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSEnumerateSessionsW", "ptr", hServer, "uint", Reserved, "uint", Version, ppSessionInfoMarshal, ppSessionInfo, pCountMarshal, pCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1641,7 +1641,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSEnumerateSessionsA", "ptr", hServer, "uint", Reserved, "uint", Version, ppSessionInfoMarshal, ppSessionInfo, pCountMarshal, pCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1674,7 +1674,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSEnumerateSessionsExW", "ptr", hServer, pLevelMarshal, pLevel, "uint", Filter, ppSessionInfoMarshal, ppSessionInfo, pCountMarshal, pCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1707,7 +1707,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSEnumerateSessionsExA", "ptr", hServer, pLevelMarshal, pLevel, "uint", Filter, ppSessionInfoMarshal, ppSessionInfo, pCountMarshal, pCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1743,7 +1743,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSEnumerateProcessesW", "ptr", hServer, "uint", Reserved, "uint", Version, ppProcessInfoMarshal, ppProcessInfo, pCountMarshal, pCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1779,7 +1779,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSEnumerateProcessesA", "ptr", hServer, "uint", Reserved, "uint", Version, ppProcessInfoMarshal, ppProcessInfo, pCountMarshal, pCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1804,7 +1804,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSTerminateProcess", "ptr", hServer, "uint", ProcessId, "uint", ExitCode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1854,7 +1854,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSQuerySessionInformationW", "ptr", hServer, "uint", SessionId, "int", WTSInfoClass, ppBufferMarshal, ppBuffer, pBytesReturnedMarshal, pBytesReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1904,7 +1904,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSQuerySessionInformationA", "ptr", hServer, "uint", SessionId, "int", WTSInfoClass, ppBufferMarshal, ppBuffer, pBytesReturnedMarshal, pBytesReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1939,7 +1939,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSQueryUserConfigW", "ptr", pServerName, "ptr", pUserName, "int", WTSConfigClass, ppBufferMarshal, ppBuffer, pBytesReturnedMarshal, pBytesReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1974,7 +1974,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSQueryUserConfigA", "ptr", pServerName, "ptr", pUserName, "int", WTSConfigClass, ppBufferMarshal, ppBuffer, pBytesReturnedMarshal, pBytesReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2006,7 +2006,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSSetUserConfigW", "ptr", pServerName, "ptr", pUserName, "int", WTSConfigClass, "ptr", pBuffer, "uint", DataLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2038,7 +2038,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSSetUserConfigA", "ptr", pServerName, "ptr", pUserName, "int", WTSConfigClass, "ptr", pBuffer, "uint", DataLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2095,7 +2095,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSSendMessageW", "ptr", hServer, "uint", SessionId, "ptr", pTitle, "uint", TitleLength, "ptr", pMessage, "uint", MessageLength, "uint", Style, "uint", Timeout, pResponseMarshal, pResponse, "int", bWait, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2152,7 +2152,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSSendMessageA", "ptr", hServer, "uint", SessionId, "ptr", pTitle, "uint", TitleLength, "ptr", pMessage, "uint", MessageLength, "uint", Style, "uint", Timeout, pResponseMarshal, pResponse, "int", bWait, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2183,7 +2183,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSDisconnectSession", "ptr", hServer, "uint", SessionId, "int", bWait, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2220,7 +2220,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSLogoffSession", "ptr", hServer, "uint", SessionId, "int", bWait, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2244,7 +2244,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSShutdownSystem", "ptr", hServer, "uint", ShutdownFlag, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2274,7 +2274,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSWaitSystemEvent", "ptr", hServer, "uint", EventMask, pEventFlagsMarshal, pEventFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2366,7 +2366,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSVirtualChannelClose", "ptr", hChannelHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2413,7 +2413,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSVirtualChannelRead", "ptr", hChannelHandle, "uint", TimeOut, "ptr", Buffer, "uint", BufferSize, pBytesReadMarshal, pBytesRead, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2441,7 +2441,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSVirtualChannelWrite", "ptr", hChannelHandle, "ptr", Buffer, "uint", Length, pBytesWrittenMarshal, pBytesWritten, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2464,7 +2464,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSVirtualChannelPurgeInput", "ptr", hChannelHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2487,7 +2487,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSVirtualChannelPurgeOutput", "ptr", hChannelHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2521,7 +2521,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSVirtualChannelQuery", "ptr", hChannelHandle, "int", param1, ppBufferMarshal, ppBuffer, pBytesReturnedMarshal, pBytesReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2563,7 +2563,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSRegisterSessionNotification", "ptr", hWnd, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2583,7 +2583,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSUnRegisterSessionNotification", "ptr", hWnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2610,7 +2610,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSRegisterSessionNotificationEx", "ptr", hServer, "ptr", hWnd, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2634,7 +2634,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSUnRegisterSessionNotificationEx", "ptr", hServer, "ptr", hWnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2669,7 +2669,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSQueryUserToken", "uint", SessionId, "ptr", phToken, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2695,7 +2695,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSFreeMemoryExW", "int", WTSTypeClass, pMemoryMarshal, pMemory, "uint", NumberOfEntries, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2721,7 +2721,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSFreeMemoryExA", "int", WTSTypeClass, pMemoryMarshal, pMemory, "uint", NumberOfEntries, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2759,7 +2759,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSEnumerateProcessesExW", "ptr", hServer, pLevelMarshal, pLevel, "uint", SessionId, ppProcessInfoMarshal, ppProcessInfo, pCountMarshal, pCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2797,7 +2797,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSEnumerateProcessesExA", "ptr", hServer, pLevelMarshal, pLevel, "uint", SessionId, ppProcessInfoMarshal, ppProcessInfo, pCountMarshal, pCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2831,7 +2831,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSEnumerateListenersW", "ptr", hServer, pReservedMarshal, pReserved, "uint", Reserved, pListenersMarshal, pListeners, pCountMarshal, pCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2865,7 +2865,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSEnumerateListenersA", "ptr", hServer, pReservedMarshal, pReserved, "uint", Reserved, pListenersMarshal, pListeners, pCountMarshal, pCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2894,7 +2894,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSQueryListenerConfigW", "ptr", hServer, pReservedMarshal, pReserved, "uint", Reserved, "ptr", pListenerName, "ptr", pBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2923,7 +2923,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSQueryListenerConfigA", "ptr", hServer, pReservedMarshal, pReserved, "uint", Reserved, "ptr", pListenerName, "ptr", pBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2953,7 +2953,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSCreateListenerW", "ptr", hServer, pReservedMarshal, pReserved, "uint", Reserved, "ptr", pListenerName, "ptr", pBuffer, "uint", flag, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2983,7 +2983,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSCreateListenerA", "ptr", hServer, pReservedMarshal, pReserved, "uint", Reserved, "ptr", pListenerName, "ptr", pBuffer, "uint", flag, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3016,7 +3016,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSSetListenerSecurityW", "ptr", hServer, pReservedMarshal, pReserved, "uint", Reserved, "ptr", pListenerName, "uint", SecurityInformation, "ptr", pSecurityDescriptor, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3049,7 +3049,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSSetListenerSecurityA", "ptr", hServer, pReservedMarshal, pReserved, "uint", Reserved, "ptr", pListenerName, "uint", SecurityInformation, "ptr", pSecurityDescriptor, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3085,7 +3085,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSGetListenerSecurityW", "ptr", hServer, pReservedMarshal, pReserved, "uint", Reserved, "ptr", pListenerName, "uint", SecurityInformation, "ptr", pSecurityDescriptor, "uint", nLength, lpnLengthNeededMarshal, lpnLengthNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3121,7 +3121,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("WTSAPI32.dll\WTSGetListenerSecurityA", "ptr", hServer, pReservedMarshal, pReserved, "uint", Reserved, "ptr", pListenerName, "uint", SecurityInformation, "ptr", pSecurityDescriptor, "uint", nLength, lpnLengthNeededMarshal, lpnLengthNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3312,7 +3312,7 @@ class RemoteDesktop {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ProcessIdToSessionId", "uint", dwProcessId, pSessionIdMarshal, pSessionId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Services/Apis.ahk
+++ b/Windows/Win32/System/Services/Apis.ahk
@@ -695,7 +695,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetServiceBits", "ptr", hServiceStatus, "uint", dwServiceBits, "int", bSetBitsOn, "int", bUpdateImmediately, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -960,7 +960,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ChangeServiceConfigA", "ptr", hService, "uint", dwServiceType, "uint", dwStartType, "uint", dwErrorControl, "ptr", lpBinaryPathName, "ptr", lpLoadOrderGroup, lpdwTagIdMarshal, lpdwTagId, "ptr", lpDependencies, "ptr", lpServiceStartName, "ptr", lpPassword, "ptr", lpDisplayName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1225,7 +1225,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ChangeServiceConfigW", "ptr", hService, "uint", dwServiceType, "uint", dwStartType, "uint", dwErrorControl, "ptr", lpBinaryPathName, "ptr", lpLoadOrderGroup, lpdwTagIdMarshal, lpdwTagId, "ptr", lpDependencies, "ptr", lpServiceStartName, "ptr", lpPassword, "ptr", lpDisplayName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1259,7 +1259,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ChangeServiceConfig2A", "ptr", hService, "uint", dwInfoLevel, lpInfoMarshal, lpInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1293,7 +1293,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ChangeServiceConfig2W", "ptr", hService, "uint", dwInfoLevel, lpInfoMarshal, lpInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1338,7 +1338,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CloseServiceHandle", "ptr", hSCObject, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1651,7 +1651,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ControlService", "ptr", hService, "uint", dwControl, "ptr", lpServiceStatus, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2136,7 +2136,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\DeleteService", "ptr", hService, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2227,7 +2227,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\EnumDependentServicesA", "ptr", hService, "uint", dwServiceState, "ptr", lpServices, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, lpServicesReturnedMarshal, lpServicesReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2318,7 +2318,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\EnumDependentServicesW", "ptr", hService, "uint", dwServiceState, "ptr", lpServices, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, lpServicesReturnedMarshal, lpServicesReturned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2414,7 +2414,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\EnumServicesStatusA", "ptr", hSCManager, "uint", dwServiceType, "uint", dwServiceState, "ptr", lpServices, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, lpServicesReturnedMarshal, lpServicesReturned, lpResumeHandleMarshal, lpResumeHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2510,7 +2510,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\EnumServicesStatusW", "ptr", hSCManager, "uint", dwServiceType, "uint", dwServiceState, "ptr", lpServices, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, lpServicesReturnedMarshal, lpServicesReturned, lpResumeHandleMarshal, lpResumeHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2631,7 +2631,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\EnumServicesStatusExA", "ptr", hSCManager, "int", InfoLevel, "uint", dwServiceType, "uint", dwServiceState, "ptr", lpServices, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, lpServicesReturnedMarshal, lpServicesReturned, lpResumeHandleMarshal, lpResumeHandle, "ptr", pszGroupName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2752,7 +2752,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\EnumServicesStatusExW", "ptr", hSCManager, "int", InfoLevel, "uint", dwServiceType, "uint", dwServiceState, "ptr", lpServices, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, lpServicesReturnedMarshal, lpServicesReturned, lpResumeHandleMarshal, lpResumeHandle, "ptr", pszGroupName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2786,7 +2786,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetServiceKeyNameA", "ptr", hSCManager, "ptr", lpDisplayName, "ptr", lpServiceName, lpcchBufferMarshal, lpcchBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2820,7 +2820,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetServiceKeyNameW", "ptr", hSCManager, "ptr", lpDisplayName, "ptr", lpServiceName, lpcchBufferMarshal, lpcchBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2864,7 +2864,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetServiceDisplayNameA", "ptr", hSCManager, "ptr", lpServiceName, "ptr", lpDisplayName, lpcchBufferMarshal, lpcchBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2909,7 +2909,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetServiceDisplayNameW", "ptr", hSCManager, "ptr", lpServiceName, "ptr", lpDisplayName, lpcchBufferMarshal, lpcchBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3017,7 +3017,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\NotifyBootConfigStatus", "int", BootAcceptable, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3395,7 +3395,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\QueryServiceConfigA", "ptr", hService, "ptr", lpServiceConfig, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3471,7 +3471,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\QueryServiceConfigW", "ptr", hService, "ptr", lpServiceConfig, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3546,7 +3546,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\QueryServiceConfig2A", "ptr", hService, "uint", dwInfoLevel, "ptr", lpBuffer, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3621,7 +3621,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\QueryServiceConfig2W", "ptr", hService, "uint", dwInfoLevel, "ptr", lpBuffer, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3693,7 +3693,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\QueryServiceLockStatusA", "ptr", hSCManager, "ptr", lpLockStatus, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3765,7 +3765,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\QueryServiceLockStatusW", "ptr", hSCManager, "ptr", lpLockStatus, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3852,7 +3852,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\QueryServiceObjectSecurity", "ptr", hService, "uint", dwSecurityInformation, "ptr", lpSecurityDescriptor, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3910,7 +3910,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\QueryServiceStatus", "ptr", hService, "ptr", lpServiceStatus, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4025,7 +4025,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\QueryServiceStatusEx", "ptr", hService, "int", InfoLevel, "ptr", lpBuffer, "uint", cbBufSize, pcbBytesNeededMarshal, pcbBytesNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4346,7 +4346,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetServiceObjectSecurity", "ptr", hService, "uint", dwSecurityInformation, "ptr", lpSecurityDescriptor, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4402,7 +4402,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetServiceStatus", "ptr", hServiceStatus, "ptr", lpServiceStatus, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4470,7 +4470,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\StartServiceCtrlDispatcherA", "ptr", lpServiceStartTable, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4538,7 +4538,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\StartServiceCtrlDispatcherW", "ptr", lpServiceStartTable, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4712,7 +4712,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\StartServiceA", "ptr", hService, "uint", dwNumServiceArgs, lpServiceArgVectorsMarshal, lpServiceArgVectors, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4886,7 +4886,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\StartServiceW", "ptr", hService, "uint", dwNumServiceArgs, lpServiceArgVectorsMarshal, lpServiceArgVectors, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4929,7 +4929,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\UnlockServiceDatabase", ScLockMarshal, ScLock, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5254,7 +5254,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ControlServiceExA", "ptr", hService, "uint", dwControl, "uint", dwInfoLevel, pControlParamsMarshal, pControlParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5527,7 +5527,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\ControlServiceExW", "ptr", hService, "uint", dwControl, "uint", dwInfoLevel, pControlParamsMarshal, pControlParams, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5569,7 +5569,7 @@ class Services {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\QueryServiceDynamicInformation", "ptr", hServiceStatus, "uint", dwInfoLevel, ppDynamicInfoMarshal, ppDynamicInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/SetupAndMigration/Apis.ahk
+++ b/Windows/Win32/System/SetupAndMigration/Apis.ahk
@@ -23,7 +23,7 @@ class SetupAndMigration {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\OOBEComplete", isOOBECompleteMarshal, isOOBEComplete, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -44,7 +44,7 @@ class SetupAndMigration {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\RegisterWaitUntilOOBECompleted", "ptr", OOBECompletedCallback, CallbackContextMarshal, CallbackContext, WaitHandleMarshal, WaitHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -62,7 +62,7 @@ class SetupAndMigration {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\UnregisterWaitUntilOOBECompleted", WaitHandleMarshal, WaitHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Shutdown/Apis.ahk
+++ b/Windows/Win32/System/Shutdown/Apis.ahk
@@ -114,7 +114,7 @@ class Shutdown {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\InitiateSystemShutdownA", "ptr", lpMachineName, "ptr", lpMessage, "uint", dwTimeout, "int", bForceAppsClosed, "int", bRebootAfterShutdown, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -158,7 +158,7 @@ class Shutdown {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\InitiateSystemShutdownW", "ptr", lpMachineName, "ptr", lpMessage, "uint", dwTimeout, "int", bForceAppsClosed, "int", bRebootAfterShutdown, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -180,7 +180,7 @@ class Shutdown {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AbortSystemShutdownA", "ptr", lpMachineName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -202,7 +202,7 @@ class Shutdown {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\AbortSystemShutdownW", "ptr", lpMachineName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -259,7 +259,7 @@ class Shutdown {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\InitiateSystemShutdownExA", "ptr", lpMachineName, "ptr", lpMessage, "uint", dwTimeout, "int", bForceAppsClosed, "int", bRebootAfterShutdown, "uint", dwReason, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -316,7 +316,7 @@ class Shutdown {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\InitiateSystemShutdownExW", "ptr", lpMachineName, "ptr", lpMessage, "uint", dwTimeout, "int", bForceAppsClosed, "int", bRebootAfterShutdown, "uint", dwReason, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -817,7 +817,7 @@ class Shutdown {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ExitWindowsEx", "uint", uFlags, "uint", dwReason, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -836,7 +836,7 @@ class Shutdown {
         A_LastError := 0
 
         result := DllCall("USER32.dll\LockWorkStation", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -860,7 +860,7 @@ class Shutdown {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ShutdownBlockReasonCreate", "ptr", hWnd, "ptr", pwszReason, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -887,7 +887,7 @@ class Shutdown {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ShutdownBlockReasonQuery", "ptr", hWnd, "ptr", pwszBuff, pcchBuffMarshal, pcchBuff, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -909,7 +909,7 @@ class Shutdown {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ShutdownBlockReasonDestroy", "ptr", hWnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/StationsAndDesktops/Apis.ahk
+++ b/Windows/Win32/System/StationsAndDesktops/Apis.ahk
@@ -402,7 +402,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EnumDesktopsA", "ptr", hwinsta, "ptr", lpEnumFunc, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -435,7 +435,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EnumDesktopsW", "ptr", hwinsta, "ptr", lpEnumFunc, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -470,7 +470,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EnumDesktopWindows", "ptr", hDesktop, "ptr", lpfn, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -502,7 +502,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SwitchDesktop", "ptr", hDesktop, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -529,7 +529,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetThreadDesktop", "ptr", hDesktop, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -554,7 +554,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CloseDesktop", "ptr", hDesktop, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -717,7 +717,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EnumWindowStationsA", "ptr", lpEnumFunc, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -741,7 +741,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EnumWindowStationsW", "ptr", lpEnumFunc, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -767,7 +767,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CloseWindowStation", "ptr", hWinSta, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -794,7 +794,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetProcessWindowStation", "ptr", hWinSta, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -845,7 +845,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetUserObjectInformationA", "ptr", hObj, "int", nIndex, "ptr", pvInfo, "uint", nLength, lpnLengthNeededMarshal, lpnLengthNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -877,7 +877,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetUserObjectInformationW", "ptr", hObj, "int", nIndex, "ptr", pvInfo, "uint", nLength, lpnLengthNeededMarshal, lpnLengthNeeded, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -940,7 +940,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetUserObjectInformationA", "ptr", hObj, "int", nIndex, "ptr", pvInfo, "uint", nLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1003,7 +1003,7 @@ class StationsAndDesktops {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetUserObjectInformationW", "ptr", hObj, "int", nIndex, "ptr", pvInfo, "uint", nLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/SystemInformation/Apis.ahk
+++ b/Windows/Win32/System/SystemInformation/Apis.ahk
@@ -616,7 +616,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GlobalMemoryStatusEx", "ptr", lpBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -742,7 +742,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetLocalTime", "ptr", lpSystemTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -796,7 +796,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetSystemTimeAdjustment", lpTimeAdjustmentMarshal, lpTimeAdjustment, lpTimeIncrementMarshal, lpTimeIncrement, lpTimeAdjustmentDisabledMarshal, lpTimeAdjustmentDisabled, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -825,7 +825,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("api-ms-win-core-sysinfo-l1-2-4.dll\GetSystemTimeAdjustmentPrecise", lpTimeAdjustmentMarshal, lpTimeAdjustment, lpTimeIncrementMarshal, lpTimeIncrement, lpTimeAdjustmentDisabledMarshal, lpTimeAdjustmentDisabled, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1138,7 +1138,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetComputerNameExA", "int", NameType, "ptr", lpBuffer, nSizeMarshal, nSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1289,7 +1289,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetComputerNameExW", "int", NameType, "ptr", lpBuffer, nSizeMarshal, nSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1312,7 +1312,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetComputerNameExW", "int", NameType, "ptr", lpBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1339,7 +1339,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetSystemTime", "ptr", lpSystemTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1369,7 +1369,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetVersionExA", "ptr", lpVersionInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1399,7 +1399,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetVersionExW", "ptr", lpVersionInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1422,7 +1422,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetLogicalProcessorInformation", "ptr", Buffer, ReturnedLengthMarshal, ReturnedLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1519,7 +1519,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetLogicalProcessorInformationEx", "int", RelationshipType, "ptr", Buffer, ReturnedLengthMarshal, ReturnedLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1743,7 +1743,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetPhysicallyInstalledSystemMemory", TotalMemoryInKilobytesMarshal, TotalMemoryInKilobytes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1790,7 +1790,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetSystemTimeAdjustment", "uint", dwTimeAdjustment, "int", bTimeAdjustmentDisabled, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1815,7 +1815,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("api-ms-win-core-sysinfo-l1-2-4.dll\SetSystemTimeAdjustmentPrecise", "uint", dwTimeAdjustment, "int", bTimeAdjustmentDisabled, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1840,7 +1840,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetProcessorSystemCycleTime", "ushort", Group, "ptr", Buffer, ReturnedLengthMarshal, ReturnedLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1894,7 +1894,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetComputerNameA", "ptr", lpComputerName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1922,7 +1922,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetComputerNameW", "ptr", lpComputerName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1945,7 +1945,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetComputerNameExA", "int", NameType, "ptr", lpBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2293,7 +2293,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetFirmwareType", FirmwareTypeMarshal, FirmwareType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2326,7 +2326,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\VerifyVersionInfoA", "ptr", lpVersionInformation, "uint", dwTypeMask, "uint", dwlConditionMask, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2359,7 +2359,7 @@ class SystemInformation {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\VerifyVersionInfoW", "ptr", lpVersionInformation, "uint", dwTypeMask, "uint", dwlConditionMask, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Threading/Apis.ahk
+++ b/Windows/Win32/System/Threading/Apis.ahk
@@ -1249,7 +1249,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetProcessWorkingSetSize", "ptr", hProcess, lpMinimumWorkingSetSizeMarshal, lpMinimumWorkingSetSize, lpMaximumWorkingSetSizeMarshal, lpMaximumWorkingSetSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1287,7 +1287,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetProcessWorkingSetSize", "ptr", hProcess, "ptr", dwMinimumWorkingSetSize, "ptr", dwMaximumWorkingSetSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1382,7 +1382,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FlsSetValue", "uint", dwFlsIndex, lpFlsDataMarshal, lpFlsData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1403,7 +1403,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FlsFree", "uint", dwFlsIndex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1600,7 +1600,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\InitializeCriticalSectionAndSpinCount", "ptr", lpCriticalSection, "uint", dwSpinCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1639,7 +1639,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\InitializeCriticalSectionEx", "ptr", lpCriticalSection, "uint", dwSpinCount, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1736,7 +1736,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\InitOnceExecuteOnce", "ptr", InitOnce, "ptr", InitFn, ParameterMarshal, Parameter, ContextMarshal, Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1800,7 +1800,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\InitOnceBeginInitialize", "ptr", lpInitOnce, "uint", dwFlags, fPendingMarshal, fPending, lpContextMarshal, lpContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1853,7 +1853,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\InitOnceComplete", "ptr", lpInitOnce, "uint", dwFlags, lpContextMarshal, lpContext, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1934,7 +1934,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SleepConditionVariableCS", "ptr", ConditionVariable, "ptr", CriticalSection, "uint", dwMilliseconds, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1959,7 +1959,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SleepConditionVariableSRW", "ptr", ConditionVariable, "ptr", SRWLock, "uint", dwMilliseconds, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1989,7 +1989,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetEvent", "ptr", hEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2019,7 +2019,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ResetEvent", "ptr", hEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2049,7 +2049,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReleaseSemaphore", "ptr", hSemaphore, "int", lReleaseCount, lpPreviousCountMarshal, lpPreviousCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2074,7 +2074,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ReleaseMutex", "ptr", hMutex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2838,7 +2838,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetWaitableTimerEx", "ptr", hTimer, lpDueTimeMarshal, lpDueTime, "int", lPeriod, "ptr", pfnCompletionRoutine, lpArgToCompletionRoutineMarshal, lpArgToCompletionRoutine, "ptr", WakeContext, "uint", TolerableDelay, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2881,7 +2881,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetWaitableTimer", "ptr", hTimer, lpDueTimeMarshal, lpDueTime, "int", lPeriod, "ptr", pfnCompletionRoutine, lpArgToCompletionRoutineMarshal, lpArgToCompletionRoutine, "int", fResume, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2906,7 +2906,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CancelWaitableTimer", "ptr", hTimer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3335,7 +3335,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\InitializeSynchronizationBarrier", "ptr", lpBarrier, "int", lTotalThreads, "int", lSpinCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3409,7 +3409,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("api-ms-win-core-synch-l1-2-0.dll\WaitOnAddress", "ptr", Address, "ptr", CompareAddress, "ptr", AddressSize, "uint", dwMilliseconds, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3795,7 +3795,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetProcessTimes", "ptr", hProcess, "ptr", lpCreationTime, "ptr", lpExitTime, "ptr", lpKernelTime, "ptr", lpUserTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3888,7 +3888,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\TerminateProcess", "ptr", hProcess, "uint", uExitCode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3918,7 +3918,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetExitCodeProcess", "ptr", hProcess, lpExitCodeMarshal, lpExitCode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4177,7 +4177,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetThreadPriority", "ptr", hThread, "int", nPriority, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4203,7 +4203,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetThreadPriorityBoost", "ptr", hThread, "int", bDisablePriorityBoost, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4231,7 +4231,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetThreadPriorityBoost", "ptr", hThread, pDisablePriorityBoostMarshal, pDisablePriorityBoost, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4435,7 +4435,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\TerminateThread", "ptr", hThread, "uint", dwExitCode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4465,7 +4465,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetExitCodeThread", "ptr", hThread, lpExitCodeMarshal, lpExitCode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4585,7 +4585,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\TlsSetValue", "uint", dwTlsIndex, lpTlsValueMarshal, lpTlsValue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4606,7 +4606,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\TlsFree", "uint", dwTlsIndex, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4741,7 +4741,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateProcessA", "ptr", lpApplicationName, "ptr", lpCommandLine, "ptr", lpProcessAttributes, "ptr", lpThreadAttributes, "int", bInheritHandles, "uint", dwCreationFlags, lpEnvironmentMarshal, lpEnvironment, "ptr", lpCurrentDirectory, "ptr", lpStartupInfo, "ptr", lpProcessInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4880,7 +4880,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateProcessW", "ptr", lpApplicationName, "ptr", lpCommandLine, "ptr", lpProcessAttributes, "ptr", lpThreadAttributes, "int", bInheritHandles, "uint", dwCreationFlags, lpEnvironmentMarshal, lpEnvironment, "ptr", lpCurrentDirectory, "ptr", lpStartupInfo, "ptr", lpProcessInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4986,7 +4986,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetProcessShutdownParameters", "uint", dwLevel, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5172,7 +5172,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CreateProcessAsUserW", "ptr", hToken, "ptr", lpApplicationName, "ptr", lpCommandLine, "ptr", lpProcessAttributes, "ptr", lpThreadAttributes, "int", bInheritHandles, "uint", dwCreationFlags, lpEnvironmentMarshal, lpEnvironment, "ptr", lpCurrentDirectory, "ptr", lpStartupInfo, "ptr", lpProcessInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5206,7 +5206,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\SetThreadToken", "ptr", Thread, "ptr", Token, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5236,7 +5236,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\OpenProcessToken", "ptr", ProcessHandle, "uint", DesiredAccess, "ptr", TokenHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5271,7 +5271,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\OpenThreadToken", "ptr", ThreadHandle, "uint", DesiredAccess, "int", OpenAsSelf, "ptr", TokenHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5300,7 +5300,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetPriorityClass", "ptr", hProcess, "uint", dwPriorityClass, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5439,7 +5439,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetThreadStackGuarantee", StackSizeInBytesMarshal, StackSizeInBytes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5555,7 +5555,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\InitializeProcThreadAttributeList", "ptr", lpAttributeList, "uint", dwAttributeCount, "uint", dwFlags, lpSizeMarshal, lpSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5598,7 +5598,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\UpdateProcThreadAttribute", "ptr", lpAttributeList, "uint", dwFlags, "ptr", Attribute, "ptr", lpValue, "ptr", cbSize, "ptr", lpPreviousValue, lpReturnSizeMarshal, lpReturnSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5624,7 +5624,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetProcessDynamicEHContinuationTargets", "ptr", Process, "ushort", NumberOfTargets, "ptr", Targets, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5668,7 +5668,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetProcessAffinityUpdateMode", "ptr", hProcess, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5694,7 +5694,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryProcessAffinityUpdateMode", "ptr", hProcess, lpdwFlagsMarshal, lpdwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5847,7 +5847,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetProcessMitigationPolicy", "ptr", hProcess, "int", MitigationPolicy, "ptr", lpBuffer, "ptr", dwLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5888,7 +5888,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetProcessMitigationPolicy", "int", MitigationPolicy, "ptr", lpBuffer, "ptr", dwLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5919,7 +5919,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetThreadTimes", "ptr", hThread, "ptr", lpCreationTime, "ptr", lpExitTime, "ptr", lpKernelTime, "ptr", lpUserTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5992,7 +5992,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetProcessHandleCount", "ptr", hProcess, pdwHandleCountMarshal, pdwHandleCount, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6026,7 +6026,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetThreadIdealProcessorEx", "ptr", hThread, "ptr", lpIdealProcessor, "ptr", lpPreviousIdealProcessor, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6048,7 +6048,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetThreadIdealProcessorEx", "ptr", hThread, "ptr", lpIdealProcessor, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6087,7 +6087,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetProcessPriorityBoost", "ptr", hProcess, pDisablePriorityBoostMarshal, pDisablePriorityBoost, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6111,7 +6111,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetProcessPriorityBoost", "ptr", hProcess, "int", bDisablePriorityBoost, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6135,7 +6135,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetThreadIOPendingFlag", "ptr", hThread, lpIOIsPendingMarshal, lpIOIsPending, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6156,7 +6156,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetSystemTimes", "ptr", lpIdleTime, "ptr", lpKernelTime, "ptr", lpUserTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6189,7 +6189,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetThreadInformation", "ptr", hThread, "int", ThreadInformationClass, "ptr", ThreadInformation, "uint", ThreadInformationSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6222,7 +6222,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetThreadInformation", "ptr", hThread, "int", ThreadInformationClass, "ptr", ThreadInformation, "uint", ThreadInformationSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6244,7 +6244,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\IsProcessCritical", "ptr", hProcess, CriticalMarshal, Critical, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6265,7 +6265,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetProtectedPolicy", "ptr", PolicyGuid, "ptr", PolicyValue, OldPolicyValueMarshal, OldPolicyValue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6356,7 +6356,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetProcessInformation", "ptr", hProcess, "int", ProcessInformationClass, "ptr", ProcessInformation, "uint", ProcessInformationSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6424,7 +6424,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetProcessInformation", "ptr", hProcess, "int", ProcessInformationClass, "ptr", ProcessInformation, "uint", ProcessInformationSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6647,7 +6647,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CreateProcessAsUserA", "ptr", hToken, "ptr", lpApplicationName, "ptr", lpCommandLine, "ptr", lpProcessAttributes, "ptr", lpThreadAttributes, "int", bInheritHandles, "uint", dwCreationFlags, lpEnvironmentMarshal, lpEnvironment, "ptr", lpCurrentDirectory, "ptr", lpStartupInfo, "ptr", lpProcessInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6754,7 +6754,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetProcessShutdownParameters", lpdwLevelMarshal, lpdwLevel, lpdwFlagsMarshal, lpdwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6923,7 +6923,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueueUserWorkItem", "ptr", Function, ContextMarshal, Context, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -6954,7 +6954,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\UnregisterWaitEx", "ptr", WaitHandle, "ptr", CompletionEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7007,7 +7007,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateTimerQueueTimer", "ptr", phNewTimer, "ptr", TimerQueue, "ptr", Callback, ParameterMarshal, Parameter, "uint", DueTime, "uint", Period, "uint", Flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7042,7 +7042,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ChangeTimerQueueTimer", "ptr", TimerQueue, "ptr", Timer, "uint", DueTime, "uint", Period, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7082,7 +7082,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DeleteTimerQueueTimer", "ptr", TimerQueue, "ptr", Timer, "ptr", CompletionEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7105,7 +7105,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DeleteTimerQueue", "ptr", TimerQueue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7137,7 +7137,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DeleteTimerQueueEx", "ptr", TimerQueue, "ptr", CompletionEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7201,7 +7201,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetThreadpoolThreadMinimum", "ptr", ptpp, "uint", cthrdMic, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7224,7 +7224,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetThreadpoolStackInformation", "ptr", ptpp, "ptr", ptpsi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7247,7 +7247,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryThreadpoolStackInformation", "ptr", ptpp, "ptr", ptpsi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7510,7 +7510,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\TrySubmitThreadpoolCallback", "ptr", pfns, pvMarshal, pv, "ptr", pcbe, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8037,7 +8037,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\IsWow64Process", "ptr", hProcess, Wow64ProcessMarshal, Wow64Process, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8075,7 +8075,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\IsWow64Process2", "ptr", hProcess, pProcessMachineMarshal, pProcessMachine, pNativeMachineMarshal, pNativeMachine, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8198,7 +8198,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\AddSIDToBoundaryDescriptor", "ptr", BoundaryDescriptor, "ptr", RequiredSid, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8238,7 +8238,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNumaHighestNodeNumber", HighestNodeNumberMarshal, HighestNodeNumber, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8669,7 +8669,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("AVRT.dll\AvRevertMmThreadCharacteristics", "ptr", AvrtHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8692,7 +8692,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("AVRT.dll\AvSetMmThreadPriority", "ptr", AvrtHandle, "int", Priority, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8732,7 +8732,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("AVRT.dll\AvRtCreateThreadOrderingGroup", "ptr", Context, PeriodMarshal, Period, "ptr", ThreadOrderingGuid, TimeoutMarshal, Timeout, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8775,7 +8775,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("AVRT.dll\AvRtCreateThreadOrderingGroupExA", "ptr", Context, PeriodMarshal, Period, "ptr", ThreadOrderingGuid, TimeoutMarshal, Timeout, "ptr", TaskName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8818,7 +8818,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("AVRT.dll\AvRtCreateThreadOrderingGroupExW", "ptr", Context, PeriodMarshal, Period, "ptr", ThreadOrderingGuid, TimeoutMarshal, Timeout, "ptr", TaskName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8840,7 +8840,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("AVRT.dll\AvRtJoinThreadOrderingGroup", "ptr", Context, "ptr", ThreadOrderingGuid, "int", Before, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8862,7 +8862,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("AVRT.dll\AvRtWaitOnThreadOrderingGroup", "ptr", Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8884,7 +8884,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("AVRT.dll\AvRtLeaveThreadOrderingGroup", "ptr", Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8906,7 +8906,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("AVRT.dll\AvRtDeleteThreadOrderingGroup", "ptr", Context, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8931,7 +8931,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("AVRT.dll\AvQuerySystemResponsiveness", "ptr", AvrtHandle, SystemResponsivenessValueMarshal, SystemResponsivenessValue, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9658,7 +9658,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("USER32.dll\IsImmersiveProcess", "ptr", hProcess, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9678,7 +9678,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetProcessRestrictionExemption", "int", fEnableExemption, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9712,7 +9712,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetProcessAffinityMask", "ptr", hProcess, lpProcessAffinityMaskMarshal, lpProcessAffinityMask, lpSystemAffinityMaskMarshal, lpSystemAffinityMask, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9742,7 +9742,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetProcessAffinityMask", "ptr", hProcess, "ptr", dwProcessAffinityMask, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9769,7 +9769,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetProcessIoCounters", "ptr", hProcess, "ptr", lpIoCounters, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9848,7 +9848,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ConvertFiberToThread", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9995,7 +9995,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateUmsCompletionList", UmsCompletionListMarshal, UmsCompletionList, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10041,7 +10041,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DequeueUmsCompletionListItems", UmsCompletionListMarshal, UmsCompletionList, "uint", WaitTimeOut, UmsThreadListMarshal, UmsThreadList, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10063,7 +10063,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetUmsCompletionListEvent", UmsCompletionListMarshal, UmsCompletionList, "ptr", UmsCompletionEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10102,7 +10102,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\ExecuteUmsThread", UmsThreadMarshal, UmsThread, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10123,7 +10123,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\UmsThreadYield", SchedulerParamMarshal, SchedulerParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10144,7 +10144,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DeleteUmsCompletionList", UmsCompletionListMarshal, UmsCompletionList, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10242,7 +10242,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryUmsThreadInformation", UmsThreadMarshal, UmsThread, "int", UmsThreadInfoClass, "ptr", UmsThreadInformation, "uint", UmsThreadInformationLength, ReturnLengthMarshal, ReturnLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10296,7 +10296,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetUmsThreadInformation", UmsThreadMarshal, UmsThread, "int", UmsThreadInfoClass, UmsThreadInformationMarshal, UmsThreadInformation, "uint", UmsThreadInformationLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10317,7 +10317,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DeleteUmsThreadContext", UmsThreadMarshal, UmsThread, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10356,7 +10356,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\CreateUmsThreadContext", lpUmsThreadMarshal, lpUmsThread, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10375,7 +10375,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\EnterUmsSchedulingMode", "ptr", SchedulerStartupInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10441,7 +10441,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetProcessDEPPolicy", "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10509,7 +10509,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetProcessDEPPolicy", "ptr", hProcess, lpFlagsMarshal, lpFlags, lpPermanentMarshal, lpPermanent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10539,7 +10539,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\PulseEvent", "ptr", hEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10893,7 +10893,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryFullProcessImageNameA", "ptr", hProcess, "uint", dwFlags, "ptr", lpExeName, lpdwSizeMarshal, lpdwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10922,7 +10922,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryFullProcessImageNameW", "ptr", hProcess, "uint", dwFlags, "ptr", lpExeName, lpdwSizeMarshal, lpdwSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11071,7 +11071,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CreateProcessWithLogonW", "ptr", lpUsername, "ptr", lpDomain, "ptr", lpPassword, "uint", dwLogonFlags, "ptr", lpApplicationName, "ptr", lpCommandLine, "uint", dwCreationFlags, lpEnvironmentMarshal, lpEnvironment, "ptr", lpCurrentDirectory, "ptr", lpStartupInfo, "ptr", lpProcessInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11203,7 +11203,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\CreateProcessWithTokenW", "ptr", hToken, "uint", dwLogonFlags, "ptr", lpApplicationName, "ptr", lpCommandLine, "uint", dwCreationFlags, lpEnvironmentMarshal, lpEnvironment, "ptr", lpCurrentDirectory, "ptr", lpStartupInfo, "ptr", lpProcessInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11242,7 +11242,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\RegisterWaitForSingleObject", "ptr", phNewWaitObject, "ptr", hObject, "ptr", Callback, ContextMarshal, Context, "uint", dwMilliseconds, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11265,7 +11265,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\UnregisterWait", "ptr", WaitHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11394,7 +11394,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\AddIntegrityLabelToBoundaryDescriptor", "ptr", BoundaryDescriptor, "ptr", IntegrityLabel, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11483,7 +11483,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNumaProcessorNode", "char", Processor, NodeNumberMarshal, NodeNumber, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11507,7 +11507,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNumaNodeNumberFromHandle", "ptr", hFile, NodeNumberMarshal, NodeNumber, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11529,7 +11529,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNumaProcessorNodeEx", "ptr", Processor, NodeNumberMarshal, NodeNumber, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11556,7 +11556,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNumaNodeProcessorMask", "char", Node, ProcessorMaskMarshal, ProcessorMask, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11579,7 +11579,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNumaAvailableMemoryNode", "char", Node, AvailableBytesMarshal, AvailableBytes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11601,7 +11601,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNumaAvailableMemoryNodeEx", "ushort", Node, AvailableBytesMarshal, AvailableBytes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11623,7 +11623,7 @@ class Threading {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetNumaProximityNode", "uint", ProximityId, NodeNumberMarshal, NodeNumber, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/Time/Apis.ahk
+++ b/Windows/Win32/System/Time/Apis.ahk
@@ -91,7 +91,7 @@ class Time {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SystemTimeToTzSpecificLocalTime", "ptr", lpTimeZoneInformation, "ptr", lpUniversalTime, "ptr", lpLocalTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -119,7 +119,7 @@ class Time {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\TzSpecificLocalTimeToSystemTime", "ptr", lpTimeZoneInformation, "ptr", lpLocalTime, "ptr", lpUniversalTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -144,7 +144,7 @@ class Time {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FileTimeToSystemTime", "ptr", lpFileTime, "ptr", lpSystemTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -176,7 +176,7 @@ class Time {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SystemTimeToFileTime", "ptr", lpSystemTime, "ptr", lpFileTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -268,7 +268,7 @@ class Time {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetTimeZoneInformation", "ptr", lpTimeZoneInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -288,7 +288,7 @@ class Time {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetDynamicTimeZoneInformation", "ptr", lpTimeZoneInformation, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -380,7 +380,7 @@ class Time {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetTimeZoneInformationForYear", "ushort", wYear, "ptr", pdtzi, "ptr", ptzi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -488,7 +488,7 @@ class Time {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SystemTimeToTzSpecificLocalTimeEx", "ptr", lpTimeZoneInformation, "ptr", lpUniversalTime, "ptr", lpLocalTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -510,7 +510,7 @@ class Time {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\TzSpecificLocalTimeToSystemTimeEx", "ptr", lpTimeZoneInformation, "ptr", lpLocalTime, "ptr", lpUniversalTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/System/WindowsProgramming/Apis.ahk
+++ b/Windows/Win32/System/WindowsProgramming/Apis.ahk
@@ -3051,7 +3051,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryThreadCycleTime", "ptr", ThreadHandle, CycleTimeMarshal, CycleTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3077,7 +3077,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryProcessCycleTime", "ptr", ProcessHandle, CycleTimeMarshal, CycleTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3102,7 +3102,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\QueryIdleProcessorCycleTime", BufferLengthMarshal, BufferLength, "ptr", ProcessorIdleCycleTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3544,7 +3544,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetSystemRegistryQuota", pdwQuotaAllowedMarshal, pdwQuotaAllowed, pdwQuotaUsedMarshal, pdwQuotaUsed, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3612,7 +3612,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\FileTimeToDosDateTime", "ptr", lpFileTime, lpFatDateMarshal, lpFatDate, lpFatTimeMarshal, lpFatTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3677,7 +3677,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DosDateTimeToFileTime", "ushort", wFatDate, "ushort", wFatTime, "ptr", lpFileTime, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3960,7 +3960,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFirmwareEnvironmentVariableA", "ptr", lpName, "ptr", lpGuid, "ptr", pValue, "uint", nSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -3986,7 +3986,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFirmwareEnvironmentVariableW", "ptr", lpName, "ptr", lpGuid, "ptr", pValue, "uint", nSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4105,7 +4105,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFirmwareEnvironmentVariableExA", "ptr", lpName, "ptr", lpGuid, "ptr", pValue, "uint", nSize, "uint", dwAttributes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4224,7 +4224,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\SetFirmwareEnvironmentVariableExW", "ptr", lpName, "ptr", lpGuid, "ptr", pValue, "uint", nSize, "uint", dwAttributes, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4246,7 +4246,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\IsNativeVhdBoot", NativeVhdBootMarshal, NativeVhdBoot, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4370,7 +4370,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteProfileStringA", "ptr", lpAppName, "ptr", lpKeyName, "ptr", lpString, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4396,7 +4396,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteProfileStringW", "ptr", lpAppName, "ptr", lpKeyName, "ptr", lpString, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4468,7 +4468,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteProfileSectionA", "ptr", lpAppName, "ptr", lpString, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4494,7 +4494,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WriteProfileSectionW", "ptr", lpAppName, "ptr", lpString, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4646,7 +4646,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WritePrivateProfileStringA", "ptr", lpAppName, "ptr", lpKeyName, "ptr", lpString, "ptr", lpFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4676,7 +4676,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WritePrivateProfileStringW", "ptr", lpAppName, "ptr", lpKeyName, "ptr", lpString, "ptr", lpFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4748,7 +4748,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WritePrivateProfileSectionA", "ptr", lpAppName, "ptr", lpString, "ptr", lpFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4776,7 +4776,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WritePrivateProfileSectionW", "ptr", lpAppName, "ptr", lpString, "ptr", lpFileName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4884,7 +4884,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WritePrivateProfileStructA", "ptr", lpszSection, "ptr", lpszKey, "ptr", lpStruct, "uint", uSizeStruct, "ptr", szFile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4914,7 +4914,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\WritePrivateProfileStructW", "ptr", lpszSection, "ptr", lpszKey, "ptr", lpStruct, "uint", uSizeStruct, "ptr", szFile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -4970,7 +4970,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetComputerNameA", "ptr", lpBuffer, nSizeMarshal, nSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5000,7 +5000,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\GetComputerNameW", "ptr", lpBuffer, nSizeMarshal, nSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5050,7 +5050,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DnsHostnameToComputerNameA", "ptr", Hostname, "ptr", ComputerName, nSizeMarshal, nSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5100,7 +5100,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("KERNEL32.dll\DnsHostnameToComputerNameW", "ptr", Hostname, "ptr", ComputerName, nSizeMarshal, nSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5130,7 +5130,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetUserNameA", "ptr", lpBuffer, pcbBufferMarshal, pcbBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5160,7 +5160,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetUserNameW", "ptr", lpBuffer, pcbBufferMarshal, pcbBuffer, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5193,7 +5193,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetCurrentHwProfileA", "ptr", lpHwProfileInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5214,7 +5214,7 @@ class WindowsProgramming {
         A_LastError := 0
 
         result := DllCall("ADVAPI32.dll\GetCurrentHwProfileW", "ptr", lpHwProfileInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/UI/Accessibility/Apis.ahk
+++ b/Windows/Win32/UI/Accessibility/Apis.ahk
@@ -5672,7 +5672,7 @@ class Accessibility {
         A_LastError := 0
 
         result := DllCall("USER32.dll\RegisterPointerInputTarget", "ptr", hwnd, "int", pointerType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -5694,7 +5694,7 @@ class Accessibility {
         A_LastError := 0
 
         result := DllCall("USER32.dll\UnregisterPointerInputTarget", "ptr", hwnd, "int", pointerType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/UI/Controls/Apis.ahk
+++ b/Windows/Win32/UI/Controls/Apis.ahk
@@ -17062,7 +17062,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CheckDlgButton", "ptr", hDlg, "int", nIDButton, "uint", uCheck, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17096,7 +17096,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CheckRadioButton", "ptr", hDlg, "int", nIDFirstButton, "int", nIDLastButton, "int", nIDCheckButton, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17204,7 +17204,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\RegisterTouchHitTestingWindow", "ptr", hwnd, "uint", value, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17225,7 +17225,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EvaluateProximityToRect", "ptr", controlBoundingBox, "ptr", pHitTestingInput, "ptr", pProximityEval, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17251,7 +17251,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EvaluateProximityToPolygon", "uint", numVertices, "ptr", controlPolygon, "ptr", pHitTestingInput, "ptr", pProximityEval, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17381,7 +17381,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetScrollRange", "ptr", hWnd, "int", nBar, "int", nMinPos, "int", nMaxPos, "int", bRedraw, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17411,7 +17411,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ShowScrollBar", "ptr", hWnd, "int", wBar, "int", bShow, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17439,7 +17439,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EnableScrollBar", "ptr", hWnd, "uint", wSBflags, "uint", wArrows, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17553,7 +17553,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DlgDirSelectExA", "ptr", hwndDlg, "ptr", lpString, "int", chCount, "int", idListBox, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17590,7 +17590,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DlgDirSelectExW", "ptr", hwndDlg, "ptr", lpString, "int", chCount, "int", idListBox, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17715,7 +17715,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DlgDirSelectComboBoxExA", "ptr", hwndDlg, "ptr", lpString, "int", cchOut, "int", idComboBox, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17752,7 +17752,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DlgDirSelectComboBoxExW", "ptr", hwndDlg, "ptr", lpString, "int", cchOut, "int", idComboBox, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17811,7 +17811,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetComboBoxInfo", "ptr", hwndCombo, "ptr", pcbi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17854,7 +17854,7 @@ class Controls {
         A_LastError := 0
 
         result := DllCall("USER32.dll\RegisterPointerDeviceNotifications", "ptr", window, "int", notifyRange, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/UI/HiDpi/Apis.ahk
+++ b/Windows/Win32/UI/HiDpi/Apis.ahk
@@ -70,7 +70,7 @@ class HiDpi {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetDialogControlDpiChangeBehavior", "ptr", hWnd, "int", mask, "int", values, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -112,7 +112,7 @@ class HiDpi {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetDialogDpiChangeBehavior", "ptr", hDlg, "int", mask, "int", values, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -174,7 +174,7 @@ class HiDpi {
         A_LastError := 0
 
         result := DllCall("USER32.dll\AdjustWindowRectExForDpi", "ptr", lpRect, "uint", dwStyle, "int", bMenu, "uint", dwExStyle, "uint", dpi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -229,7 +229,7 @@ class HiDpi {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SystemParametersInfoForDpi", "uint", uiAction, "uint", uiParam, pvParamMarshal, pvParam, "uint", fWinIni, "uint", dpi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -384,7 +384,7 @@ class HiDpi {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EnableNonClientDpiScaling", "ptr", hwnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -405,7 +405,7 @@ class HiDpi {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetProcessDpiAwarenessContext", "ptr", value, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/UI/Input/Apis.ahk
+++ b/Windows/Win32/UI/Input/Apis.ahk
@@ -177,7 +177,7 @@ class Input {
         A_LastError := 0
 
         result := DllCall("USER32.dll\RegisterRawInputDevices", "ptr", pRawInputDevices, "uint", uiNumDevices, "uint", cbSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -285,7 +285,7 @@ class Input {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetCurrentInputMessageSource", "ptr", inputMessageSource, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/UI/Input/KeyboardAndMouse/Apis.ahk
+++ b/Windows/Win32/UI/Input/KeyboardAndMouse/Apis.ahk
@@ -903,7 +903,7 @@ class KeyboardAndMouse {
         A_LastError := 0
 
         result := DllCall("USER32.dll\UnloadKeyboardLayout", "ptr", hkl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -928,7 +928,7 @@ class KeyboardAndMouse {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetKeyboardLayoutNameA", "ptr", pwszKLID, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -953,7 +953,7 @@ class KeyboardAndMouse {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetKeyboardLayoutNameW", "ptr", pwszKLID, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1060,7 +1060,7 @@ class KeyboardAndMouse {
         A_LastError := 0
 
         result := DllCall("USER32.dll\TrackMouseEvent", "ptr", lpEventTrack, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1094,7 +1094,7 @@ class KeyboardAndMouse {
         A_LastError := 0
 
         result := DllCall("USER32.dll\RegisterHotKey", "ptr", hWnd, "int", id, "uint", fsModifiers, "uint", vk, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1122,7 +1122,7 @@ class KeyboardAndMouse {
         A_LastError := 0
 
         result := DllCall("USER32.dll\UnregisterHotKey", "ptr", hWnd, "int", id, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1174,7 +1174,7 @@ class KeyboardAndMouse {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetDoubleClickTime", "uint", param0, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1312,7 +1312,7 @@ class KeyboardAndMouse {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetKeyboardState", lpKeyStateMarshal, lpKeyState, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -1337,7 +1337,7 @@ class KeyboardAndMouse {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetKeyboardState", lpKeyStateMarshal, lpKeyState, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2561,7 +2561,7 @@ class KeyboardAndMouse {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ReleaseCapture", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -2675,7 +2675,7 @@ class KeyboardAndMouse {
         A_LastError := 0
 
         result := DllCall("USER32.dll\BlockInput", "int", fBlockIt, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/UI/Input/Pointer/Apis.ahk
+++ b/Windows/Win32/UI/Input/Pointer/Apis.ahk
@@ -40,7 +40,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\InitializeTouchInjection", "uint", maxCount, "uint", dwMode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -62,7 +62,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\InjectTouchInput", "uint", count, "ptr", contacts, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -84,7 +84,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerType", "uint", pointerId, pointerTypeMarshal, pointerType, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -106,7 +106,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerCursorId", "uint", pointerId, cursorIdMarshal, cursorId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -126,7 +126,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerInfo", "uint", pointerId, "ptr", pointerInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -149,7 +149,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerInfoHistory", "uint", pointerId, entriesCountMarshal, entriesCount, "ptr", pointerInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -172,7 +172,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerFrameInfo", "uint", pointerId, pointerCountMarshal, pointerCount, "ptr", pointerInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -199,7 +199,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerFrameInfoHistory", "uint", pointerId, entriesCountMarshal, entriesCount, pointerCountMarshal, pointerCount, "ptr", pointerInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -219,7 +219,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerTouchInfo", "uint", pointerId, "ptr", touchInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -242,7 +242,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerTouchInfoHistory", "uint", pointerId, entriesCountMarshal, entriesCount, "ptr", touchInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -265,7 +265,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerFrameTouchInfo", "uint", pointerId, pointerCountMarshal, pointerCount, "ptr", touchInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -292,7 +292,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerFrameTouchInfoHistory", "uint", pointerId, entriesCountMarshal, entriesCount, pointerCountMarshal, pointerCount, "ptr", touchInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -312,7 +312,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerPenInfo", "uint", pointerId, "ptr", penInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -344,7 +344,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerPenInfoHistory", "uint", pointerId, entriesCountMarshal, entriesCount, "ptr", penInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -367,7 +367,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerFramePenInfo", "uint", pointerId, pointerCountMarshal, pointerCount, "ptr", penInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -395,7 +395,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerFramePenInfoHistory", "uint", pointerId, entriesCountMarshal, entriesCount, pointerCountMarshal, pointerCount, "ptr", penInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -414,7 +414,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SkipPointerFrameMessages", "uint", pointerId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -447,7 +447,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\InjectSyntheticPointerInput", "ptr", device, "ptr", pointerInfo, "uint", count, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -479,7 +479,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EnableMouseInPointer", "int", fEnable, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -517,7 +517,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerInputTransform", "uint", pointerId, "uint", historyCount, "ptr", inputTransform, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -539,7 +539,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerDevices", deviceCountMarshal, deviceCount, "ptr", pointerDevices, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -561,7 +561,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerDevice", "ptr", device, "ptr", pointerDevice, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -590,7 +590,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerDeviceProperties", "ptr", device, propertyCountMarshal, propertyCount, "ptr", pointerProperties, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -611,7 +611,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerDeviceRects", "ptr", device, "ptr", pointerDeviceRect, "ptr", displayRect, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -634,7 +634,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPointerDeviceCursors", "ptr", device, cursorCountMarshal, cursorCount, "ptr", deviceCursors, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -657,7 +657,7 @@ class Pointer {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetRawPointerDeviceData", "uint", pointerId, "uint", historyCount, "uint", propertiesCount, "ptr", pProperties, pValuesMarshal, pValues, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/UI/Input/Touch/Apis.ahk
+++ b/Windows/Win32/UI/Input/Touch/Apis.ahk
@@ -28,7 +28,7 @@ class Touch {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetTouchInputInfo", "ptr", hTouchInput, "uint", cInputs, "ptr", pInputs, "int", cbSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -52,7 +52,7 @@ class Touch {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CloseTouchInputHandle", "ptr", hTouchInput, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -77,7 +77,7 @@ class Touch {
         A_LastError := 0
 
         result := DllCall("USER32.dll\RegisterTouchWindow", "ptr", hwnd, "uint", ulFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -101,7 +101,7 @@ class Touch {
         A_LastError := 0
 
         result := DllCall("USER32.dll\UnregisterTouchWindow", "ptr", hwnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -143,7 +143,7 @@ class Touch {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetGestureInfo", "ptr", hGestureInfo, "ptr", pGestureInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -169,7 +169,7 @@ class Touch {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetGestureExtraArgs", "ptr", hGestureInfo, "uint", cbExtraArgs, "ptr", pExtraArgs, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -193,7 +193,7 @@ class Touch {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CloseGestureInfoHandle", "ptr", hGestureInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -221,7 +221,7 @@ class Touch {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetGestureConfig", "ptr", hwnd, "uint", dwReserved, "uint", cIDs, "ptr", pGestureConfig, "uint", cbSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -252,7 +252,7 @@ class Touch {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetGestureConfig", "ptr", hwnd, "uint", dwReserved, "uint", dwFlags, pcIDsMarshal, pcIDs, "ptr", pGestureConfig, "uint", cbSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/UI/Magnification/Apis.ahk
+++ b/Windows/Win32/UI/Magnification/Apis.ahk
@@ -387,7 +387,7 @@ class Magnification {
         A_LastError := 0
 
         result := DllCall("MAGNIFICATION.dll\MagSetInputTransform", "int", fEnabled, "ptr", pRectSource, "ptr", pRectDest, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/UI/Shell/Apis.ahk
+++ b/Windows/Win32/UI/Shell/Apis.ahk
@@ -8102,7 +8102,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\LoadUserProfileA", "ptr", hToken, "ptr", lpProfileInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8132,7 +8132,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\LoadUserProfileW", "ptr", hToken, "ptr", lpProfileInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8159,7 +8159,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\UnloadUserProfile", "ptr", hToken, "ptr", hProfile, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8191,7 +8191,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\GetProfilesDirectoryA", "ptr", lpProfileDir, lpcchSizeMarshal, lpcchSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8223,7 +8223,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\GetProfilesDirectoryW", "ptr", lpProfileDir, lpcchSizeMarshal, lpcchSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8244,7 +8244,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\GetProfileType", dwFlagsMarshal, dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8281,7 +8281,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\DeleteProfileA", "ptr", lpSidString, "ptr", lpProfilePath, "ptr", lpComputerName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8318,7 +8318,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\DeleteProfileW", "ptr", lpSidString, "ptr", lpProfilePath, "ptr", lpComputerName, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8411,7 +8411,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\GetDefaultUserProfileDirectoryA", "ptr", lpProfileDir, lpcchSizeMarshal, lpcchSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8443,7 +8443,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\GetDefaultUserProfileDirectoryW", "ptr", lpProfileDir, lpcchSizeMarshal, lpcchSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8475,7 +8475,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\GetAllUsersProfileDirectoryA", "ptr", lpProfileDir, lpcchSizeMarshal, lpcchSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8507,7 +8507,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\GetAllUsersProfileDirectoryW", "ptr", lpProfileDir, lpcchSizeMarshal, lpcchSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8543,7 +8543,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\GetUserProfileDirectoryA", "ptr", hToken, "ptr", lpProfileDir, lpcchSizeMarshal, lpcchSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8579,7 +8579,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USERENV.dll\GetUserProfileDirectoryW", "ptr", hToken, "ptr", lpProfileDir, lpcchSizeMarshal, lpcchSize, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8831,7 +8831,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetWindowContextHelpId", "ptr", param0, "uint", param1, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8871,7 +8871,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetMenuContextHelpId", "ptr", param0, "uint", param1, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8924,7 +8924,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USER32.dll\WinHelpA", "ptr", hWndMain, "ptr", lpszHelp, "uint", uCommand, "ptr", dwData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8961,7 +8961,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("USER32.dll\WinHelpW", "ptr", hWndMain, "ptr", lpszHelp, "uint", uCommand, "ptr", dwData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16013,7 +16013,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("SHELL32.dll\ShellExecuteExA", "ptr", pExecInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16034,7 +16034,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("SHELL32.dll\ShellExecuteExW", "ptr", pExecInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16055,7 +16055,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("SHELL32.dll\SHCreateProcessAsUserW", "ptr", pscpi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19499,7 +19499,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("SHLWAPI.dll\PathCanonicalizeA", "ptr", pszBuf, "ptr", pszPath, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19526,7 +19526,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("SHLWAPI.dll\PathCanonicalizeW", "ptr", pszBuf, "ptr", pszPath, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19755,7 +19755,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("SHLWAPI.dll\PathFileExistsA", "ptr", pszPath, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19778,7 +19778,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("SHLWAPI.dll\PathFileExistsW", "ptr", pszPath, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26227,7 +26227,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("SHLWAPI.dll\SHFreeShared", "ptr", hData, "uint", dwProcessId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26269,7 +26269,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("SHLWAPI.dll\SHUnlockShared", pvDataMarshal, pvData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26571,7 +26571,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("SHLWAPI.dll\SHCreateThread", "ptr", pfnThreadProc, pDataMarshal, pData, "uint", flags, "ptr", pfnCallback, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26606,7 +26606,7 @@ class Shell {
         A_LastError := 0
 
         result := DllCall("SHLWAPI.dll\SHCreateThreadWithHandle", "ptr", pfnThreadProc, pDataMarshal, pData, "uint", flags, "ptr", pfnCallback, "ptr", pHandle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result

--- a/Windows/Win32/UI/WindowsAndMessaging/Apis.ahk
+++ b/Windows/Win32/UI/WindowsAndMessaging/Apis.ahk
@@ -7661,7 +7661,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetMessageA", "ptr", lpMsg, "ptr", hWnd, "uint", wMsgFilterMin, "uint", wMsgFilterMax, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -7739,7 +7739,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetMessageW", "ptr", lpMsg, "ptr", hWnd, "uint", wMsgFilterMin, "uint", wMsgFilterMax, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8153,7 +8153,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SendNotifyMessageA", "ptr", hWnd, "uint", Msg, "ptr", wParam, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8189,7 +8189,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SendNotifyMessageW", "ptr", hWnd, "uint", Msg, "ptr", wParam, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8235,7 +8235,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SendMessageCallbackA", "ptr", hWnd, "uint", Msg, "ptr", wParam, "ptr", lParam, "ptr", lpResultCallBack, "ptr", dwData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8281,7 +8281,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SendMessageCallbackW", "ptr", hWnd, "uint", Msg, "ptr", wParam, "ptr", lParam, "ptr", lpResultCallBack, "ptr", dwData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8374,7 +8374,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\UnregisterDeviceNotification", "ptr", Handle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8442,7 +8442,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\PostMessageA", "ptr", hWnd, "uint", Msg, "ptr", wParam, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8510,7 +8510,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\PostMessageW", "ptr", hWnd, "uint", Msg, "ptr", wParam, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8550,7 +8550,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\PostThreadMessageA", "uint", idThread, "uint", Msg, "ptr", wParam, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8590,7 +8590,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\PostThreadMessageW", "uint", idThread, "uint", Msg, "ptr", wParam, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8628,7 +8628,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\WaitMessage", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8923,7 +8923,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\UnregisterClassA", "ptr", lpClassName, "ptr", hInstance, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8952,7 +8952,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\UnregisterClassW", "ptr", lpClassName, "ptr", hInstance, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -8987,7 +8987,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetClassInfoA", "ptr", hInstance, "ptr", lpClassName, "ptr", lpWndClass, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9022,7 +9022,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetClassInfoW", "ptr", hInstance, "ptr", lpClassName, "ptr", lpWndClass, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9097,7 +9097,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetClassInfoExA", "ptr", hInstance, "ptr", lpszClass, "ptr", lpwcx, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9130,7 +9130,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetClassInfoExW", "ptr", hInstance, "ptr", lpszClass, "ptr", lpwcx, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9381,7 +9381,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DestroyWindow", "ptr", hWnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9440,7 +9440,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\AnimateWindow", "ptr", hWnd, "uint", dwTime, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9493,7 +9493,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\UpdateLayeredWindow", "ptr", hWnd, "ptr", hdcDst, "ptr", pptDst, "ptr", psize, "ptr", hdcSrc, "ptr", pptSrc, "uint", crKey, "ptr", pblend, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9542,7 +9542,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetLayeredWindowAttributes", "ptr", hwnd, pcrKeyMarshal, pcrKey, pbAlphaMarshal, pbAlpha, pdwFlagsMarshal, pdwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9578,7 +9578,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetLayeredWindowAttributes", "ptr", hwnd, "uint", crKey, "char", bAlpha, "uint", dwFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9662,7 +9662,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ShowOwnedPopups", "ptr", hWnd, "int", fShow, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9687,7 +9687,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\OpenIcon", "ptr", hWnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9712,7 +9712,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CloseWindow", "ptr", hWnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9752,7 +9752,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\MoveWindow", "ptr", hWnd, "int", X, "int", Y, "int", nWidth, "int", nHeight, "int", bRepaint, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9792,7 +9792,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetWindowPos", "ptr", hWnd, "ptr", hWndInsertAfter, "int", X, "int", Y, "int", cx, "int", cy, "uint", uFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9820,7 +9820,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetWindowPlacement", "ptr", hWnd, "ptr", lpwndpl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9850,7 +9850,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetWindowPlacement", "ptr", hWnd, "ptr", lpwndpl, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9881,7 +9881,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetWindowDisplayAffinity", "ptr", hWnd, pdwAffinityMarshal, pdwAffinity, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -9907,7 +9907,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetWindowDisplayAffinity", "ptr", hWnd, "uint", dwAffinity, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10001,7 +10001,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EndDeferWindowPos", "ptr", hWinPosInfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10081,7 +10081,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\BringWindowToTop", "ptr", hWnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10461,7 +10461,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EndDialog", "ptr", hDlg, "ptr", nResult, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10523,7 +10523,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetDlgItemInt", "ptr", hDlg, "int", nIDDlgItem, "uint", uValue, "int", bSigned, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10599,7 +10599,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetDlgItemTextA", "ptr", hDlg, "int", nIDDlgItem, "ptr", lpString, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -10631,7 +10631,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetDlgItemTextW", "ptr", hDlg, "int", nIDDlgItem, "ptr", lpString, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11001,7 +11001,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CharToOemA", "ptr", pSrc, "ptr", pDst, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11033,7 +11033,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CharToOemW", "ptr", pSrc, "ptr", pDst, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11065,7 +11065,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\OemToCharA", "ptr", pSrc, "ptr", pDst, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11097,7 +11097,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\OemToCharW", "ptr", pSrc, "ptr", pDst, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11127,7 +11127,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CharToOemBuffA", "ptr", lpszSrc, "ptr", lpszDst, "uint", cchDstLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11157,7 +11157,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CharToOemBuffW", "ptr", lpszSrc, "ptr", lpszDst, "uint", cchDstLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11194,7 +11194,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\OemToCharBuffA", "ptr", lpszSrc, "ptr", lpszDst, "uint", cchDstLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11231,7 +11231,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\OemToCharBuffW", "ptr", lpszSrc, "ptr", lpszDst, "uint", cchDstLength, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11706,7 +11706,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\IsCharAlphaA", "char", ch, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11729,7 +11729,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\IsCharAlphaW", "char", ch, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11752,7 +11752,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\IsCharAlphaNumericA", "char", ch, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11775,7 +11775,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\IsCharAlphaNumericW", "char", ch, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11798,7 +11798,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\IsCharUpperA", "char", ch, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11821,7 +11821,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\IsCharUpperW", "char", ch, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11844,7 +11844,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\IsCharLowerA", "char", ch, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -11866,7 +11866,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\IsCharLowerW", "char", ch, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12247,7 +12247,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\KillTimer", "ptr", hWnd, "ptr", uIDEvent, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -12681,7 +12681,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetMenu", "ptr", hWnd, "ptr", hMenu, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13028,7 +13028,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DrawMenuBar", "ptr", hWnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13114,7 +13114,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DestroyMenu", "ptr", hMenu, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13385,7 +13385,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\InsertMenuA", "ptr", hMenu, "uint", uPosition, "uint", uFlags, "ptr", uIDNewItem, "ptr", lpNewItem, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13492,7 +13492,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\InsertMenuW", "ptr", hMenu, "uint", uPosition, "uint", uFlags, "ptr", uIDNewItem, "ptr", lpNewItem, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13563,7 +13563,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\AppendMenuA", "ptr", hMenu, "uint", uFlags, "ptr", uIDNewItem, "ptr", lpNewItem, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13634,7 +13634,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\AppendMenuW", "ptr", hMenu, "uint", uFlags, "ptr", uIDNewItem, "ptr", lpNewItem, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13742,7 +13742,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ModifyMenuA", "ptr", hMnu, "uint", uPosition, "uint", uFlags, "ptr", uIDNewItem, "ptr", lpNewItem, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13850,7 +13850,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ModifyMenuW", "ptr", hMnu, "uint", uPosition, "uint", uFlags, "ptr", uIDNewItem, "ptr", lpNewItem, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13879,7 +13879,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\RemoveMenu", "ptr", hMenu, "uint", uPosition, "uint", uFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13908,7 +13908,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DeleteMenu", "ptr", hMenu, "uint", uPosition, "uint", uFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -13945,7 +13945,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetMenuItemBitmaps", "ptr", hMenu, "uint", uPosition, "uint", uFlags, "ptr", hBitmapUnchecked, "ptr", hBitmapChecked, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14237,7 +14237,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\TrackPopupMenu", "ptr", hMenu, "uint", uFlags, "int", x, "int", y, "int", nReserved, "ptr", hWnd, "ptr", prcRect, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14548,7 +14548,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\TrackPopupMenuEx", "ptr", hMenu, "uint", uFlags, "int", x, "int", y, "ptr", hwnd, "ptr", lptpm, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14763,7 +14763,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CalculatePopupWindowPosition", "ptr", anchorPoint, "ptr", windowSize, "uint", flags, "ptr", excludeRect, "ptr", popupWindowPosition, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14787,7 +14787,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetMenuInfo", "ptr", param0, "ptr", param1, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14811,7 +14811,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetMenuInfo", "ptr", param0, "ptr", param1, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14831,7 +14831,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EndMenu", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14865,7 +14865,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\InsertMenuItemA", "ptr", hmenu, "uint", item, "int", fByPosition, "ptr", lpmi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14899,7 +14899,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\InsertMenuItemW", "ptr", hmenu, "uint", item, "int", fByPosition, "ptr", lpmi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14933,7 +14933,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetMenuItemInfoA", "ptr", hmenu, "uint", item, "int", fByPosition, "ptr", lpmii, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -14967,7 +14967,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetMenuItemInfoW", "ptr", hmenu, "uint", item, "int", fByPosition, "ptr", lpmii, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15001,7 +15001,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetMenuItemInfoA", "ptr", hmenu, "uint", item, "int", fByPositon, "ptr", lpmii, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15035,7 +15035,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetMenuItemInfoW", "ptr", hmenu, "uint", item, "int", fByPositon, "ptr", lpmii, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15096,7 +15096,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetMenuDefaultItem", "ptr", hMenu, "uint", uItem, "uint", fByPos, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15136,7 +15136,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetMenuItemRect", "ptr", hWnd, "ptr", hMenu, "uint", uItem, "ptr", lprcItem, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15214,7 +15214,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DrawIcon", "ptr", hDC, "int", X, "int", Y, "ptr", hIcon, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15299,7 +15299,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\AllowSetForegroundWindow", "uint", dwProcessId, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15320,7 +15320,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\LockSetForegroundWindow", "uint", uLockCode, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15358,7 +15358,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ScrollWindow", "ptr", hWnd, "int", XAmount, "int", YAmount, "ptr", lpRect, "ptr", lpClipRect, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15406,7 +15406,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ScrollDC", "ptr", hDC, "int", dx, "int", dy, "ptr", lprcScroll, "ptr", lprcClip, "ptr", hrgnUpdate, "ptr", lprcUpdate, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15515,7 +15515,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetScrollRange", "ptr", hWnd, "int", nBar, lpMinPosMarshal, lpMinPos, lpMaxPosMarshal, lpMaxPos, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15548,7 +15548,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetPropA", "ptr", hWnd, "ptr", lpString, "ptr", hData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15581,7 +15581,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetPropW", "ptr", hWnd, "ptr", lpString, "ptr", hData, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15798,7 +15798,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetWindowTextA", "ptr", hWnd, "ptr", lpString, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15827,7 +15827,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetWindowTextW", "ptr", hWnd, "ptr", lpString, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -15979,7 +15979,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetClientRect", "ptr", hWnd, "ptr", lpRect, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16007,7 +16007,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetWindowRect", "ptr", hWnd, "ptr", lpRect, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16036,7 +16036,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\AdjustWindowRect", "ptr", lpRect, "uint", dwStyle, "int", bMenu, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -16068,7 +16068,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\AdjustWindowRectEx", "ptr", lpRect, "uint", dwStyle, "int", bMenu, "uint", dwExStyle, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17002,7 +17002,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetCursorPos", "int", X, "int", Y, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17026,7 +17026,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetPhysicalCursorPos", "int", X, "int", Y, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17067,7 +17067,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetCursorPos", "ptr", lpPoint, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17091,7 +17091,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetPhysicalCursorPos", "ptr", lpPoint, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17114,7 +17114,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetClipCursor", "ptr", lpRect, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17165,7 +17165,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CreateCaret", "ptr", hWnd, "ptr", hBitmap, "int", nWidth, "int", nHeight, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17212,7 +17212,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetCaretBlinkTime", "uint", uMSeconds, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17232,7 +17232,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DestroyCaret", "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17257,7 +17257,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\HideCaret", "ptr", hWnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17282,7 +17282,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ShowCaret", "ptr", hWnd, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17308,7 +17308,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetCaretPos", "int", X, "int", Y, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17332,7 +17332,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetCaretPos", "ptr", lpPoint, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17480,7 +17480,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ClipCursor", "ptr", lpRect, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17921,7 +17921,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetProcessDefaultLayout", pdwDefaultLayoutMarshal, pdwDefaultLayout, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -17962,7 +17962,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetProcessDefaultLayout", "uint", dwDefaultLayout, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -18301,7 +18301,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\EnumWindows", "ptr", lpEnumFunc, "ptr", lParam, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -18629,7 +18629,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\UnhookWindowsHookEx", "ptr", hhk, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -18693,7 +18693,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\CheckMenuRadioItem", "ptr", hmenu, "uint", first, "uint", last, "uint", check, "uint", flags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19282,7 +19282,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DestroyCursor", "ptr", hCursor, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19310,7 +19310,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SetSystemCursor", "ptr", hcur, "uint", id, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19551,7 +19551,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DestroyIcon", "ptr", hIcon, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19907,7 +19907,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\DrawIconEx", "ptr", hdc, "int", xLeft, "int", yTop, "ptr", hIcon, "int", cxWidth, "int", cyWidth, "uint", istepIfAniCur, "ptr", hbrFlickerFreeDraw, "uint", diFlags, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -19981,7 +19981,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetIconInfo", "ptr", hIcon, "ptr", piconinfo, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20093,7 +20093,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\MapDialogRect", "ptr", hDlg, "ptr", lpRect, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -20128,7 +20128,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetScrollInfo", "ptr", hwnd, "int", nBar, "ptr", lpsi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -23322,7 +23322,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SystemParametersInfoA", "uint", uiAction, "uint", uiParam, pvParamMarshal, pvParam, "uint", fWinIni, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26175,7 +26175,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\SystemParametersInfoW", "uint", uiAction, "uint", uiParam, pvParamMarshal, pvParam, "uint", fWinIni, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26295,7 +26295,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetGUIThreadInfo", "uint", idThread, "ptr", pgui, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26408,7 +26408,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetCursorInfo", "ptr", pci, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26438,7 +26438,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetWindowInfo", "ptr", hwnd, "ptr", pwi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26466,7 +26466,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetTitleBarInfo", "ptr", hwnd, "ptr", pti, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26498,7 +26498,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetMenuBarInfo", "ptr", hwnd, "int", idObject, "int", idItem, "ptr", pmbi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26532,7 +26532,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetScrollBarInfo", "ptr", hwnd, "int", idObject, "ptr", psbi, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26668,7 +26668,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetAltTabInfoA", "ptr", hwnd, "int", iItem, "ptr", pati, "ptr", pszItemText, "uint", cchItemText, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26706,7 +26706,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\GetAltTabInfoW", "ptr", hwnd, "int", iItem, "ptr", pati, "ptr", pszItemText, "uint", cchItemText, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26733,7 +26733,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ChangeWindowMessageFilter", "uint", message, "uint", dwFlag, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result
@@ -26763,7 +26763,7 @@ class WindowsAndMessaging {
         A_LastError := 0
 
         result := DllCall("USER32.dll\ChangeWindowMessageFilterEx", "ptr", hwnd, "uint", message, "uint", action, "ptr", pChangeFilterStruct, "int")
-        if(A_LastError)
+        if(!result && A_LastError)
             throw OSError()
 
         return result


### PR DESCRIPTION
BOOL-returning functions will sometimes succeed but still set LastError which causes the projection to erroneously throw.

Now, if a function returns a Bool and has [SetsLastError], we will also check the return value of the DllCall and only throw an OSError if it's falsy AND LastError != 0

Generator: https://github.com/holy-tao/AhkWin32Structs-Generator/commit/facd755e3c25e92088152311d62d530f01edbb11

Fixes #88