### PR TITLE
Fix circular references in embedded structs

### DIFF
--- a/Win32FixedArray.ahk
+++ b/Win32FixedArray.ahk
@@ -39,6 +39,7 @@ class Win32FixedArray extends CStyleArrayList {
         ; which we don't want. Instead, wrap external memory with a plain buffer-like object.
         this.elementType := elementType
         this.dllCallType := dllCallType
+        this._owned := false
         this.__buf := {ptr: ptr, size: length * this._GetElementWidth()}
         this.__length := length
     }

--- a/Win32Handle.ahk
+++ b/Win32Handle.ahk
@@ -55,7 +55,7 @@ class Win32Handle extends Win32Struct {
     __New(ptrOrObj := 0, ownedOrParent := true){
         if(IsObject(ownedOrParent)){
             super.__New(ptrOrObj, ownedOrParent)
-            this.owned := this._parent._owned
+            this.owned := ownedOrParent._owned
         }
         else{
             super.__New(ptrOrObj)

--- a/Win32Struct.ahk
+++ b/Win32Struct.ahk
@@ -33,11 +33,7 @@ class Win32Struct extends Object{
      *          created by the OS are not.
      * @type {Boolean}
      */
-    _owned => IsObject(this._parent) ? this._parent._owned : this.__buf is Buffer
-
-    ; Private - used for embedded structs
-    _parent := ""
-    _offset := ""
+    _owned := unset
 
     /**
      * @readonly The size of the struct for packing purposes. This value may be larger than the
@@ -79,22 +75,22 @@ class Win32Struct extends Object{
                 throw TypeError("ptrOrObj must be an Integer if parent is set, but it is a(n) " . type(ptrOrObj), , ptrOrObj)
             }
 
-            this._parent := parent
-            this._offset := Integer(ptrOrObj)
-
-            this.__buf := {ptr: this._parent.ptr + this._offset, size: size}
+            this._owned := parent._owned
+            this.__buf := {ptr: parent.ptr + ptrOrObj, size: size}
 
             return
         }
 
         ; "top-level" struct declared at an existing memory location
         if(IsInteger(ptrOrObj) && ptrOrObj != 0){
+            this._owned := false
             this.__buf := {ptr: ptrOrObj, size: size}
             return
         }
         
         ; new struct, potentially with initialization information
         this.__buf := Buffer(size, 0)
+        this._owned := true
         if(IsObject(ptrOrObj)){
             this._InitFromObject(ptrOrObj)
         }


### PR DESCRIPTION

**Previously**, Embedded structs determined ownership based on the status of their parents as part of a getter. 


**This was problematic because** embedded structs held refs back to their parents, creating circular references and preventing the structs from being cleaned up.

**Now**, ownership is determined in __New, and embedded structs do not hold references back to their parents.


### Changes

<!-- Summarize the key changes made in this PR - if there are breaking changes, list them here and add the "breaking" label -->
- `Win32Struct.ahk`, `Win32Handle.ahk`, `Win32FixedArray.ahk` - use a boolean property to determine ownership

### Related Issues

Fixes #127 

---

#### Checklist

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] No breaking changes (or breaking changes documented)
