### PR TITLE
Use assembly version instead of metadata in version.ini

### DIFF
--- a/version.ini
+++ b/version.ini
@@ -1,7 +1,6 @@
-# The metadata version as reported in the actual metadata file
-metadata = v4.0.30319
+[Assemblies]
+Windows.Win32 = 0.0.0.0
 
-# NuGet package versions used to generate files
 [Packages]
 Microsoft.Windows.SDK.Win32Docs = 0.1.8-alpha
 Microsoft.Windows.SDK.Win32Metadata = 68.0.4-preview


### PR DESCRIPTION
Changes the version.ini file to use the assembly version instead of internal metadata version. This isn't very useful for Win32, but WinRT has many assemblies and assembly information is more useful than metadata information in that case.

Comes bundled with  [generator changes](https://github.com/holy-tao/AhkWin32Structs-Generator/commit/b425b7b504b891390931ce8c42a46e49082b7454) to allow generation off of multiple .winmd files; a foundational change required for eventual generation of WinRT bindings.