### PR TITLE
Don't generate invalid free functions

### DIFF
--- a/Windows/Win32/Foundation/PSTR.ahk
+++ b/Windows/Win32/Foundation/PSTR.ahk
@@ -32,6 +32,9 @@ class PSTR extends Win32Struct
         if(!(str is String))
             throw TypeError("Expected a String but got a(n) " . str, , str)
     
+        if(str == "")
+            str := Chr(0)
+    
         requiredLen := StrPut(str, "CP0")
         buffLen := buffLen ?? requiredLen
     

--- a/Windows/Win32/Foundation/PWSTR.ahk
+++ b/Windows/Win32/Foundation/PWSTR.ahk
@@ -34,7 +34,7 @@ class PWSTR extends Win32Struct
     
         if(str == "")
             str := Chr(0)
-
+    
         requiredLen := StrPut(str, "UTF-16")
         buffLen := buffLen ?? requiredLen
     

--- a/Windows/Win32/Media/Audio/HACMDRIVER.ahk
+++ b/Windows/Win32/Media/Audio/HACMDRIVER.ahk
@@ -1,6 +1,5 @@
 #Requires AutoHotkey v2.0.0 64-bit
 #Include ..\..\..\..\Win32Struct.ahk
-#Include .\Apis.ahk
 #Include ..\..\..\..\Win32Handle.ahk
 
 /**
@@ -25,10 +24,5 @@ class HACMDRIVER extends Win32Handle
     Value {
         get => NumGet(this, 0, "ptr")
         set => NumPut("ptr", value, this, 0)
-    }
-
-    Free(){
-        Audio.acmDriverClose(this.Value)
-        this.Value := -1
     }
 }

--- a/Windows/Win32/Media/Audio/HACMSTREAM.ahk
+++ b/Windows/Win32/Media/Audio/HACMSTREAM.ahk
@@ -1,6 +1,5 @@
 #Requires AutoHotkey v2.0.0 64-bit
 #Include ..\..\..\..\Win32Struct.ahk
-#Include .\Apis.ahk
 #Include ..\..\..\..\Win32Handle.ahk
 
 /**
@@ -25,10 +24,5 @@ class HACMSTREAM extends Win32Handle
     Value {
         get => NumGet(this, 0, "ptr")
         set => NumPut("ptr", value, this, 0)
-    }
-
-    Free(){
-        Audio.acmStreamClose(this.Value)
-        this.Value := -1
     }
 }

--- a/Windows/Win32/Security/Cryptography/Apis.ahk
+++ b/Windows/Win32/Security/Cryptography/Apis.ahk
@@ -2,7 +2,6 @@
 #Include ..\..\..\..\Win32Handle.ahk
 #Include ..\..\..\..\Guid.ahk
 #Include .\HCERTSTORE.ahk
-#Include .\Apis.ahk
 #Include .\BCRYPT_ALG_HANDLE.ahk
 
 /**

--- a/Windows/Win32/Security/Cryptography/BCRYPT_ALG_HANDLE.ahk
+++ b/Windows/Win32/Security/Cryptography/BCRYPT_ALG_HANDLE.ahk
@@ -1,6 +1,5 @@
 #Requires AutoHotkey v2.0.0 64-bit
 #Include ..\..\..\..\Win32Struct.ahk
-#Include .\Apis.ahk
 #Include ..\..\..\..\Win32Handle.ahk
 
 /**
@@ -25,10 +24,5 @@ class BCRYPT_ALG_HANDLE extends Win32Handle
     Value {
         get => NumGet(this, 0, "ptr")
         set => NumPut("ptr", value, this, 0)
-    }
-
-    Free(){
-        Cryptography.BCryptCloseAlgorithmProvider(this.Value)
-        this.Value := 0
     }
 }

--- a/Windows/Win32/Storage/Jet/JET_SESID.ahk
+++ b/Windows/Win32/Storage/Jet/JET_SESID.ahk
@@ -1,6 +1,5 @@
 #Requires AutoHotkey v2.0.0 64-bit
 #Include ..\..\..\..\Win32Struct.ahk
-#Include .\Apis.ahk
 #Include ..\..\..\..\Win32Handle.ahk
 
 /**
@@ -27,10 +26,5 @@ class JET_SESID extends Win32Handle
     Value {
         get => NumGet(this, 0, "ptr")
         set => NumPut("ptr", value, this, 0)
-    }
-
-    Free(){
-        Jet.JetEndSession(this.Value)
-        this.Value := 0
     }
 }

--- a/Windows/Win32/System/LibraryLoader/Apis.ahk
+++ b/Windows/Win32/System/LibraryLoader/Apis.ahk
@@ -3061,7 +3061,6 @@ class LibraryLoader {
         }
 
         resultHandle := HANDLE({Value: result}, True)
-        resultHandle.DefineProp("Free", { Call: (self) => LibraryLoader.EndUpdateResourceA(self.Value) })
         return resultHandle
     }
 
@@ -3096,7 +3095,6 @@ class LibraryLoader {
         }
 
         resultHandle := HANDLE({Value: result}, True)
-        resultHandle.DefineProp("Free", { Call: (self) => LibraryLoader.EndUpdateResourceW(self.Value) })
         return resultHandle
     }
 

--- a/Windows/Win32/System/Performance/PDH_HLOG.ahk
+++ b/Windows/Win32/System/Performance/PDH_HLOG.ahk
@@ -1,6 +1,5 @@
 #Requires AutoHotkey v2.0.0 64-bit
 #Include ..\..\..\..\Win32Struct.ahk
-#Include .\Apis.ahk
 #Include ..\..\..\..\Win32Handle.ahk
 
 /**
@@ -25,10 +24,5 @@ class PDH_HLOG extends Win32Handle
     Value {
         get => NumGet(this, 0, "ptr")
         set => NumPut("ptr", value, this, 0)
-    }
-
-    Free(){
-        Performance.PdhCloseLog(this.Value)
-        this.Value := -1
     }
 }

--- a/Windows/Win32/System/Threading/Apis.ahk
+++ b/Windows/Win32/System/Threading/Apis.ahk
@@ -10593,7 +10593,6 @@ class Threading {
 
         result := DllCall("KERNEL32.dll\CreatePrivateNamespaceW", "ptr", lpPrivateNamespaceAttributes, lpBoundaryDescriptorMarshal, lpBoundaryDescriptor, "ptr", lpAliasPrefix, "ptr")
         resultHandle := HANDLE({Value: result}, True)
-        resultHandle.DefineProp("Free", { Call: (self) => Threading.ClosePrivateNamespace(self.Value) })
         return resultHandle
     }
 
@@ -10613,7 +10612,6 @@ class Threading {
 
         result := DllCall("KERNEL32.dll\OpenPrivateNamespaceW", lpBoundaryDescriptorMarshal, lpBoundaryDescriptor, "ptr", lpAliasPrefix, "ptr")
         resultHandle := HANDLE({Value: result}, True)
-        resultHandle.DefineProp("Free", { Call: (self) => Threading.ClosePrivateNamespace(self.Value) })
         return resultHandle
     }
 
@@ -14843,7 +14841,6 @@ class Threading {
         }
 
         resultHandle := HANDLE({Value: result}, True)
-        resultHandle.DefineProp("Free", { Call: (self) => Threading.ClosePrivateNamespace(self.Value) })
         return resultHandle
     }
 
@@ -14864,7 +14861,6 @@ class Threading {
 
         result := DllCall("KERNEL32.dll\OpenPrivateNamespaceA", lpBoundaryDescriptorMarshal, lpBoundaryDescriptor, "ptr", lpAliasPrefix, "ptr")
         resultHandle := HANDLE({Value: result}, True)
-        resultHandle.DefineProp("Free", { Call: (self) => Threading.ClosePrivateNamespace(self.Value) })
         return resultHandle
     }
 


### PR DESCRIPTION
Previously, handles with `[RAIIFree]` or `[FreeWith]` attributes would blindly call the function named in the attribute, assuming that it both took only one argument (See #101 for an example). In a few cases, this turns out to be untrue, and the automatic freeing logic would cause errors to be thrown. This is true of the changes in #93 but also of the original handle implementation in #45.

Now, we only generate free functions for handles if we can tell for certain that it's safe to call the function with the handle as its only argument.

Fixes #101 