### PR TITLE
Update Win32 Metadata to v69.0.7-preview

### DIFF
--- a/Windows/Win32/Globalization/Apis.ahk
+++ b/Windows/Win32/Globalization/Apis.ahk
@@ -33,6 +33,31 @@ class Globalization {
     /**
      * @type {Integer (UInt32)}
      */
+    static LOCALE_CUSTOM_DEFAULT => 3072
+
+    /**
+     * @type {Integer (UInt32)}
+     */
+    static LOCALE_CUSTOM_UNSPECIFIED => 4096
+
+    /**
+     * @type {Integer (UInt32)}
+     */
+    static LOCALE_CUSTOM_UI_DEFAULT => 5120
+
+    /**
+     * @type {Integer (UInt32)}
+     */
+    static LOCALE_NEUTRAL => 0
+
+    /**
+     * @type {Integer (UInt32)}
+     */
+    static LOCALE_INVARIANT => 127
+
+    /**
+     * @type {Integer (UInt32)}
+     */
     static ALL_SERVICE_TYPES => 0
 
     /**

--- a/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/Apis.ahk
@@ -2989,7 +2989,7 @@ class WindowsFilteringPlatform {
      * @param {Pointer<FWPM_SESSION0>} session Type: [FWPM_SESSION0](/windows/win32/api/fwpmtypes/ns-fwpmtypes-fwpm_session0)*</b>
      * 
      * Session-specific parameters for the session being opened. This pointer is optional and can be <b>NULL</b>.
-     * @param {Pointer<HANDLE>} engineHandle Type: <b>HANDLE*</b>
+     * @param {Pointer<FWPM_ENGINE_HANDLE>} engineHandle Type: <b>HANDLE*</b>
      * 
      * Handle for the open session to the filter engine.
      * @returns {Integer} Type: <b>DWORD</b>
@@ -3068,7 +3068,7 @@ class WindowsFilteringPlatform {
      * If this function is called with a transaction in progress, the transaction will be aborted.
      * 
      * <b>FwpmEngineClose0</b> is a specific implementation of FwpmEngineClose. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @returns {Integer} Type: <b>DWORD</b>
@@ -3133,7 +3133,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the filter engine. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmEngineGetOption0</b> is a specific implementation of FwpmEngineGetOption. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} option Type: [FWPM_ENGINE_OPTION](/windows/desktop/api/fwpmtypes/ne-fwpmtypes-fwpm_engine_option)</b>
@@ -3265,7 +3265,7 @@ class WindowsFilteringPlatform {
      * Disabling and re-enabling of network event collection (FWPM_ENGINE_COLLECT_NET_EVENTS) does not reset the collection of inbound broadcast and multicast events.
      * 
      * <b>FwpmEngineSetOption0</b> is a specific implementation of FwpmEngineSetOption. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} option Type: [FWPM_ENGINE_OPTION](/windows/desktop/api/fwpmtypes/ne-fwpmtypes-fwpm_engine_option)</b>
@@ -3370,7 +3370,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	<a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-getsecurityinfo">GetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>GetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmEngineGetSecurityInfo0</b> is a specific implementation of FwpmEngineGetSecurityInfo. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -3459,7 +3459,7 @@ class WindowsFilteringPlatform {
      * <b>FwpmEngineSetSecurityInfo0</b> behaves like the standard Win32 	 <a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>SetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmEngineSetSecurityInfo0</b> is a specific implementation of FwpmEngineSetSecurityInfo. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -3544,7 +3544,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ENUM</a> access to the filter engine. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmSessionCreateEnumHandle0</b> is a specific implementation of FwpmSessionCreateEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_SESSION_ENUM_TEMPLATE0>} enumTemplate Type: [FWPM_SESSION_ENUM_TEMPLATE0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_session_enum_template0)*</b>
@@ -3619,7 +3619,7 @@ class WindowsFilteringPlatform {
      * <b>FwpmSessionEnum0</b> works on a snapshot of the sessions taken at the time the enumeration handle was created.
      * 
      * <b>FwpmSessionEnum0</b> is a specific implementation of FwpmSessionEnum. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -3696,7 +3696,7 @@ class WindowsFilteringPlatform {
      * Frees a handle returned by FwpmSessionCreateEnumHandle0.
      * @remarks
      * <b>FwpmSessionDestroyEnumHandle0</b> is a specific implementation of FwpmSessionDestroyEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -3766,7 +3766,7 @@ class WindowsFilteringPlatform {
      * For a read-only transaction, the caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_BEGIN_READ_TXN</a> access to the filter engine. For a read/write transaction, the caller needs <b>FWPM_ACTRL_BEGIN_WRITE_TXN</b> access to the filter engine. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmTransactionBegin0</b> is a specific implementation of FwpmTransactionBegin. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} flags Type: <b>UINT32</b>
@@ -3861,7 +3861,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_NO_TXN_IN_PROGRESS</b>.
      * 
      * <b>FwpmTransactionCommit0</b> is a specific implementation of FwpmTransactionCommit. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @returns {Integer} Type: <b>DWORD</b>
@@ -3925,7 +3925,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_NO_TXN_IN_PROGRESS</b>.
      * 
      * <b>FwpmTransactionAbort0</b> is a specific implementation of FwpmTransactionAbort. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @returns {Integer} Type: <b>DWORD</b>
@@ -4000,7 +4000,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ADD</a> access to the provider's container.  See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmProviderAdd0</b> is a specific implementation of FwpmProviderAdd. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_PROVIDER0>} provider Type: [FWPM_PROVIDER0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_provider0)*</b>
@@ -4075,7 +4075,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/standard-access-rights">DELETE</a> access to the provider. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmProviderDeleteByKey0</b> is a specific implementation of FwpmProviderDeleteByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -4143,7 +4143,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the provider. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmProviderGetByKey0</b> is a specific implementation of FwpmProviderGetByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -4220,7 +4220,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ENUM</a> access to the providers' containers and <b>FWPM_ACTRL_READ</b> access to the providers. Only providers to which the caller has <b>FWPM_ACTRL_READ</b> access will be returned. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmProviderCreateEnumHandle0</b> is a specific implementation of FwpmProviderCreateEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_PROVIDER_ENUM_TEMPLATE0>} enumTemplate Type: [FWPM_PROVIDER_ENUM_TEMPLATE0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_provider_enum_template0)*</b>
@@ -4295,7 +4295,7 @@ class WindowsFilteringPlatform {
      * <b>FwpmProviderEnum0</b> works on a snapshot of the providers taken at the time the enumeration handle was created.
      * 
      * <b>FwpmProviderEnum0</b> is a specific implementation of FwpmProviderEnum. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -4372,7 +4372,7 @@ class WindowsFilteringPlatform {
      * Frees a handle returned by FwpmProviderCreateEnumHandle0.
      * @remarks
      * <b>FwpmProviderDestroyEnumHandle0</b> is a specific implementation of FwpmProviderDestroyEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -4443,7 +4443,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	<a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-getsecurityinfo">GetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>GetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmProviderGetSecurityInfoByKey0</b> is a specific implementation of FwpmProviderGetSecurityInfoByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -4539,7 +4539,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	 <a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>SetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmProviderSetSecurityInfoByKey0</b> is a specific implementation of FwpmProviderSetSecurityInfoByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -4627,7 +4627,7 @@ class WindowsFilteringPlatform {
      *    <b>FWPM_ACTRL_READ</b> access. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmProviderSubscribeChanges0</b> is a specific implementation of FwpmProviderSubscribeChanges. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_PROVIDER_SUBSCRIPTION0>} subscription Type: [FWPM_PROVIDER_SUBSCRIPTION0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_provider_subscription0)*</b>
@@ -4709,7 +4709,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * <b>FwpmProviderUnsubscribeChanges0</b> is a specific implementation of FwpmProviderUnsubscribeChanges. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} changeHandle Type: <b>HANDLE</b>
@@ -4778,7 +4778,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the provider's container. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmProviderSubscriptionsGet0</b> is a specific implementation of FwpmProviderSubscriptionsGet. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Pointer<Pointer<FWPM_PROVIDER_SUBSCRIPTION0>>>} entries Type: [FWPM_PROVIDER_SUBSCRIPTION0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_provider_subscription0)***</b>
@@ -4855,7 +4855,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_INCOMPATIBLE_TXN</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ADD</a> access to the provider context's container and <b>FWPM_ACTRL_ADD_LINK</b> access to the provider (if any).  See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_PROVIDER_CONTEXT0>} providerContext Type: [FWPM_PROVIDER_CONTEXT0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_provider_context0)*</b>
@@ -4948,7 +4948,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_INCOMPATIBLE_TXN</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ADD</a> access to the provider context's container and <b>FWPM_ACTRL_ADD_LINK</b> access to the provider (if any).  See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_PROVIDER_CONTEXT1>} providerContext Type: [FWPM_PROVIDER_CONTEXT1](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_provider_context1)*</b>
@@ -5041,7 +5041,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_INCOMPATIBLE_TXN</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ADD</a> access to the provider context's container and <b>FWPM_ACTRL_ADD_LINK</b> access to the provider (if any).  See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_PROVIDER_CONTEXT2>} providerContext Type: [FWPM_PROVIDER_CONTEXT2](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_provider_context2)*</b>
@@ -5125,7 +5125,7 @@ class WindowsFilteringPlatform {
 
     /**
      * 
-     * @param {HANDLE} engineHandle 
+     * @param {FWPM_ENGINE_HANDLE} engineHandle 
      * @param {Pointer<FWPM_PROVIDER_CONTEXT3>} providerContext 
      * @param {PSECURITY_DESCRIPTOR} sd 
      * @param {Pointer<Integer>} id 
@@ -5152,7 +5152,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/standard-access-rights">DELETE</a> access to the provider context. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmProviderContextDeleteById0</b> is a specific implementation of FwpmProviderContextDeleteById. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -5223,7 +5223,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/standard-access-rights">DELETE</a> access to the provider context. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmProviderContextDeleteByKey0</b> is a specific implementation of FwpmProviderContextDeleteByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -5289,7 +5289,7 @@ class WindowsFilteringPlatform {
      * The caller must free the returned object by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the provider context. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -5360,7 +5360,7 @@ class WindowsFilteringPlatform {
      * The caller must free the returned object by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the provider context. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -5431,7 +5431,7 @@ class WindowsFilteringPlatform {
      * The caller must free the returned object by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the provider context. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -5498,7 +5498,7 @@ class WindowsFilteringPlatform {
 
     /**
      * 
-     * @param {HANDLE} engineHandle 
+     * @param {FWPM_ENGINE_HANDLE} engineHandle 
      * @param {Integer} id 
      * @param {Pointer<Pointer<FWPM_PROVIDER_CONTEXT3>>} providerContext 
      * @returns {Integer} 
@@ -5518,7 +5518,7 @@ class WindowsFilteringPlatform {
      * The caller must free the returned object by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the provider context. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -5589,7 +5589,7 @@ class WindowsFilteringPlatform {
      * The caller must free the returned object by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the provider context. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -5660,7 +5660,7 @@ class WindowsFilteringPlatform {
      * The caller must free the returned object by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the provider context. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -5727,7 +5727,7 @@ class WindowsFilteringPlatform {
 
     /**
      * 
-     * @param {HANDLE} engineHandle 
+     * @param {FWPM_ENGINE_HANDLE} engineHandle 
      * @param {Pointer<Guid>} key 
      * @param {Pointer<Pointer<FWPM_PROVIDER_CONTEXT3>>} providerContext 
      * @returns {Integer} 
@@ -5753,7 +5753,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ENUM</a> access to the provider contexts' containers and <b>FWPM_ACTRL_READ</b> access to the provider contexts. Only provider contexts to which the caller has <b>FWPM_ACTRL_READ</b> access will be returned. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmProviderContextCreateEnumHandle0</b> is a specific implementation of FwpmProviderContextCreateEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_PROVIDER_CONTEXT_ENUM_TEMPLATE0>} enumTemplate Type: <b>const <a href="https://docs.microsoft.com/windows/win32/api/fwpmtypes/ns-fwpmtypes-fwpm_provider_context_enum_template0">FWPM_PROVIDER_CONTEXT_ENUM_TEMPLATE0</a>*</b>
@@ -5826,7 +5826,7 @@ class WindowsFilteringPlatform {
      * A subsequent call using the same enumeration handle will return the next set of items following those in the last output buffer.
      * 
      * <b>FwpmProviderContextEnum0</b> works on a snapshot of the provider contexts taken at the time the enumeration handle was created.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -5909,7 +5909,7 @@ class WindowsFilteringPlatform {
      * A subsequent call using the same enumeration handle will return the next set of items following those in the last output buffer.
      * 
      * <b>FwpmProviderContextEnum1</b> works on a snapshot of the provider contexts taken at the time the enumeration handle was created.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -5992,7 +5992,7 @@ class WindowsFilteringPlatform {
      * A subsequent call using the same enumeration handle will return the next set of items following those in the last output buffer.
      * 
      * <b>FwpmProviderContextEnum2</b> works on a snapshot of the provider contexts taken at the time the enumeration handle was created.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -6067,7 +6067,7 @@ class WindowsFilteringPlatform {
 
     /**
      * 
-     * @param {HANDLE} engineHandle 
+     * @param {FWPM_ENGINE_HANDLE} engineHandle 
      * @param {HANDLE} enumHandle 
      * @param {Integer} numEntriesRequested 
      * @param {Pointer<Pointer<Pointer<FWPM_PROVIDER_CONTEXT3>>>} entries 
@@ -6089,7 +6089,7 @@ class WindowsFilteringPlatform {
      * Frees a handle returned by FwpmProviderContextCreateEnumHandle0.
      * @remarks
      * <b>FwpmProviderContextDestroyEnumHandle0</b> is a specific implementation of FwpmProviderContextDestroyEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -6160,7 +6160,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	<a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-getsecurityinfo">GetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>GetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmProviderContextGetSecurityInfoByKey0</b> is a specific implementation of FwpmProviderContextGetSecurityInfoByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -6256,7 +6256,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	 <a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>SetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmProviderContextSetSecurityInfoByKey0</b> is a specific implementation of FwpmProviderContextSetSecurityInfoByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -6344,7 +6344,7 @@ class WindowsFilteringPlatform {
      *    <b>FWPM_ACTRL_READ</b> access. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmProviderContextSubscribeChanges0</b> is a specific implementation of FwpmProviderContextSubscribeChanges. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_PROVIDER_CONTEXT_SUBSCRIPTION0>} subscription Type: <b>const <a href="https://docs.microsoft.com/windows/win32/api/fwpmtypes/ns-fwpmtypes-fwpm_provider_context_subscription0">FWPM_PROVIDER_CONTEXT_SUBSCRIPTION0</a>*</b>
@@ -6426,7 +6426,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * <b>FwpmProviderContextUnsubscribeChanges0</b> is a specific implementation of FwpmProviderContextUnsubscribeChanges. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} changeHandle Type: <b>HANDLE</b>
@@ -6495,7 +6495,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the provider context's container. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmProviderContextSubscriptionsGet0</b> is a specific implementation of FwpmProviderContextSubscriptionsGet. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Pointer<Pointer<FWPM_PROVIDER_CONTEXT_SUBSCRIPTION0>>>} entries Type: <b><a href="https://docs.microsoft.com/windows/win32/api/fwpmtypes/ns-fwpmtypes-fwpm_provider_context_subscription0">FWPM_PROVIDER_CONTEXT_SUBSCRIPTION0</a>***</b>
@@ -6572,7 +6572,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ADD</a> access to the sublayers's container and <b>FWPM_ACTRL_ADD_LINK</b> access to the provider (if any).  See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmSubLayerAdd0</b> is a specific implementation of FwpmSubLayerAdd. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_SUBLAYER0>} subLayer Type: [FWPM_SUBLAYER0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_sublayer0)*</b>
@@ -6647,7 +6647,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/standard-access-rights">DELETE</a> access to the sub-layer. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmSubLayerDeleteByKey0</b> is a specific implementation of FwpmSubLayerDeleteByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -6715,7 +6715,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the sublayer. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmSubLayerGetByKey0</b> is a specific implementation of FwpmSubLayerGetByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -6792,7 +6792,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ENUM</a> access to the sublayers' containers and <b>FWPM_ACTRL_READ</b> access to the sub-layers. Only sublayers to which the caller has <b>FWPM_ACTRL_READ</b> access will be returned. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmSubLayerCreateEnumHandle0</b> is a specific implementation of FwpmSubLayerCreateEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_SUBLAYER_ENUM_TEMPLATE0>} enumTemplate Type: [FWPM_SUBLAYER_ENUM_TEMPLATE0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_sublayer_enum_template0)*</b>
@@ -6867,7 +6867,7 @@ class WindowsFilteringPlatform {
      * <b>FwpmSubLayerEnum0</b> works on a snapshot of the sublayers taken at the time the enumeration handle was created.
      * 
      * <b>FwpmSubLayerEnum0</b> is a specific implementation of FwpmSubLayerEnum. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -6944,7 +6944,7 @@ class WindowsFilteringPlatform {
      * Frees a handle returned by FwpmSubLayerCreateEnumHandle0.
      * @remarks
      * <b>FwpmSubLayerDestroyEnumHandle0</b> is a specific implementation of FwpmSubLayerDestroyEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -7015,7 +7015,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	<a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-getsecurityinfo">GetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>GetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmSubLayerGetSecurityInfoByKey0</b> is a specific implementation of FwpmSubLayerGetSecurityInfoByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -7111,7 +7111,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	 <a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>SetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmSubLayerSetSecurityInfoByKey0</b> is a specific implementation of FwpmSubLayerSetSecurityInfoByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -7199,7 +7199,7 @@ class WindowsFilteringPlatform {
      *    <b>FWPM_ACTRL_READ</b> access. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmSubLayerSubscribeChanges0</b> is a specific implementation of FwpmSubLayerSubscribeChanges. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_SUBLAYER_SUBSCRIPTION0>} subscription Type: [FWPM_SUBLAYER_SUBSCRIPTION0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_sublayer_subscription0)*</b>
@@ -7281,7 +7281,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * <b>FwpmSubLayerUnsubscribeChanges0</b> is a specific implementation of FwpmSubLayerUnsubscribeChanges. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} changeHandle Type: <b>HANDLE</b>
@@ -7350,7 +7350,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the sublayer's container. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmSubLayerSubscriptionsGet0</b> is a specific implementation of FwpmSubLayerSubscriptionsGet. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Pointer<Pointer<FWPM_SUBLAYER_SUBSCRIPTION0>>>} entries Type: [FWPM_SUBLAYER_SUBSCRIPTION0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_sublayer_subscription0)***</b>
@@ -7424,7 +7424,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the layer. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmLayerGetById0</b> is a specific implementation of FwpmLayerGetById. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT16</b>
@@ -7497,7 +7497,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the layer. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmLayerGetByKey0</b> is a specific implementation of FwpmLayerGetByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -7574,7 +7574,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ENUM</a> access to the layers' containers and <b>FWPM_ACTRL_READ</b> access to the layers. Only layers to which the caller has <b>FWPM_ACTRL_READ</b> access will be returned. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmLayerCreateEnumHandle0</b> is a specific implementation of FwpmLayerCreateEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_LAYER_ENUM_TEMPLATE0>} enumTemplate Type: [FWPM_LAYER_ENUM_TEMPLATE0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_layer_enum_template0)*</b>
@@ -7647,7 +7647,7 @@ class WindowsFilteringPlatform {
      * A subsequent call using the same enumeration handle will return the next set of items following those in the last output buffer.
      * 
      * <b>FwpmLayerEnum0</b> is a specific implementation of FwpmLayerEnum. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -7724,7 +7724,7 @@ class WindowsFilteringPlatform {
      * Frees a handle returned by FwpmFilterCreateEnumHandle0. (FwpmLayerDestroyEnumHandle0)
      * @remarks
      * <b>FwpmLayerDestroyEnumHandle0</b> is a specific implementation of FwpmLayerDestroyEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -7795,7 +7795,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	<a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-getsecurityinfo">GetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>GetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmLayerGetSecurityInfoByKey0</b> is a specific implementation of FwpmLayerGetSecurityInfoByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -7889,7 +7889,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	 <a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>SetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmLayerSetSecurityInfoByKey0</b> is a specific implementation of FwpmLayerSetSecurityInfoByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -7987,7 +7987,7 @@ class WindowsFilteringPlatform {
      * By default filters that reference callouts that have been added but have not yet registered with the filter engine are treated as Block filters.
      * 
      * <b>FwpmCalloutAdd0</b> is a specific implementation of FwpmCalloutAdd. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_CALLOUT0>} callout Type: [FWPM_CALLOUT0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_callout0)*</b>
@@ -8082,7 +8082,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/standard-access-rights">DELETE</a> access to the callout. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmCalloutDeleteById0</b> is a specific implementation of FwpmCalloutDeleteById. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT32</b>
@@ -8155,7 +8155,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/standard-access-rights">DELETE</a> access to the callout. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmCalloutDeleteByKey0</b> is a specific implementation of FwpmCalloutDeleteByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -8223,7 +8223,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the callout. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmCalloutGetById0</b> is a specific implementation of FwpmCalloutGetById. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT32</b>
@@ -8296,7 +8296,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the callout. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmCalloutGetByKey0</b> is a specific implementation of FwpmCalloutGetByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -8373,7 +8373,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ENUM</a> access to the callouts' containers and <b>FWPM_ACTRL_READ</b> access to the callouts. Only callouts to which the caller has <b>FWPM_ACTRL_READ</b> access will be returned. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmCalloutCreateEnumHandle0</b> is a specific implementation of FwpmCalloutCreateEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_CALLOUT_ENUM_TEMPLATE0>} enumTemplate Type: [FWPM_CALLOUT_ENUM_TEMPLATE0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_callout_enum_template0)*</b>
@@ -8448,7 +8448,7 @@ class WindowsFilteringPlatform {
      * <b>FwpmCalloutEnum0</b> works on a snapshot of the callouts taken at the time the enumeration handle was created.
      * 
      * <b>FwpmCalloutEnum0</b> is a specific implementation of FwpmCalloutEnum. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -8525,7 +8525,7 @@ class WindowsFilteringPlatform {
      * Frees a handle returned by FwpmCalloutCreateEnumHandle0.
      * @remarks
      * <b>FwpmCalloutDestroyEnumHandle0</b> is a specific implementation of FwpmCalloutDestroyEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -8596,7 +8596,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	<a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-getsecurityinfo">GetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>GetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmCalloutGetSecurityInfoByKey0</b> is a specific implementation of FwpmCalloutGetSecurityInfoByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -8692,7 +8692,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	 <a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>SetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmCalloutSetSecurityInfoByKey0</b> is a specific implementation of FwpmCalloutSetSecurityInfoByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -8780,7 +8780,7 @@ class WindowsFilteringPlatform {
      *    <b>FWPM_ACTRL_READ</b> access. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmCalloutSubscribeChanges0</b> is a specific implementation of FwpmCalloutSubscribeChanges. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_CALLOUT_SUBSCRIPTION0>} subscription Type: [FWPM_CALLOUT_SUBSCRIPTION0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_callout_subscription0)*</b>
@@ -8862,7 +8862,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * <b>FwpmCalloutUnsubscribeChanges0</b> is a specific implementation of FwpmCalloutUnsubscribeChanges. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} changeHandle Type: <b>HANDLE</b>
@@ -8931,7 +8931,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the callout's container. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmCalloutSubscriptionsGet0</b> is a specific implementation of FwpmCalloutSubscriptionsGet. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Pointer<Pointer<FWPM_CALLOUT_SUBSCRIPTION0>>>} entries Type: [FWPM_CALLOUT_SUBSCRIPTION0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_callout_subscription0)***</b>
@@ -9035,7 +9035,7 @@ class WindowsFilteringPlatform {
      * By default filters that reference callouts that have been added but have not yet registered with the filter engine are treated as Block filters.
      * 
      * **FwpmFilterAdd0** is a specific implementation of FwpmFilterAdd. See [WFP Version-Independent Names and Targeting Specific Versions of Windows](/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows)  for more information.
-     * @param {HANDLE} engineHandle Type: **HANDLE**
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: **HANDLE**
      * 
      * Handle for an open session to the filter engine. Call  [FwpmEngineOpen0](nf-fwpmu-fwpmengineopen0.md) to open a session to the filter engine.
      * @param {Pointer<FWPM_FILTER0>} filter Type: **[FWPM_FILTER0](../fwpmtypes/ns-fwpmtypes-fwpm_filter0.md)***
@@ -9080,7 +9080,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/standard-access-rights">DELETE</a> access to the filter. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmFilterDeleteById0</b> is a specific implementation of FwpmFilterDeleteById. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -9151,7 +9151,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/standard-access-rights">DELETE</a> access to the filter. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmFilterDeleteByKey0</b> is a specific implementation of FwpmFilterDeleteByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -9219,7 +9219,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the filter. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmFilterGetById0</b> is a specific implementation of FwpmFilterGetById. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -9292,7 +9292,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the filter. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmFilterGetByKey0</b> is a specific implementation of FwpmFilterGetByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -9369,7 +9369,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ENUM</a> access to the filters' containers and <b>FWPM_ACTRL_READ</b> access to the filters. Only filters to which the caller has <b>FWPM_ACTRL_READ</b> access will be returned. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmFilterCreateEnumHandle0</b> is a specific implementation of FwpmFilterCreateEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_FILTER_ENUM_TEMPLATE0>} enumTemplate Type: [FWPM_FILTER_ENUM_TEMPLATE0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_filter_enum_template0)*</b>
@@ -9444,7 +9444,7 @@ class WindowsFilteringPlatform {
      * <b>FwpmFilterEnum0</b> works on a snapshot of the filters taken at the time the enumeration handle was created.
      * 
      * <b>FwpmFilterEnum0</b> is a specific implementation of FwpmFilterEnum. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -9521,7 +9521,7 @@ class WindowsFilteringPlatform {
      * Frees a handle returned by FwpmFilterCreateEnumHandle0. (FwpmFilterDestroyEnumHandle0)
      * @remarks
      * <b>FwpmFilterDestroyEnumHandle0</b> is a specific implementation of FwpmFilterDestroyEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -9592,7 +9592,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	<a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-getsecurityinfo">GetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>GetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmFilterGetSecurityInfoByKey0</b> is a specific implementation of FwpmFilterGetSecurityInfoByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -9688,7 +9688,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	 <a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>SetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmFilterSetSecurityInfoByKey0</b> is a specific implementation of FwpmFilterSetSecurityInfoByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -9776,7 +9776,7 @@ class WindowsFilteringPlatform {
      *    <b>FWPM_ACTRL_READ</b> access. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmFilterSubscribeChanges0</b> is a specific implementation of FwpmFilterSubscribeChanges. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_FILTER_SUBSCRIPTION0>} subscription Type: [FWPM_FILTER_SUBSCRIPTION0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_filter_subscription0)*</b>
@@ -9858,7 +9858,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * <b>FwpmFilterUnsubscribeChanges0</b> is a specific implementation of FwpmFilterUnsubscribeChanges. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} changeHandle Type: <b>HANDLE</b>
@@ -9927,7 +9927,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the filter's container. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmFilterSubscriptionsGet0</b> is a specific implementation of FwpmFilterSubscriptionsGet. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Pointer<Pointer<FWPM_FILTER_SUBSCRIPTION0>>>} entries Type: [FWPM_FILTER_SUBSCRIPTION0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_filter_subscription0)***</b>
@@ -10066,7 +10066,7 @@ class WindowsFilteringPlatform {
      * @remarks
      * This function cannot be called from within a read-only transaction. It will fail
      * with <b>FWP_E_INCOMPATIBLE_TXN</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * A handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} flags Type: <b>UINT32</b>
@@ -10177,7 +10177,7 @@ class WindowsFilteringPlatform {
      * @remarks
      * This function cannot be called from within a read-only transaction. It will fail
      * with <b>FWP_E_INCOMPATIBLE_TXN</b>.  See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * A handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} flags Type: <b>UINT32</b>
@@ -10303,7 +10303,7 @@ class WindowsFilteringPlatform {
      * @remarks
      * This function cannot be called from within a read-only transaction. It will fail
      * with <b>FWP_E_INCOMPATIBLE_TXN</b>.  See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * A handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} flags Type: <b>UINT32</b>
@@ -10426,7 +10426,7 @@ class WindowsFilteringPlatform {
 
     /**
      * 
-     * @param {HANDLE} engineHandle 
+     * @param {FWPM_ENGINE_HANDLE} engineHandle 
      * @param {Integer} flags 
      * @param {Pointer<FWPM_PROVIDER_CONTEXT3>} mainModePolicy 
      * @param {Pointer<FWPM_PROVIDER_CONTEXT3>} tunnelPolicy 
@@ -10451,7 +10451,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_INCOMPATIBLE_TXN</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * <b>FwpmIPsecTunnelDeleteByKey0</b> is a specific implementation of FwpmIPsecTunnelDeleteByKey. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * A handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Guid>} key Type: <b>const GUID*</b>
@@ -10518,7 +10518,7 @@ class WindowsFilteringPlatform {
      * <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ_STATS</a> access to the IPsec security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<IPSEC_STATISTICS0>} ipsecStatistics Type: [IPSEC_STATISTICS0](/windows/desktop/api/ipsectypes/ns-ipsectypes-ipsec_statistics0)*</b>
@@ -10585,7 +10585,7 @@ class WindowsFilteringPlatform {
      * <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ_STATS</a> access to the IPsec security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<IPSEC_STATISTICS1>} ipsecStatistics Type: [IPSEC_STATISTICS1](/windows/desktop/api/ipsectypes/ns-ipsectypes-ipsec_statistics1)*</b>
@@ -10654,7 +10654,7 @@ class WindowsFilteringPlatform {
      * This function cannot be called from within a dynamic session. The call will fail with <b>FWP_E_DYNAMIC_SESSION_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about dynamic sessions.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ADD</a> access to the IPsec security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<IPSEC_TRAFFIC0>} outboundTraffic Type: [IPSEC_TRAFFIC0](/windows/desktop/api/ipsectypes/ns-ipsectypes-ipsec_traffic0)*</b>
@@ -10732,7 +10732,7 @@ class WindowsFilteringPlatform {
      * This function cannot be called from within a dynamic session. The call will fail with <b>FWP_E_DYNAMIC_SESSION_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about dynamic sessions.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ADD</a> access to the IPsec security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<IPSEC_TRAFFIC1>} outboundTraffic Type: [IPSEC_TRAFFIC1](/windows/desktop/api/ipsectypes/ns-ipsectypes-ipsec_traffic0)*</b>
@@ -10815,7 +10815,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/standard-access-rights">DELETE</a> access to the IPsec security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>IPsecSaContextDeleteById0</b> is a specific implementation of IPsecSaContextDeleteById. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -10881,7 +10881,7 @@ class WindowsFilteringPlatform {
      * The caller must free the returned object, <i>saContext</i>,  by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the IPsec security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -10952,7 +10952,7 @@ class WindowsFilteringPlatform {
      * The caller must free the returned object, <i>saContext</i>,  by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the IPsec security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -11021,7 +11021,7 @@ class WindowsFilteringPlatform {
      * Retrieves the security parameters index (SPI) for a security association (SA) context. (IPsecSaContextGetSpi0)
      * @remarks
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ADD</a> access to the IPsec security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -11093,7 +11093,7 @@ class WindowsFilteringPlatform {
      * Retrieves the security parameters index (SPI) for a security association (SA) context. (IPsecSaContextGetSpi1)
      * @remarks
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ADD</a> access to the IPsec security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -11167,7 +11167,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ADD</a> access to the IPsec security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>IPsecSaContextSetSpi0</b> is a specific implementation of IPsecSaContextSetSpi. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -11235,7 +11235,7 @@ class WindowsFilteringPlatform {
 
     /**
      * The IPsecSaContextAddInbound0 function adds an inbound IPsec security association (SA) bundle to an existing SA context.Note  IPsecSaContextAddInbound0 is the specific implementation of IPsecSaContextAddInbound used in Windows Vista.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -11300,7 +11300,7 @@ class WindowsFilteringPlatform {
 
     /**
      * The IPsecSaContextAddOutbound0 function adds an outbound IPsec security association (SA) bundle to an existing SA context.Note  IPsecSaContextAddOutbound0 is the specific implementation of IPsecSaContextAddOutbound used in Windows Vista.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -11365,7 +11365,7 @@ class WindowsFilteringPlatform {
 
     /**
      * The IPsecSaContextAddInbound1 function adds an inbound IPsec security association (SA) bundle to an existing SA context.Note  IPsecSaContextAddInbound1 is the specific implementation of IPsecSaContextAddInbound used in Windows 7 and later.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -11430,7 +11430,7 @@ class WindowsFilteringPlatform {
 
     /**
      * The IPsecSaContextAddOutbound1 function adds an outbound IPsec security association (SA) bundle to an existing SA context.Note  IPsecSaContextAddOutbound1 is the specific implementation of IPsecSaContextAddOutbound used in Windows 7 and later.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -11501,7 +11501,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/standard-access-rights">DELETE</a> access to the IPsec security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>IPsecSaContextExpire0</b> is a specific implementation of IPsecSaContextExpire. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -11565,7 +11565,7 @@ class WindowsFilteringPlatform {
      * Updates an IPsec security association (SA) context.
      * @remarks
      * <b>IPsecSaContextUpdate0</b> is a specific implementation of IPsecSaContextUpdate. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} flags Type: <b>UINT32</b>
@@ -11717,7 +11717,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ENUM</a> and <b>FWPM_ACTRL_READ</b> access to the IPsec security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>IPsecSaContextCreateEnumHandle0</b> is a specific implementation of IPsecSaContextCreateEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<IPSEC_SA_CONTEXT_ENUM_TEMPLATE0>} enumTemplate Type: <b>const <a href="https://docs.microsoft.com/windows/win32/api/ipsectypes/ns-ipsectypes-ipsec_sa_context_enum_template0">IPSEC_SA_CONTEXT_ENUM_TEMPLATE0</a>*</b>
@@ -11786,7 +11786,7 @@ class WindowsFilteringPlatform {
      * If the <i>numEntriesReturned</i> is less than the <i>numEntriesRequested</i>, the enumeration is exhausted. 
      * 
      * The returned array of entries (but not the individual entries themselves) must be freed by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -11865,7 +11865,7 @@ class WindowsFilteringPlatform {
      * If the <i>numEntriesReturned</i> is less than the <i>numEntriesRequested</i>, the enumeration is exhausted. 
      * 
      * The returned array of entries (but not the individual entries themselves) must be freed by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -11942,7 +11942,7 @@ class WindowsFilteringPlatform {
      * Frees a handle returned by IPsecSaContextCreateEnumHandle0.
      * @remarks
      * <b>IPsecSaContextDestroyEnumHandle0</b> is a specific implementation of IPsecSaContextDestroyEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -12010,7 +12010,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_SUBSCRIBE</a> access to the IPsec SA context's container.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<IPSEC_SA_CONTEXT_SUBSCRIPTION0>} subscription Type: <b>const <a href="https://docs.microsoft.com/windows/win32/api/ipsectypes/ns-ipsectypes-ipsec_sa_context_subscription0">IPSEC_SA_CONTEXT_SUBSCRIPTION0</a>*</b>
@@ -12090,7 +12090,7 @@ class WindowsFilteringPlatform {
      * 
      * This function cannot be called from within a transaction. It will fail
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} eventsHandle Type: <b>HANDLE</b>
@@ -12157,7 +12157,7 @@ class WindowsFilteringPlatform {
      * Retrieves an array of all the current IPsec security association (SA) change notification subscriptions.
      * @remarks
      * The returned array (but not the individual entries in the array) must be freed through a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Pointer<Pointer<IPSEC_SA_CONTEXT_SUBSCRIPTION0>>>} entries Type: <b><a href="https://docs.microsoft.com/windows/win32/api/ipsectypes/ns-ipsectypes-ipsec_sa_context_subscription0">IPSEC_SA_CONTEXT_SUBSCRIPTION0</a>***</b>
@@ -12233,7 +12233,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> and <b>FWPM_ACTRL_ENUM</b> access to the IPsec security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>IPsecSaCreateEnumHandle0</b> is a specific implementation of IPsecSaCreateEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<IPSEC_SA_ENUM_TEMPLATE0>} enumTemplate Type: [IPSEC_SA_ENUM_TEMPLATE0](/windows/desktop/api/ipsectypes/ns-ipsectypes-ipsec_sa_enum_template0)*</b>
@@ -12306,7 +12306,7 @@ class WindowsFilteringPlatform {
      * A subsequent call using the same enumeration handle will return the next set of items following those in the last output buffer.
      * 
      * <b>IPsecSaEnum0</b> works on a snapshot of the SAs taken at the time the enumeration handle was created.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -12389,7 +12389,7 @@ class WindowsFilteringPlatform {
      * A subsequent call using the same enumeration handle will return the next set of items following those in the last output buffer.
      * 
      * <b>IPsecSaEnum1</b> works on a snapshot of the SAs taken at the time the enumeration handle was created.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -12466,7 +12466,7 @@ class WindowsFilteringPlatform {
      * Frees a handle returned by IPsecSaCreateEnumHandle0.
      * @remarks
      * <b>IPsecSaDestroyEnumHandle0</b> is a specific implementation of IPsecSaDestroyEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -12535,7 +12535,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	<a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-getsecurityinfo">GetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>GetSecurityInfo</b> reference topic.
      * 
      * <b>IPsecSaDbGetSecurityInfo0</b> is a specific implementation of IPsecSaDbGetSecurityInfo. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -12621,7 +12621,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	 <a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>SetSecurityInfo</b> reference topic.
      * 
      * <b>IPsecSaDbSetSecurityInfo0</b> is a specific implementation of IPsecSaDbSetSecurityInfo. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -12702,7 +12702,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ_STATS</a> access to the IPsec DoS Protection component. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>IPsecDospGetStatistics0</b> is a specific implementation of IPsecDospGetStatistics. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<IPSEC_DOSP_STATISTICS0>} idpStatistics Type: [IPSEC_DOSP_STATISTICS0](/windows/desktop/api/ipsectypes/ns-ipsectypes-ipsec_dosp_statistics0)*</b>
@@ -12772,7 +12772,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ_STATS</a> access to the IPsec DoS Protection component. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>IPsecDospStateCreateEnumHandle0</b> is a specific implementation of IPsecDospStateCreateEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<IPSEC_DOSP_STATE_ENUM_TEMPLATE0>} enumTemplate Type: <b>const <a href="https://docs.microsoft.com/windows/win32/api/ipsectypes/ns-ipsectypes-ipsec_dosp_state_enum_template0">IPSEC_DOSP_STATE_ENUM_TEMPLATE0</a>*</b>
@@ -12845,7 +12845,7 @@ class WindowsFilteringPlatform {
      * A subsequent call using the same enumeration handle will return the next set of items following those in the last output buffer.
      * 
      * <b>IPsecDospStateEnum0</b> is a specific implementation of IPsecDospStateEnum. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -12922,7 +12922,7 @@ class WindowsFilteringPlatform {
      * Frees a handle returned by IPsecDospStateCreateEnumHandle0.
      * @remarks
      * <b>IPsecDospStateDestroyEnumHandle0</b> is a specific implementation of IPsecDospStateDestroyEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -12991,7 +12991,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	<a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-getsecurityinfo">GetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>GetSecurityInfo</b> reference topic. 
      * 
      * <b>IPsecDospGetSecurityInfo0</b> is a specific implementation of IPsecDospGetSecurityInfo. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -13077,7 +13077,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	 <a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>SetSecurityInfo</b> reference topic.
      * 
      * <b>IPsecDospSetSecurityInfo0</b> is a specific implementation of IPsecDospSetSecurityInfo. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -13156,7 +13156,7 @@ class WindowsFilteringPlatform {
      * 
      * This function cannot be called from within a transaction. It will fail
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * A handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<IPSEC_KEY_MANAGER0>} keyManager Type: <b>const <a href="https://docs.microsoft.com/windows/desktop/api/ipsectypes/ns-ipsectypes-ipsec_key_manager0">IPSEC_KEY_MANAGER0</a>*</b>
@@ -13260,7 +13260,7 @@ class WindowsFilteringPlatform {
 
     /**
      * Unregisters a Trusted Intermediary Agent (TIA) which had previously been registered with IPsec.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * A handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} keyMgmtHandle Type: <b>HANDLE</b>
@@ -13325,7 +13325,7 @@ class WindowsFilteringPlatform {
      * Returns a list of current Trusted Intermediary Agents (TIAs).
      * @remarks
      * The returned array of entries (but not the individual entries themselves) must be freed by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * A handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Pointer<Pointer<IPSEC_KEY_MANAGER0>>>} entries Type: <b><a href="https://docs.microsoft.com/windows/desktop/api/ipsectypes/ns-ipsectypes-ipsec_key_manager0">IPSEC_KEY_MANAGER0</a>***</b>
@@ -13393,7 +13393,7 @@ class WindowsFilteringPlatform {
 
     /**
      * Retrieves a copy of the security descriptor that controls access to the key manager.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * A handle to an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -13477,7 +13477,7 @@ class WindowsFilteringPlatform {
 
     /**
      * Sets specified security information in the security descriptor that controls access to the key manager.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * A handle to an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -13555,7 +13555,7 @@ class WindowsFilteringPlatform {
      * Retrieves Internet Key Exchange (IKE) and Authenticated Internet Protocol (AuthIP) statistics. (IkeextGetStatistics0)
      * @remarks
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ_STATS</a> access to the IKE/AuthIP security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine generated by a previous  call to  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a>.
      * @param {Pointer<IKEEXT_STATISTICS0>} ikeextStatistics Type: [IKEEXT_STATISTICS0](/windows/desktop/api/iketypes/ns-iketypes-ikeext_statistics0)*</b>
@@ -13619,7 +13619,7 @@ class WindowsFilteringPlatform {
      * Retrieves Internet Key Exchange (IKE) and Authenticated Internet Protocol (AuthIP) statistics. (IkeextGetStatistics1)
      * @remarks
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ_STATS</a> access to the IKE/AuthIP security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine generated by a previous  call to  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a>.
      * @param {Pointer<IKEEXT_STATISTICS1>} ikeextStatistics Type: [IKEEXT_STATISTICS1](/windows/desktop/api/iketypes/ns-iketypes-ikeext_statistics1)*</b>
@@ -13683,7 +13683,7 @@ class WindowsFilteringPlatform {
      * The IkeextSaDeleteById0 function removes a security association (SA) from the database.
      * @remarks
      * <b>IkeextSaDeleteById0</b> is a specific implementation of IkeextSaDeleteById. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine generated by a previous  call to  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a>.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -13749,7 +13749,7 @@ class WindowsFilteringPlatform {
      * The caller must free <i>sa</i> by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the IKE/AuthIP security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -13820,7 +13820,7 @@ class WindowsFilteringPlatform {
      * The caller must free <i>sa</i> by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the IKE/AuthIP security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -13894,7 +13894,7 @@ class WindowsFilteringPlatform {
      * The caller must free <i>sa</i> by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the IKE/AuthIP security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -13972,7 +13972,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ENUM</a> and <b>FWPM_ACTRL_READ</b> access to the IKE/AuthIP security associations database. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>IkeextSaCreateEnumHandle0</b> is a specific implementation of IkeextSaCreateEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine generated by a previous  call to  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a>.
      * @param {Pointer<IKEEXT_SA_ENUM_TEMPLATE0>} enumTemplate Type: [IKEEXT_SA_ENUM_TEMPLATE0](/windows/desktop/api/iketypes/ns-iketypes-ikeext_sa_enum_template0)*</b>
@@ -14045,7 +14045,7 @@ class WindowsFilteringPlatform {
      * A subsequent call using the same enumeration handle will return the next set of items following those in the last output buffer.
      * 
      * <b>IkeextSaEnum0</b> works on a snapshot of the SAs taken at the time the enumeration handle was created.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -14128,7 +14128,7 @@ class WindowsFilteringPlatform {
      * A subsequent call using the same enumeration handle will return the next set of items following those in the last output buffer.
      * 
      * <b>IkeextSaEnum1</b> works on a snapshot of the SAs taken at the time the enumeration handle was created.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -14211,7 +14211,7 @@ class WindowsFilteringPlatform {
      * A subsequent call using the same enumeration handle will return the next set of items following those in the last output buffer.
      * 
      * <b>IkeextSaEnum2</b> works on a snapshot of the SAs taken at the time the enumeration handle was created.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -14288,7 +14288,7 @@ class WindowsFilteringPlatform {
      * Frees a handle returned by IkeextSaCreateEnumHandle0.
      * @remarks
      * <b>IkeextSaDestroyEnumHandle0</b> is a specific implementation of IkeextSaDestroyEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine generated by a previous  call to  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a>.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -14357,7 +14357,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	<a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-getsecurityinfo">GetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>GetSecurityInfo</b> reference topic.
      * 
      * <b>IkeextSaDbGetSecurityInfo0</b> is a specific implementation of IkeextSaDbGetSecurityInfo. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine generated by a previous  call to  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a>.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -14443,7 +14443,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	 <a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>SetSecurityInfo</b> reference topic.
      * 
      * <b>IkeextSaDbSetSecurityInfo0</b> is a specific implementation of IkeextSaDbSetSecurityInfo. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine generated by a previous  call to  <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a>.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -14528,7 +14528,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ENUM</a> access to the events' containers. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
      * 
      * <b>FwpmNetEventCreateEnumHandle0</b> is a specific implementation of FwpmNetEventCreateEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_NET_EVENT_ENUM_TEMPLATE0>} enumTemplate Type: [FWPM_NET_EVENT_ENUM_TEMPLATE0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_net_event_enum_template0)*</b>
@@ -14601,7 +14601,7 @@ class WindowsFilteringPlatform {
      * A subsequent call  that uses  the same <i>enumHandle</i> parameter will return the next set of events following those in the  current <i>entries</i> buffer.
      * 
      * <b>FwpmNetEventEnum0</b> returns only events that were logged prior to the creation of the  <i>enumHandle</i> parameter. See <a href="https://docs.microsoft.com/windows/desktop/FWP/logging">Logging</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -14697,7 +14697,7 @@ class WindowsFilteringPlatform {
      * A subsequent call  that uses  the same <i>enumHandle</i> parameter will return the next set of events following those in the  current <i>entries</i> buffer.
      * 
      * <b>FwpmNetEventEnum1</b> returns only events that were logged prior to the creation of the  <i>enumHandle</i> parameter. See <a href="https://docs.microsoft.com/windows/desktop/FWP/logging">Logging</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -14793,7 +14793,7 @@ class WindowsFilteringPlatform {
      * A subsequent call  that uses  the same <i>enumHandle</i> parameter will return the next set of events following those in the  current <i>entries</i> buffer.
      * 
      * <b>FwpmNetEventEnum2</b> returns only events that were logged prior to the creation of the  <i>enumHandle</i> parameter. See <a href="https://docs.microsoft.com/windows/desktop/FWP/logging">Logging</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -14889,7 +14889,7 @@ class WindowsFilteringPlatform {
      * A subsequent call  that uses  the same <i>enumHandle</i> parameter will return the next set of events following those in the  current <i>entries</i> buffer.
      * 
      * <b>FwpmNetEventEnum3</b> returns only events that were logged prior to the creation of the  <i>enumHandle</i> parameter. See <a href="https://docs.microsoft.com/windows/desktop/FWP/logging">Logging</a> for more information.
-     * @param {HANDLE} engineHandle Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Handle for a network event enumeration created by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmneteventcreateenumhandle0">FwpmNetEventCreateEnumHandle0</a>.
      * @param {Integer} numEntriesRequested The number of enumeration entries requested.
      * @param {Pointer<Pointer<Pointer<FWPM_NET_EVENT3>>>} entries Addresses of enumeration entries.
@@ -14965,7 +14965,7 @@ class WindowsFilteringPlatform {
 
     /**
      * 
-     * @param {HANDLE} engineHandle 
+     * @param {FWPM_ENGINE_HANDLE} engineHandle 
      * @param {HANDLE} enumHandle 
      * @param {Integer} numEntriesRequested 
      * @param {Pointer<Pointer<Pointer<FWPM_NET_EVENT4>>>} entries 
@@ -14985,7 +14985,7 @@ class WindowsFilteringPlatform {
 
     /**
      * 
-     * @param {HANDLE} engineHandle 
+     * @param {FWPM_ENGINE_HANDLE} engineHandle 
      * @param {HANDLE} enumHandle 
      * @param {Integer} numEntriesRequested 
      * @param {Pointer<Pointer<Pointer<FWPM_NET_EVENT5>>>} entries 
@@ -15007,7 +15007,7 @@ class WindowsFilteringPlatform {
      * Frees a handle returned by FwpmNetEventCreateEnumHandle0.
      * @remarks
      * <b>FwpmNetEventDestroyEnumHandle0</b> is a specific implementation of FwpmNetEventDestroyEnumHandle. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -15076,7 +15076,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	<a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-getsecurityinfo">GetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>GetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmNetEventsGetSecurityInfo0</b> is a specific implementation of FwpmNetEventsGetSecurityInfo. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -15172,7 +15172,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	 <a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>SetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmNetEventsSetSecurityInfo0</b> is a specific implementation of FwpmNetEventsSetSecurityInfo. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -15251,7 +15251,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_SUBSCRIBE</a> access to the net event's container.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_NET_EVENT_SUBSCRIPTION0>} subscription Type: [FWPM_NET_EVENT_SUBSCRIPTION0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_net_event_subscription0)*</b>
@@ -15333,7 +15333,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * <b>FwpmNetEventUnsubscribe0</b> is a specific implementation of FwpmNetEventUnsubscribe. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} eventsHandle Type: <b>HANDLE</b>
@@ -15402,7 +15402,7 @@ class WindowsFilteringPlatform {
      * The returned array (but not the individual entries in the array) must be freed through a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * <b>FwpmNetEventSubscriptionsGet0</b> is a specific implementation of FwpmNetEventSubscriptionsGet. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Pointer<Pointer<FWPM_NET_EVENT_SUBSCRIPTION0>>>} entries Type: [FWPM_NET_EVENT_SUBSCRIPTION0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_net_event_subscription0)***</b>
@@ -15475,7 +15475,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_SUBSCRIBE</a> access to the net event's container.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_NET_EVENT_SUBSCRIPTION0>} subscription Type: [FWPM_NET_EVENT_SUBSCRIPTION0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_net_event_subscription0)*</b>
@@ -15553,7 +15553,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_SUBSCRIBE</a> access to the net event's container.
-     * @param {HANDLE} engineHandle Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_NET_EVENT_SUBSCRIPTION0>} subscription An [FWPM_NET_EVENT_SUBSCRIPTION0](/windows/win32/api/fwpmtypes/ns-fwpmtypes-fwpm_net_event_subscription0) structure which describes which notifications will be delivered.
      * @param {Pointer<FWPM_NET_EVENT_CALLBACK2>} callback Pointer to a function of type [FWPM_NET_EVENT_CALLBACK2](/windows/win32/api/fwpmu/nc-fwpmu-fwpm_net_event_callback2) that will be invoked when a notification is ready for delivery.
      * @param {Pointer<Void>} context Optional context pointer. This pointer is passed to the <i>callback</i> function along with details of the event.
@@ -15614,7 +15614,7 @@ class WindowsFilteringPlatform {
 
     /**
      * 
-     * @param {HANDLE} engineHandle 
+     * @param {FWPM_ENGINE_HANDLE} engineHandle 
      * @param {Pointer<FWPM_NET_EVENT_SUBSCRIPTION0>} subscription 
      * @param {Pointer<FWPM_NET_EVENT_CALLBACK3>} callback 
      * @param {Pointer<Void>} context 
@@ -15632,7 +15632,7 @@ class WindowsFilteringPlatform {
 
     /**
      * 
-     * @param {HANDLE} engineHandle 
+     * @param {FWPM_ENGINE_HANDLE} engineHandle 
      * @param {Pointer<FWPM_NET_EVENT_SUBSCRIPTION0>} subscription 
      * @param {Pointer<FWPM_NET_EVENT_CALLBACK4>} callback 
      * @param {Pointer<Void>} context 
@@ -15719,7 +15719,7 @@ class WindowsFilteringPlatform {
      * The returned array (but not the individual entries in the array) must be freed through a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * <b>FwpmSystemPortsGet0</b> is a specific implementation of FwpmSystemPortsGet. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Optional handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<Pointer<FWPM_SYSTEM_PORTS0>>} sysPorts Type: [FWPM_SYSTEM_PORTS0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_system_ports0)**</b>
@@ -15788,7 +15788,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * <b>FwpmSystemPortsSubscribe0</b> is a specific implementation of FwpmSystemPortsSubscribe. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_SYSTEM_PORTS_CALLBACK0>} callback Type: <b><a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nc-fwpmu-fwpm_system_ports_callback0">FWPM_SYSTEM_PORTS_CALLBACK0</a></b>
@@ -15871,7 +15871,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * <b>FwpmSystemPortsUnsubscribe0</b> is a specific implementation of FwpmSystemPortsUnsubscribe. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} sysPortsHandle Type: <b>HANDLE</b>
@@ -15938,7 +15938,7 @@ class WindowsFilteringPlatform {
      * The caller must free the returned object by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_READ</a> access to the provider context. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} id Type: <b>UINT64</b>
@@ -16013,7 +16013,7 @@ class WindowsFilteringPlatform {
      * A subsequent call using the same enumeration handle will return the next set of items following those in the last output buffer.
      * 
      * <b>FwpmConnectionEnum0</b> works on a snapshot of the connection objects taken at the time the enumeration handle was created.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -16092,7 +16092,7 @@ class WindowsFilteringPlatform {
      * The caller must free the returned handle by a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmconnectiondestroyenumhandle0">FwpmConnectionDestroyEnumHandle0</a>.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_ENUM</a> access to the connection objects' containers and <b>FWPM_ACTRL_READ</b> access to the connection objects. See <a href="https://docs.microsoft.com/windows/desktop/FWP/access-control">Access Control</a> for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_CONNECTION_ENUM_TEMPLATE0>} enumTemplate Type: [FWPM_CONNECTION_ENUM_TEMPLATE0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_connection_enum_template0)*</b>
@@ -16157,7 +16157,7 @@ class WindowsFilteringPlatform {
 
     /**
      * Frees a handle returned by FwpmConnectionCreateEnumHandle0.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} enumHandle Type: <b>HANDLE</b>
@@ -16224,7 +16224,7 @@ class WindowsFilteringPlatform {
      * The returned <i>securityDescriptor</i> parameter must be freed through a call to <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmfreememory0">FwpmFreeMemory0</a>. The other four returned parameters must not be freed, as they point to addresses within the <i>securityDescriptor</i> parameter.
      * 
      * This function behaves like the standard Win32 	<a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-getsecurityinfo">GetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>GetSecurityInfo</b> reference topic.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -16314,7 +16314,7 @@ class WindowsFilteringPlatform {
      * <b>FWP_E_DYNAMIC_SESSION_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about sessions.
      * 
      * This function behaves like the standard Win32 	 <a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>SetSecurityInfo</b> reference topic.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * A handle to an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -16393,7 +16393,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_SUBSCRIBE</a> access to the connection object's container.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_CONNECTION_SUBSCRIPTION0>} subscription Type: **[FWPM_CONNECTION_SUBSCRIPTION0](/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_connection_subscription0)\***
@@ -16473,7 +16473,7 @@ class WindowsFilteringPlatform {
      * 
      * This function cannot be called from within a transaction. It will fail
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} eventsHandle Type: <b>HANDLE</b>
@@ -16545,7 +16545,7 @@ class WindowsFilteringPlatform {
      * The caller needs <a href="https://docs.microsoft.com/windows/desktop/FWP/access-right-identifiers">FWPM_ACTRL_SUBSCRIBE</a> access to the virtual switch event's container.
      * 
      * <b>FwpmvSwitchEventSubscribe0</b> is a specific implementation of FwpmvSwitchEventSubscribe. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Pointer<FWPM_VSWITCH_EVENT_SUBSCRIPTION0>} subscription Type: <b>const <a href="https://docs.microsoft.com/windows/win32/api/fwpmtypes/ns-fwpmtypes-fwpm_vswitch_event_subscription0">FWPM_VSWITCH_EVENT_SUBSCRIPTION0</a>*</b>
@@ -16627,7 +16627,7 @@ class WindowsFilteringPlatform {
      * with <b>FWP_E_TXN_IN_PROGRESS</b>. See <a href="https://docs.microsoft.com/windows/desktop/FWP/object-management">Object Management</a> for more information about transactions.
      * 
      * <b>FwpmvSwitchEventUnsubscribe0</b> is a specific implementation of FwpmvSwitchEventUnsubscribe. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {HANDLE} subscriptionHandle Type: <b>HANDLE</b>
@@ -16698,7 +16698,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	<a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-getsecurityinfo">GetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>GetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmvSwitchEventsGetSecurityInfo0</b> is a specific implementation of FwpmvSwitchEventsGetSecurityInfo. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * Handle for an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -16790,7 +16790,7 @@ class WindowsFilteringPlatform {
      * This function behaves like the standard Win32 	 <a href="https://docs.microsoft.com/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function. The caller needs the same standard access rights as described in the <b>SetSecurityInfo</b> reference topic.
      * 
      * <b>FwpmvSwitchEventsSetSecurityInfo0</b> is a specific implementation of FwpmvSwitchEventsSetSecurityInfo. See <a href="https://docs.microsoft.com/windows/desktop/FWP/wfp-version-independent-names-and-targeting-specific-versions-of-windows">WFP Version-Independent Names and Targeting Specific Versions of Windows</a>  for more information.
-     * @param {HANDLE} engineHandle Type: <b>HANDLE</b>
+     * @param {FWPM_ENGINE_HANDLE} engineHandle Type: <b>HANDLE</b>
      * 
      * A handle to an open session to the filter engine. Call <a href="https://docs.microsoft.com/windows/desktop/api/fwpmu/nf-fwpmu-fwpmengineopen0">FwpmEngineOpen0</a> to open a session to the filter engine.
      * @param {Integer} securityInfo Type: <b><a href="https://docs.microsoft.com/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a></b>
@@ -16864,7 +16864,7 @@ class WindowsFilteringPlatform {
 
     /**
      * 
-     * @param {HANDLE} engineHandle 
+     * @param {FWPM_ENGINE_HANDLE} engineHandle 
      * @param {Pointer<FWPM_PROVIDER_CONTEXT3>} connectionPolicy 
      * @param {Integer} ipVersion 
      * @param {Integer} weight 
@@ -16883,7 +16883,7 @@ class WindowsFilteringPlatform {
 
     /**
      * 
-     * @param {HANDLE} engineHandle 
+     * @param {FWPM_ENGINE_HANDLE} engineHandle 
      * @param {Pointer<Guid>} key 
      * @returns {Integer} 
      */

--- a/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/FWPM_ENGINE_HANDLE.ahk
+++ b/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/FWPM_ENGINE_HANDLE.ahk
@@ -1,0 +1,34 @@
+#Requires AutoHotkey v2.0.0 64-bit
+#Include ..\..\..\..\Win32Struct.ahk
+#Include .\Apis.ahk
+#Include ..\..\..\..\Win32Handle.ahk
+
+/**
+ * @namespace Windows.Win32.NetworkManagement.WindowsFilteringPlatform
+ * @version v4.0.30319
+ */
+class FWPM_ENGINE_HANDLE extends Win32Handle
+{
+    static sizeof => 8
+
+    static packingSize => 8
+
+    /**
+     * The list of values which indicate that the handle is invalid
+     * @type {Array<Integer>}
+     */
+    static invalidValues => [-1, 0]
+
+    /**
+     * @type {Pointer<Void>}
+     */
+    Value {
+        get => NumGet(this, 0, "ptr")
+        set => NumPut("ptr", value, this, 0)
+    }
+
+    Free(){
+        WindowsFilteringPlatform.FwpmEngineClose0(this.Value)
+        this.Value := -1
+    }
+}

--- a/Windows/Win32/Networking/DeliveryOptimization/Apis.ahk
+++ b/Windows/Win32/Networking/DeliveryOptimization/Apis.ahk
@@ -1,0 +1,55 @@
+#Requires AutoHotkey v2.0.0 64-bit
+#Include ..\..\..\..\Win32Handle.ahk
+
+/**
+ * @namespace Windows.Win32.Networking.DeliveryOptimization
+ * @version v4.0.30319
+ */
+class DeliveryOptimization {
+
+;@region Constants
+
+    /**
+     * @type {String}
+     */
+    static DecryptionInfo_KeyData => "KeyData"
+
+    /**
+     * @type {String}
+     */
+    static DecryptionInfo_EncryptionBufferSize => "EncryptionBufferSize"
+
+    /**
+     * @type {String}
+     */
+    static DecryptionInfo_AlgorithmName => "AlgorithmName"
+
+    /**
+     * @type {String}
+     */
+    static DecryptionInfo_ChainingMode => "ChainingMode"
+
+    /**
+     * @type {String}
+     */
+    static IntegrityCheckInfo_PiecesHashFileUrl => "PiecesHashFileUrl"
+
+    /**
+     * @type {String}
+     */
+    static IntegrityCheckInfo_PiecesHashFileDigest => "PiecesHashFileDigest"
+
+    /**
+     * @type {String}
+     */
+    static IntegrityCheckInfo_PiecesHashFileDigestAlgorithm => "PiecesHashFileDigestAlgorithm"
+
+    /**
+     * @type {String}
+     */
+    static IntegrityCheckInfo_HashOfHashes => "HashOfHashes"
+;@endregion Constants
+
+;@region Methods
+;@endregion Methods
+}

--- a/Windows/Win32/Networking/DeliveryOptimization/DODownloadCostPolicy.ahk
+++ b/Windows/Win32/Networking/DeliveryOptimization/DODownloadCostPolicy.ahk
@@ -1,0 +1,49 @@
+#Requires AutoHotkey v2.0.0 64-bit
+#Include ..\..\..\..\Win32Enum.ahk
+
+/**
+ * Specifies the ID of cost policies options associated with the **DODownloadProperty_CostPolicy** property.
+ * @remarks
+ * 
+ * @see https://learn.microsoft.com/windows/win32/api/deliveryoptimization/ne-deliveryoptimization-dodownloadcostpolicy
+ * @namespace Windows.Win32.Networking.DeliveryOptimization
+ * @version v4.0.30319
+ */
+class DODownloadCostPolicy extends Win32Enum{
+
+    /**
+     * Download runs regardless of the cost.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadCostPolicy_Always => 0
+
+    /**
+     * Download runs unless imposes costs or traffic limits.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadCostPolicy_Unrestricted => 1
+
+    /**
+     * Download runs unless neither subject to a surcharge nor near exhaustion.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadCostPolicy_Standard => 2
+
+    /**
+     * Download runs unless that connectivity is subject to roaming surcharges.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadCostPolicy_NoRoaming => 3
+
+    /**
+     * Download runs unless subject to a surcharge.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadCostPolicy_NoSurcharge => 4
+
+    /**
+     * Download runs unless network is on cellular.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadCostPolicy_NoCellular => 5
+}

--- a/Windows/Win32/Networking/DeliveryOptimization/DODownloadProperty.ahk
+++ b/Windows/Win32/Networking/DeliveryOptimization/DODownloadProperty.ahk
@@ -1,0 +1,197 @@
+#Requires AutoHotkey v2.0.0 64-bit
+#Include ..\..\..\..\Win32Enum.ahk
+
+/**
+ * Specifies the ID of properties for the Delivery Optimization download operation.
+ * @remarks
+ * 
+ * @see https://learn.microsoft.com/windows/win32/api/deliveryoptimization/ne-deliveryoptimization-dodownloadproperty
+ * @namespace Windows.Win32.Networking.DeliveryOptimization
+ * @version v4.0.30319
+ */
+class DODownloadProperty extends Win32Enum{
+
+    /**
+     * Read-only. Use this property to get the ID that uniquely identifies the download. VARIANT type is VT_BSTR.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_Id => 0
+
+    /**
+     * Use this property to set or get the remote URI path of the resource to download. This property is required only if *DODownloadProperty_ContentId* isn't provided. VARIANT type is VT_BSTR.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_Uri => 1
+
+    /**
+     * Use this property to set or get the download unique content ID. This property is required only if *DODownloadProperty_Uri* isn't provided. VARIANT type is VT_BSTR.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_ContentId => 2
+
+    /**
+     * Optional. Use this property to set or get the download display name. VARIANT type is VT_BSTR.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_DisplayName => 3
+
+    /**
+     * Use this property to set or get the local path name to save the download file. If the path does not exist, Delivery Optimization will attempt to create it under the caller's privileges. This property is required only if *DODownloadProperty_StreamInterface* wasn’t provided. VARIANT type is VT_BSTR.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_LocalPath => 4
+
+    /**
+     * Optional. Use this property to set or get custom HTTP request headers. Delivery Optimization will include these headers during HTTP file request operations. The headers must already be formatted as standard HTTP headers. VARIANT type is VT_BSTR.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_HttpCustomHeaders => 5
+
+    /**
+     * Optional. Use this property to set or get one of the **DODownloadCostPolicy** enumeration values. VARIANT type is VT_UI4.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_CostPolicy => 6
+
+    /**
+     * Optional write-only. Use this property to set or get the standard WinHTTP security flags (**WINHTTP_OPTION_SECURITY_FLAGS**). VARIANT type is VT_UI4.
+     * 
+     * The following flags are supported:
+     * 
+     * * **SECURITY_FLAG_IGNORE_CERT_CN_INVALID**. Allows an invalid common name in a certificate.
+     * * **SECURITY_FLAG_IGNORE_CERT_DATE_INVALID**. Allows an invalid certificate date.
+     * * **SECURITY_FLAG_IGNORE_UNKNOWN_CA**. Allows an invalid certificate authority.
+     * * **SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE**. Allows the identity of a server to be established with a non-server certificate.
+     * * **WINHTTP_ENABLE_SSL_REVOCATION**. Allows SSL revocation. If this flag is set, the above flags will be ignored.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_SecurityFlags => 7
+
+    /**
+     * Optional. Use this property to set or get callback frequency based on download percentage. VARIANT type is VT_UI4.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_CallbackFreqPercent => 8
+
+    /**
+     * Optional. Use this property to set or get callback frequency based on download time. The default is every one second. VARIANT type is VT_UI4.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_CallbackFreqSeconds => 9
+
+    /**
+     * Optional. Use this property to set or get the download timeout length for no progress. The minimum accepted value is 60 seconds of no download activity. VARIANT type is VT_UI4.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_NoProgressTimeoutSeconds => 10
+
+    /**
+     * Optional. Use this property to set or get the current download priority. VARIANT_TRUE value will bring the download to the foreground with higher priority. The default is background priority. VARIANT type is VT_BOOL.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_ForegroundPriority => 11
+
+    /**
+     * Optional. Use this property to set or get the current download blocking mode. VARIANT_TRUE value will cause **IDODownload::Start** to block until download is complete or error has occurred. The default is nonblocking mode. VARIANT type is VT_BOOL.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_BlockingMode => 12
+
+    /**
+     * Optional. Use this property to set or get the pointer to **IDODownloadStatusCallback** interface used for download callbacks. VARIANT type is VT_UNKNOWN.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_CallbackInterface => 13
+
+    /**
+     * Optional. Use this property to set or get the pointer to IStream interface used for stream download type. VARIANT type is VT_UNKNOWN.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_StreamInterface => 14
+
+    /**
+     * Optional write-only. Use this property to set the certificate context to be used during HTTP request operations. The value must consist of serialized bytes of CERT_CONTEXT. VARIANT type is (VT_ARRAY \| VT_UI1).
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_SecurityContext => 15
+
+    /**
+     * Optional write-only. Use this property to set the network token to be used during HTTP operations. VARIANT_TRUE value will cause Delivery Optimization to capture the caller's identity token and VARIANT_FALSE will clear the existing token. The default is the token of the logged-on user. VARIANT type is VT_BOOL.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_NetworkToken => 16
+
+    /**
+     * Optional. Sets a specific correlation vector for telemetry purposes. VARIANT type is VT_BSTR.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_CorrelationVector => 17
+
+    /**
+     * Optional write-only. Sets decryption information in the form of a JSON string. VARIANT type is VT_BSTR.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_DecryptionInfo => 18
+
+    /**
+     * Optional write-only. Sets the piece hash file (PHF) location, which is used by Delivery Optimization to perform runtime integrity checks on the downloaded content. VARIANT type is VT_BSTR.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_IntegrityCheckInfo => 19
+
+    /**
+     * Optional. Sets a Boolean flag indicating whether usage of the piece hash file (PHF) is mandatory. If VARIANT_TRUE, the download will be aborted if the integrity check fails. VARIANT type is VT_BOOL.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_IntegrityCheckMandatory => 20
+
+    /**
+     * Optional. Specifies the total download size in bytes. VARIANT type is VT_UI8.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_TotalSizeBytes => 21
+
+    /**
+     * Don't download when on a cellular connection.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_DisallowOnCellular => 22
+
+    /**
+     * Custom HTTPS headers are used when challenged.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_HttpCustomAuthHeaders => 23
+
+    /**
+     * Https-to-http redirection. Default is `FALSE`.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_HttpAllowSecureToNonSecureRedirect => 24
+
+    /**
+     * Save download info to the Windows Registry. Default is `FALSE` for Delivery Optimization download jobs; `TRUE` for BITS-style jobs.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_NonVolatile => 25
+
+    /**
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_HttpRedirectionTarget => 26
+
+    /**
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_HttpResponseHeaders => 27
+
+    /**
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_HttpServerIPAddress => 28
+
+    /**
+     * @type {Integer (Int32)}
+     */
+    static DODownloadProperty_HttpStatusCode => 29
+}

--- a/Windows/Win32/Networking/DeliveryOptimization/DODownloadState.ahk
+++ b/Windows/Win32/Networking/DeliveryOptimization/DODownloadState.ahk
@@ -1,0 +1,49 @@
+#Requires AutoHotkey v2.0.0 64-bit
+#Include ..\..\..\..\Win32Enum.ahk
+
+/**
+ * Specifies the ID of the current download state, which is part of the **DO_DOWNLOAD_STATUS** structure.
+ * @remarks
+ * 
+ * @see https://learn.microsoft.com/windows/win32/api/deliveryoptimization/ne-deliveryoptimization-dodownloadstate
+ * @namespace Windows.Win32.Networking.DeliveryOptimization
+ * @version v4.0.30319
+ */
+class DODownloadState extends Win32Enum{
+
+    /**
+     * Download object is created but hasn't been started yet.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadState_Created => 0
+
+    /**
+     * Download is in progress.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadState_Transferring => 1
+
+    /**
+     * Download is transferred and can start again by downloading another portion of the file.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadState_Transferred => 2
+
+    /**
+     * Download is finalized and cannot be started again.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadState_Finalized => 3
+
+    /**
+     * Download was aborted.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadState_Aborted => 4
+
+    /**
+     * Download has been paused on demand or due to transient error.
+     * @type {Integer (Int32)}
+     */
+    static DODownloadState_Paused => 5
+}

--- a/Windows/Win32/Networking/DeliveryOptimization/DO_DOWNLOAD_ENUM_CATEGORY.ahk
+++ b/Windows/Win32/Networking/DeliveryOptimization/DO_DOWNLOAD_ENUM_CATEGORY.ahk
@@ -1,0 +1,41 @@
+#Requires AutoHotkey v2.0.0 64-bit
+#Include ..\..\..\..\Win32Struct.ahk
+
+/**
+ * Used by **IDOManager::EnumDownloads** to filter the downloads enumeration by the specific property's value.
+ * @remarks
+ * 
+ * @see https://learn.microsoft.com/windows/win32/api/deliveryoptimization/ns-deliveryoptimization-do_download_enum_category
+ * @namespace Windows.Win32.Networking.DeliveryOptimization
+ * @version v4.0.30319
+ */
+class DO_DOWNLOAD_ENUM_CATEGORY extends Win32Struct
+{
+    static sizeof => 16
+
+    static packingSize => 8
+
+    /**
+     * The property name to be used for the download enumeration. These properties are supported for enumeration purposes.
+     * 
+     * - **DODownloadProperty_Id**
+     * - **DODownloadProperty_Uri**
+     * - **DODownloadProperty_ContentId**
+     * - **DODownloadProperty_DisplayName**
+     * - **DODownloadProperty_LocalPath**
+     * @type {Integer}
+     */
+    Property {
+        get => NumGet(this, 0, "int")
+        set => NumPut("int", value, this, 0)
+    }
+
+    /**
+     * The property's value.
+     * @type {PWSTR}
+     */
+    Value {
+        get => NumGet(this, 8, "ptr")
+        set => NumPut("ptr", value, this, 8)
+    }
+}

--- a/Windows/Win32/Networking/DeliveryOptimization/DO_DOWNLOAD_RANGE.ahk
+++ b/Windows/Win32/Networking/DeliveryOptimization/DO_DOWNLOAD_RANGE.ahk
@@ -1,0 +1,35 @@
+#Requires AutoHotkey v2.0.0 64-bit
+#Include ..\..\..\..\Win32Struct.ahk
+
+/**
+ * Identifies a single range of bytes to download from a file.
+ * @remarks
+ * 
+ * @see https://learn.microsoft.com/windows/win32/api/deliveryoptimization/ns-deliveryoptimization-do_download_range
+ * @namespace Windows.Win32.Networking.DeliveryOptimization
+ * @version v4.0.30319
+ */
+class DO_DOWNLOAD_RANGE extends Win32Struct
+{
+    static sizeof => 16
+
+    static packingSize => 8
+
+    /**
+     * Zero-based offset to the beginning of the range of bytes to download from a file.
+     * @type {Integer}
+     */
+    Offset {
+        get => NumGet(this, 0, "uint")
+        set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * The length of the range, in bytes. Do not specify a zero-byte length. To indicate that the range extends to the end of the file, specify **DO_LENGTH_TO_EOF**.
+     * @type {Integer}
+     */
+    Length {
+        get => NumGet(this, 8, "uint")
+        set => NumPut("uint", value, this, 8)
+    }
+}

--- a/Windows/Win32/Networking/DeliveryOptimization/DO_DOWNLOAD_RANGES_INFO.ahk
+++ b/Windows/Win32/Networking/DeliveryOptimization/DO_DOWNLOAD_RANGES_INFO.ahk
@@ -1,0 +1,39 @@
+#Requires AutoHotkey v2.0.0 64-bit
+#Include ..\..\..\..\Win32Struct.ahk
+#Include .\DO_DOWNLOAD_RANGE.ahk
+
+/**
+ * Identifies an array of ranges of bytes to download from a file.
+ * @remarks
+ * 
+ * @see https://learn.microsoft.com/windows/win32/api/deliveryoptimization/ns-deliveryoptimization-do_download_ranges_info
+ * @namespace Windows.Win32.Networking.DeliveryOptimization
+ * @version v4.0.30319
+ */
+class DO_DOWNLOAD_RANGES_INFO extends Win32Struct
+{
+    static sizeof => 16
+
+    static packingSize => 8
+
+    /**
+     * Number of elements in Ranges.
+     * @type {Integer}
+     */
+    RangeCount {
+        get => NumGet(this, 0, "uint")
+        set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * Array of one or more **DO_DOWNLOAD_RANGE** structures that specify the ranges to download.
+     * @type {Array<DO_DOWNLOAD_RANGE>}
+     */
+    Ranges{
+        get {
+            if(!this.HasProp("__RangesProxyArray"))
+                this.__RangesProxyArray := Win32FixedArray(this.ptr + 8, 1, DO_DOWNLOAD_RANGE, "")
+            return this.__RangesProxyArray
+        }
+    }
+}

--- a/Windows/Win32/Networking/DeliveryOptimization/DO_DOWNLOAD_STATUS.ahk
+++ b/Windows/Win32/Networking/DeliveryOptimization/DO_DOWNLOAD_STATUS.ahk
@@ -1,0 +1,62 @@
+#Requires AutoHotkey v2.0.0 64-bit
+#Include ..\..\..\..\Win32Struct.ahk
+
+/**
+ * Used to obtain the status of a specific download.
+ * @remarks
+ * 
+ * @see https://learn.microsoft.com/windows/win32/api/deliveryoptimization/ns-deliveryoptimization-do_download_status
+ * @namespace Windows.Win32.Networking.DeliveryOptimization
+ * @version v4.0.30319
+ */
+class DO_DOWNLOAD_STATUS extends Win32Struct
+{
+    static sizeof => 32
+
+    static packingSize => 8
+
+    /**
+     * The total number of bytes to download.
+     * @type {Integer}
+     */
+    BytesTotal {
+        get => NumGet(this, 0, "uint")
+        set => NumPut("uint", value, this, 0)
+    }
+
+    /**
+     * The number of bytes that have already been downloaded.
+     * @type {Integer}
+     */
+    BytesTransferred {
+        get => NumGet(this, 8, "uint")
+        set => NumPut("uint", value, this, 8)
+    }
+
+    /**
+     * The current download state as defined by the **DODownloadState** enumeration.
+     * @type {Integer}
+     */
+    State {
+        get => NumGet(this, 16, "int")
+        set => NumPut("int", value, this, 16)
+    }
+
+    /**
+     * The error information (if it exists) that is associated with the current download.
+     * @type {HRESULT}
+     */
+    Error {
+        get => NumGet(this, 20, "int")
+        set => NumPut("int", value, this, 20)
+    }
+
+    /**
+     * The extended error information (if it exists) that is associated with the current download.
+     * @type {HRESULT}
+     */
+    ExtendedError {
+        get => NumGet(this, 24, "int")
+        set => NumPut("int", value, this, 24)
+    }
+}

--- a/Windows/Win32/Networking/DeliveryOptimization/DeliveryOptimization.ahk
+++ b/Windows/Win32/Networking/DeliveryOptimization/DeliveryOptimization.ahk
@@ -1,0 +1,13 @@
+#Requires AutoHotkey v2.0.0 64-bit
+#Include ..\..\..\..\Win32Struct.ahk
+
+/**
+ * @namespace Windows.Win32.Networking.DeliveryOptimization
+ * @version v4.0.30319
+ */
+class DeliveryOptimization extends Win32Struct
+{
+    static sizeof => 0
+
+    static packingSize => 1
+}

--- a/Windows/Win32/System/SystemServices/Apis.ahk
+++ b/Windows/Win32/System/SystemServices/Apis.ahk
@@ -2313,6 +2313,11 @@ class SystemServices {
     /**
      * @type {Integer (UInt32)}
      */
+    static LOCALE_UNASSIGNED_LCID => 4096
+
+    /**
+     * @type {Integer (UInt32)}
+     */
     static MAXIMUM_WAIT_OBJECTS => 64
 
     /**

--- a/version.ini
+++ b/version.ini
@@ -4,5 +4,5 @@ Windows.Win32 = 0.0.0.0
 
 [Packages]
 Microsoft.Windows.SDK.Win32Docs = 0.1.42-alpha
-Microsoft.Windows.SDK.Win32Metadata = 68.0.4-preview
+Microsoft.Windows.SDK.Win32Metadata = 69.0.7-preview
 Microsoft.Windows.WDK.Win32Metadata = 0.13.25-experimental


### PR DESCRIPTION
Automated update of generated Win32 bindings.
- SDK Metadata version: [**69.0.7-preview**](https://github.com/microsoft/win32metadata/releases/tag/v69.0.7-preview)
- WDK Metadata version: [**0.13.25-experimental**](https://github.com/microsoft/wdkmetadata/releases/tag/v0.13.25-experimental)
- ApiDocs version: **0.1.42-alpha**

Triggered by update-packages workflow.