### PR TITLE
Support variadic methods

### DIFF
--- a/Tests/GeneratedApiSmoke.test.ahk
+++ b/Tests/GeneratedApiSmoke.test.ahk
@@ -258,6 +258,31 @@ class GeneratedApiSmokeTests {
             Assert.Equals(type(val), "HSTRING")
         }
     }
+
+    /**
+     * Tests for variadic functions (__arglist). These accept additional arguments
+     * as alternating DllCall type/value pairs via AHK's variadic parameter syntax.
+     */
+    class VariadicFunctions {
+
+        wsprintfW_WithVariadicArgs_FormatsCorrectly() {
+            buf := Buffer(256, 0)
+            nChars := WindowsAndMessaging.wsprintfW(buf, "%d %s", "int", 42, "ptr", StrPtr("hello"))
+            result := StrGet(buf, "UTF-16")
+
+            Yunit.Assert(nChars == 8, Format("Expected 8 chars but got {1}", nChars))
+            Yunit.Assert(result == "42 hello", Format("Expected '42 hello' but got '{1}'", result))
+        }
+
+        wsprintfW_WithNoVariadicArgs_StillWorks() {
+            buf := Buffer(256, 0)
+            nChars := WindowsAndMessaging.wsprintfW(buf, "Hello World")
+            result := StrGet(buf, "UTF-16")
+
+            Yunit.Assert(nChars == 11, Format("Expected 11 chars but got {1}", nChars))
+            Yunit.Assert(result == "Hello World", Format("Expected 'Hello World' but got '{1}'", result))
+        }
+    }
 }
 
 /**

--- a/Windows/Wdk/NetworkManagement/Ndis/Apis.ahk
+++ b/Windows/Wdk/NetworkManagement/Ndis/Apis.ahk
@@ -10330,12 +10330,16 @@ class Ndis {
      * @param {Pointer<Void>} NdisAdapterHandle 
      * @param {Integer} ErrorCode 
      * @param {Integer} NumberOfErrorValues 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {String} Nothing - always returns an empty string
      */
-    static NdisWriteErrorLogEntry(NdisAdapterHandle, ErrorCode, NumberOfErrorValues) {
+    static NdisWriteErrorLogEntry(NdisAdapterHandle, ErrorCode, NumberOfErrorValues, args*) {
         NdisAdapterHandleMarshal := NdisAdapterHandle is VarRef ? "ptr" : "ptr"
 
-        DllCall("NDIS.sys\NdisWriteErrorLogEntry", NdisAdapterHandleMarshal, NdisAdapterHandle, "uint", ErrorCode, "uint", NumberOfErrorValues, "CDecl ")
+        varArgs := [args*]
+        varArgs.Push("CDecl")
+
+        DllCall("NDIS.sys\NdisWriteErrorLogEntry", NdisAdapterHandleMarshal, NdisAdapterHandle, "uint", ErrorCode, "uint", NumberOfErrorValues, varArgs*)
     }
 
     /**

--- a/Windows/Wdk/Storage/FileSystem/Apis.ahk
+++ b/Windows/Wdk/Storage/FileSystem/Apis.ahk
@@ -5730,10 +5730,14 @@ class FileSystem {
      * @param {PSID} _Sid 
      * @param {Pointer<SID_IDENTIFIER_AUTHORITY>} IdentifierAuthority 
      * @param {Integer} SubAuthorityCount 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {NTSTATUS} 
      */
-    static RtlInitializeSidEx(_Sid, IdentifierAuthority, SubAuthorityCount) {
-        result := DllCall("ntdll.dll\RtlInitializeSidEx", "ptr", _Sid, "ptr", IdentifierAuthority, "char", SubAuthorityCount, "CDecl int")
+    static RtlInitializeSidEx(_Sid, IdentifierAuthority, SubAuthorityCount, args*) {
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("ntdll.dll\RtlInitializeSidEx", "ptr", _Sid, "ptr", IdentifierAuthority, "char", SubAuthorityCount, varArgs*)
         NTSTATUS.ThrowIfError(result)
         return result
     }

--- a/Windows/Wdk/System/SystemServices/Apis.ahk
+++ b/Windows/Wdk/System/SystemServices/Apis.ahk
@@ -8625,12 +8625,16 @@ class SystemServices {
     /**
      * 
      * @param {PSTR} Format 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} 
      */
-    static DbgPrint(Format) {
+    static DbgPrint(Format, args*) {
         Format := Format is String ? StrPtr(Format) : Format
 
-        result := DllCall("ntdll.dll\DbgPrint", "ptr", Format, "CDecl uint")
+        varArgs := [args*]
+        varArgs.Push("CDecl uint")
+
+        result := DllCall("ntdll.dll\DbgPrint", "ptr", Format, varArgs*)
         return result
     }
 
@@ -8639,12 +8643,16 @@ class SystemServices {
      * @param {Integer} ComponentId 
      * @param {Integer} Level 
      * @param {PSTR} Format 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} 
      */
-    static DbgPrintEx(ComponentId, Level, Format) {
+    static DbgPrintEx(ComponentId, Level, Format, args*) {
         Format := Format is String ? StrPtr(Format) : Format
 
-        result := DllCall("ntdll.dll\DbgPrintEx", "uint", ComponentId, "uint", Level, "ptr", Format, "CDecl uint")
+        varArgs := [args*]
+        varArgs.Push("CDecl uint")
+
+        result := DllCall("ntdll.dll\DbgPrintEx", "uint", ComponentId, "uint", Level, "ptr", Format, varArgs*)
         return result
     }
 
@@ -8687,12 +8695,16 @@ class SystemServices {
     /**
      * 
      * @param {PSTR} Format 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} 
      */
-    static DbgPrintReturnControlC(Format) {
+    static DbgPrintReturnControlC(Format, args*) {
         Format := Format is String ? StrPtr(Format) : Format
 
-        result := DllCall("ntdll.dll\DbgPrintReturnControlC", "ptr", Format, "CDecl uint")
+        varArgs := [args*]
+        varArgs.Push("CDecl uint")
+
+        result := DllCall("ntdll.dll\DbgPrintReturnControlC", "ptr", Format, varArgs*)
         return result
     }
 

--- a/Windows/Win32/Devices/AllJoyn/Apis.ahk
+++ b/Windows/Win32/Devices/AllJoyn/Apis.ahk
@@ -444,12 +444,16 @@ class AllJoyn {
     /**
      * 
      * @param {PSTR} signature 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {alljoyn_msgarg} 
      */
-    static alljoyn_msgarg_create_and_set(signature) {
+    static alljoyn_msgarg_create_and_set(signature, args*) {
         signature := signature is String ? StrPtr(signature) : signature
 
-        result := DllCall("MSAJApi.dll\alljoyn_msgarg_create_and_set", "ptr", signature, "CDecl ptr")
+        varArgs := [args*]
+        varArgs.Push("CDecl ptr")
+
+        result := DllCall("MSAJApi.dll\alljoyn_msgarg_create_and_set", "ptr", signature, varArgs*)
         return result
     }
 
@@ -487,12 +491,16 @@ class AllJoyn {
      * 
      * @param {alljoyn_msgarg} arg 
      * @param {PSTR} signature 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {QStatus} 
      */
-    static alljoyn_msgarg_set(arg, signature) {
+    static alljoyn_msgarg_set(arg, signature, args*) {
         signature := signature is String ? StrPtr(signature) : signature
 
-        result := DllCall("MSAJApi.dll\alljoyn_msgarg_set", "ptr", arg, "ptr", signature, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("MSAJApi.dll\alljoyn_msgarg_set", "ptr", arg, "ptr", signature, varArgs*)
         return result
     }
 
@@ -500,12 +508,16 @@ class AllJoyn {
      * 
      * @param {alljoyn_msgarg} arg 
      * @param {PSTR} signature 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {QStatus} 
      */
-    static alljoyn_msgarg_get(arg, signature) {
+    static alljoyn_msgarg_get(arg, signature, args*) {
         signature := signature is String ? StrPtr(signature) : signature
 
-        result := DllCall("MSAJApi.dll\alljoyn_msgarg_get", "ptr", arg, "ptr", signature, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("MSAJApi.dll\alljoyn_msgarg_get", "ptr", arg, "ptr", signature, varArgs*)
         return result
     }
 
@@ -545,14 +557,18 @@ class AllJoyn {
      * @param {alljoyn_msgarg} args 
      * @param {Pointer<Pointer>} numArgs 
      * @param {PSTR} signature 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {QStatus} 
      */
-    static alljoyn_msgarg_array_set(args, numArgs, signature) {
+    static alljoyn_msgarg_array_set(args, numArgs, signature, args*) {
         signature := signature is String ? StrPtr(signature) : signature
 
         numArgsMarshal := numArgs is VarRef ? "ptr*" : "ptr"
 
-        result := DllCall("MSAJApi.dll\alljoyn_msgarg_array_set", "ptr", args, numArgsMarshal, numArgs, "ptr", signature, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("MSAJApi.dll\alljoyn_msgarg_array_set", "ptr", args, numArgsMarshal, numArgs, "ptr", signature, varArgs*)
         return result
     }
 
@@ -561,12 +577,16 @@ class AllJoyn {
      * @param {alljoyn_msgarg} args 
      * @param {Pointer} numArgs 
      * @param {PSTR} signature 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {QStatus} 
      */
-    static alljoyn_msgarg_array_get(args, numArgs, signature) {
+    static alljoyn_msgarg_array_get(args, numArgs, signature, args*) {
         signature := signature is String ? StrPtr(signature) : signature
 
-        result := DllCall("MSAJApi.dll\alljoyn_msgarg_array_get", "ptr", args, "ptr", numArgs, "ptr", signature, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("MSAJApi.dll\alljoyn_msgarg_array_get", "ptr", args, "ptr", numArgs, "ptr", signature, varArgs*)
         return result
     }
 
@@ -647,12 +667,16 @@ class AllJoyn {
      * 
      * @param {alljoyn_msgarg} arg 
      * @param {PSTR} elemSig 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {QStatus} 
      */
-    static alljoyn_msgarg_getdictelement(arg, elemSig) {
+    static alljoyn_msgarg_getdictelement(arg, elemSig, args*) {
         elemSig := elemSig is String ? StrPtr(elemSig) : elemSig
 
-        result := DllCall("MSAJApi.dll\alljoyn_msgarg_getdictelement", "ptr", arg, "ptr", elemSig, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("MSAJApi.dll\alljoyn_msgarg_getdictelement", "ptr", arg, "ptr", elemSig, varArgs*)
         return result
     }
 
@@ -690,14 +714,18 @@ class AllJoyn {
      * @param {Pointer} argOffset 
      * @param {Pointer<Pointer>} numArgs 
      * @param {PSTR} signature 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {QStatus} 
      */
-    static alljoyn_msgarg_array_set_offset(args, argOffset, numArgs, signature) {
+    static alljoyn_msgarg_array_set_offset(args, argOffset, numArgs, signature, args*) {
         signature := signature is String ? StrPtr(signature) : signature
 
         numArgsMarshal := numArgs is VarRef ? "ptr*" : "ptr"
 
-        result := DllCall("MSAJApi.dll\alljoyn_msgarg_array_set_offset", "ptr", args, "ptr", argOffset, numArgsMarshal, numArgs, "ptr", signature, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("MSAJApi.dll\alljoyn_msgarg_array_set_offset", "ptr", args, "ptr", argOffset, numArgsMarshal, numArgs, "ptr", signature, varArgs*)
         return result
     }
 
@@ -705,12 +733,16 @@ class AllJoyn {
      * 
      * @param {alljoyn_msgarg} arg 
      * @param {PSTR} signature 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {QStatus} 
      */
-    static alljoyn_msgarg_set_and_stabilize(arg, signature) {
+    static alljoyn_msgarg_set_and_stabilize(arg, signature, args*) {
         signature := signature is String ? StrPtr(signature) : signature
 
-        result := DllCall("MSAJApi.dll\alljoyn_msgarg_set_and_stabilize", "ptr", arg, "ptr", signature, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("MSAJApi.dll\alljoyn_msgarg_set_and_stabilize", "ptr", arg, "ptr", signature, varArgs*)
         return result
     }
 
@@ -2891,12 +2923,16 @@ class AllJoyn {
      * 
      * @param {alljoyn_message} _msg 
      * @param {PSTR} signature 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {QStatus} 
      */
-    static alljoyn_message_parseargs(_msg, signature) {
+    static alljoyn_message_parseargs(_msg, signature, args*) {
         signature := signature is String ? StrPtr(signature) : signature
 
-        result := DllCall("MSAJApi.dll\alljoyn_message_parseargs", "ptr", _msg, "ptr", signature, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("MSAJApi.dll\alljoyn_message_parseargs", "ptr", _msg, "ptr", signature, varArgs*)
         return result
     }
 

--- a/Windows/Win32/Devices/DeviceAndDriverInstallation/Apis.ahk
+++ b/Windows/Win32/Devices/DeviceAndDriverInstallation/Apis.ahk
@@ -14004,14 +14004,18 @@ class DeviceAndDriverInstallation {
      * </li>
      * </ul>
      * @param {PSTR} MessageStr A pointer to a NULL-terminated constant string that contains a <b>printf</b>-compatible format string, which specifies the formatted message to include in the log entry. The comma-separated parameter list that follows <i>MessageStr</i> must match the format specifiers in the format string.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {String} Nothing - always returns an empty string
      * @see https://learn.microsoft.com/windows/win32/api/setupapi/nf-setupapi-setupwritetextlog
      * @since windows6.0.6000
      */
-    static SetupWriteTextLog(LogToken, Category, Flags, MessageStr) {
+    static SetupWriteTextLog(LogToken, Category, Flags, MessageStr, args*) {
         MessageStr := MessageStr is String ? StrPtr(MessageStr) : MessageStr
 
-        DllCall("SETUPAPI.dll\SetupWriteTextLog", "uint", LogToken, "uint", Category, "uint", Flags, "ptr", MessageStr, "CDecl ")
+        varArgs := [args*]
+        varArgs.Push("CDecl")
+
+        DllCall("SETUPAPI.dll\SetupWriteTextLog", "uint", LogToken, "uint", Category, "uint", Flags, "ptr", MessageStr, varArgs*)
     }
 
     /**
@@ -14074,14 +14078,18 @@ class DeviceAndDriverInstallation {
      * </ul>
      * @param {Integer} _Error A SetupAPI-specific error code or a Win32 error code. The SetupAPI-specific error codes are listed in <i>Setupapi.h</i>. The Win32 error codes are listed in <i>Winerror.h</i>.
      * @param {PSTR} MessageStr A pointer to a NULL-terminated constant string that contains a <b>printf</b>-compatible format string, which specifies the formatted message to include in the log entry.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {String} Nothing - always returns an empty string
      * @see https://learn.microsoft.com/windows/win32/api/setupapi/nf-setupapi-setupwritetextlogerror
      * @since windows6.0.6000
      */
-    static SetupWriteTextLogError(LogToken, Category, LogFlags, _Error, MessageStr) {
+    static SetupWriteTextLogError(LogToken, Category, LogFlags, _Error, MessageStr, args*) {
         MessageStr := MessageStr is String ? StrPtr(MessageStr) : MessageStr
 
-        DllCall("SETUPAPI.dll\SetupWriteTextLogError", "uint", LogToken, "uint", Category, "uint", LogFlags, "uint", _Error, "ptr", MessageStr, "CDecl ")
+        varArgs := [args*]
+        varArgs.Push("CDecl")
+
+        DllCall("SETUPAPI.dll\SetupWriteTextLogError", "uint", LogToken, "uint", Category, "uint", LogFlags, "uint", _Error, "ptr", MessageStr, varArgs*)
     }
 
     /**

--- a/Windows/Win32/Globalization/Apis.ahk
+++ b/Windows/Win32/Globalization/Apis.ahk
@@ -15103,7 +15103,7 @@ class Globalization {
 
         versionArrayMarshal := versionArray is VarRef ? "char*" : "ptr"
 
-        DllCall("icuuc.dll\u_versionFromString", versionArrayMarshal, versionArray, "ptr", versionString, "CDecl ")
+        DllCall("icuuc.dll\u_versionFromString", versionArrayMarshal, versionArray, "ptr", versionString, "CDecl")
     }
 
     /**
@@ -15116,7 +15116,7 @@ class Globalization {
         versionArrayMarshal := versionArray is VarRef ? "char*" : "ptr"
         versionStringMarshal := versionString is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuuc.dll\u_versionFromUString", versionArrayMarshal, versionArray, versionStringMarshal, versionString, "CDecl ")
+        DllCall("icuuc.dll\u_versionFromUString", versionArrayMarshal, versionArray, versionStringMarshal, versionString, "CDecl")
     }
 
     /**
@@ -15130,7 +15130,7 @@ class Globalization {
 
         versionArrayMarshal := versionArray is VarRef ? "char*" : "ptr"
 
-        DllCall("icuuc.dll\u_versionToString", versionArrayMarshal, versionArray, "ptr", versionString, "CDecl ")
+        DllCall("icuuc.dll\u_versionToString", versionArrayMarshal, versionArray, "ptr", versionString, "CDecl")
     }
 
     /**
@@ -15141,7 +15141,7 @@ class Globalization {
     static u_getVersion(versionArray) {
         versionArrayMarshal := versionArray is VarRef ? "char*" : "ptr"
 
-        DllCall("icuuc.dll\u_getVersion", versionArrayMarshal, versionArray, "CDecl ")
+        DllCall("icuuc.dll\u_getVersion", versionArrayMarshal, versionArray, "CDecl")
     }
 
     /**
@@ -15160,7 +15160,7 @@ class Globalization {
      * @returns {String} Nothing - always returns an empty string
      */
     static utrace_setLevel(traceLevel) {
-        DllCall("icuuc.dll\utrace_setLevel", "int", traceLevel, "CDecl ")
+        DllCall("icuuc.dll\utrace_setLevel", "int", traceLevel, "CDecl")
     }
 
     /**
@@ -15183,7 +15183,7 @@ class Globalization {
     static utrace_setFunctions(_context, e, x, d) {
         _contextMarshal := _context is VarRef ? "ptr" : "ptr"
 
-        DllCall("icuuc.dll\utrace_setFunctions", _contextMarshal, _context, "ptr", e, "ptr", x, "ptr", d, "CDecl ")
+        DllCall("icuuc.dll\utrace_setFunctions", _contextMarshal, _context, "ptr", e, "ptr", x, "ptr", d, "CDecl")
     }
 
     /**
@@ -15200,7 +15200,7 @@ class Globalization {
         xMarshal := x is VarRef ? "ptr*" : "ptr"
         dMarshal := d is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\utrace_getFunctions", _contextMarshal, _context, eMarshal, e, xMarshal, x, dMarshal, d, "CDecl ")
+        DllCall("icuuc.dll\utrace_getFunctions", _contextMarshal, _context, eMarshal, e, xMarshal, x, dMarshal, d, "CDecl")
     }
 
     /**
@@ -15228,13 +15228,17 @@ class Globalization {
      * @param {Integer} capacity 
      * @param {Integer} indent 
      * @param {PSTR} fmt 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} 
      */
-    static utrace_format(outBuf, capacity, indent, fmt) {
+    static utrace_format(outBuf, capacity, indent, fmt, args*) {
         outBuf := outBuf is String ? StrPtr(outBuf) : outBuf
         fmt := fmt is String ? StrPtr(fmt) : fmt
 
-        result := DllCall("icuuc.dll\utrace_format", "ptr", outBuf, "int", capacity, "int", indent, "ptr", fmt, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("icuuc.dll\utrace_format", "ptr", outBuf, "int", capacity, "int", indent, "ptr", fmt, varArgs*)
         return result
     }
 
@@ -15451,7 +15455,7 @@ class Globalization {
     static uiter_setState(iter, state, pErrorCode) {
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\uiter_setState", "ptr", iter, "uint", state, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\uiter_setState", "ptr", iter, "uint", state, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -15464,7 +15468,7 @@ class Globalization {
     static uiter_setString(iter, s, length) {
         sMarshal := s is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuuc.dll\uiter_setString", "ptr", iter, sMarshal, s, "int", length, "CDecl ")
+        DllCall("icuuc.dll\uiter_setString", "ptr", iter, sMarshal, s, "int", length, "CDecl")
     }
 
     /**
@@ -15477,7 +15481,7 @@ class Globalization {
     static uiter_setUTF16BE(iter, s, length) {
         s := s is String ? StrPtr(s) : s
 
-        DllCall("icuuc.dll\uiter_setUTF16BE", "ptr", iter, "ptr", s, "int", length, "CDecl ")
+        DllCall("icuuc.dll\uiter_setUTF16BE", "ptr", iter, "ptr", s, "int", length, "CDecl")
     }
 
     /**
@@ -15490,7 +15494,7 @@ class Globalization {
     static uiter_setUTF8(iter, s, length) {
         s := s is String ? StrPtr(s) : s
 
-        DllCall("icuuc.dll\uiter_setUTF8", "ptr", iter, "ptr", s, "int", length, "CDecl ")
+        DllCall("icuuc.dll\uiter_setUTF8", "ptr", iter, "ptr", s, "int", length, "CDecl")
     }
 
     /**
@@ -15501,7 +15505,7 @@ class Globalization {
     static uenum_close(en) {
         enMarshal := en is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uenum_close", enMarshal, en, "CDecl ")
+        DllCall("icuuc.dll\uenum_close", enMarshal, en, "CDecl")
     }
 
     /**
@@ -15560,7 +15564,7 @@ class Globalization {
         enMarshal := en is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\uenum_reset", enMarshal, en, _statusMarshal, _status, "CDecl ")
+        DllCall("icuuc.dll\uenum_reset", enMarshal, en, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -15613,7 +15617,7 @@ class Globalization {
 
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\uloc_setDefault", "ptr", localeID, _statusMarshal, _status, "CDecl ")
+        DllCall("icuuc.dll\uloc_setDefault", "ptr", localeID, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -16333,7 +16337,7 @@ class Globalization {
     static ures_close(resourceBundle) {
         resourceBundleMarshal := resourceBundle is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ures_close", resourceBundleMarshal, resourceBundle, "CDecl ")
+        DllCall("icuuc.dll\ures_close", resourceBundleMarshal, resourceBundle, "CDecl")
     }
 
     /**
@@ -16346,7 +16350,7 @@ class Globalization {
         resBMarshal := resB is VarRef ? "ptr*" : "ptr"
         versionInfoMarshal := versionInfo is VarRef ? "char*" : "ptr"
 
-        DllCall("icuuc.dll\ures_getVersion", resBMarshal, resB, versionInfoMarshal, versionInfo, "CDecl ")
+        DllCall("icuuc.dll\ures_getVersion", resBMarshal, resB, versionInfoMarshal, versionInfo, "CDecl")
     }
 
     /**
@@ -16504,7 +16508,7 @@ class Globalization {
     static ures_resetIterator(resourceBundle) {
         resourceBundleMarshal := resourceBundle is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ures_resetIterator", resourceBundleMarshal, resourceBundle, "CDecl ")
+        DllCall("icuuc.dll\ures_resetIterator", resourceBundleMarshal, resourceBundle, "CDecl")
     }
 
     /**
@@ -16707,7 +16711,7 @@ class Globalization {
     static uldn_close(ldn) {
         ldnMarshal := ldn is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uldn_close", ldnMarshal, ldn, "CDecl ")
+        DllCall("icuuc.dll\uldn_close", ldnMarshal, ldn, "CDecl")
     }
 
     /**
@@ -17233,7 +17237,7 @@ class Globalization {
      * @returns {String} Nothing - always returns an empty string
      */
     static ucptrie_close(trie) {
-        DllCall("icu.dll\ucptrie_close", "ptr", trie, "CDecl ")
+        DllCall("icu.dll\ucptrie_close", "ptr", trie, "CDecl")
     }
 
     /**
@@ -17379,7 +17383,7 @@ class Globalization {
     static umutablecptrie_close(trie) {
         trieMarshal := trie is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icu.dll\umutablecptrie_close", trieMarshal, trie, "CDecl ")
+        DllCall("icu.dll\umutablecptrie_close", trieMarshal, trie, "CDecl")
     }
 
     /**
@@ -17455,7 +17459,7 @@ class Globalization {
         trieMarshal := trie is VarRef ? "ptr*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\umutablecptrie_set", trieMarshal, trie, "int", c, "uint", value, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icu.dll\umutablecptrie_set", trieMarshal, trie, "int", c, "uint", value, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -17471,7 +17475,7 @@ class Globalization {
         trieMarshal := trie is VarRef ? "ptr*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\umutablecptrie_setRange", trieMarshal, trie, "int", start, "int", end, "uint", value, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icu.dll\umutablecptrie_setRange", trieMarshal, trie, "int", start, "int", end, "uint", value, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -17506,7 +17510,7 @@ class Globalization {
         codeUnitsMarshal := codeUnits is VarRef ? "ushort*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\UCNV_FROM_U_CALLBACK_STOP", _contextMarshal, _context, "ptr", fromUArgs, codeUnitsMarshal, codeUnits, "int", length, "int", codePoint, "int", reason, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\UCNV_FROM_U_CALLBACK_STOP", _contextMarshal, _context, "ptr", fromUArgs, codeUnitsMarshal, codeUnits, "int", length, "int", codePoint, "int", reason, errMarshal, err, "CDecl")
     }
 
     /**
@@ -17525,7 +17529,7 @@ class Globalization {
         _contextMarshal := _context is VarRef ? "ptr" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\UCNV_TO_U_CALLBACK_STOP", _contextMarshal, _context, "ptr", toUArgs, "ptr", codeUnits, "int", length, "int", reason, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\UCNV_TO_U_CALLBACK_STOP", _contextMarshal, _context, "ptr", toUArgs, "ptr", codeUnits, "int", length, "int", reason, errMarshal, err, "CDecl")
     }
 
     /**
@@ -17544,7 +17548,7 @@ class Globalization {
         codeUnitsMarshal := codeUnits is VarRef ? "ushort*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\UCNV_FROM_U_CALLBACK_SKIP", _contextMarshal, _context, "ptr", fromUArgs, codeUnitsMarshal, codeUnits, "int", length, "int", codePoint, "int", reason, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\UCNV_FROM_U_CALLBACK_SKIP", _contextMarshal, _context, "ptr", fromUArgs, codeUnitsMarshal, codeUnits, "int", length, "int", codePoint, "int", reason, errMarshal, err, "CDecl")
     }
 
     /**
@@ -17563,7 +17567,7 @@ class Globalization {
         codeUnitsMarshal := codeUnits is VarRef ? "ushort*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\UCNV_FROM_U_CALLBACK_SUBSTITUTE", _contextMarshal, _context, "ptr", fromUArgs, codeUnitsMarshal, codeUnits, "int", length, "int", codePoint, "int", reason, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\UCNV_FROM_U_CALLBACK_SUBSTITUTE", _contextMarshal, _context, "ptr", fromUArgs, codeUnitsMarshal, codeUnits, "int", length, "int", codePoint, "int", reason, errMarshal, err, "CDecl")
     }
 
     /**
@@ -17582,7 +17586,7 @@ class Globalization {
         codeUnitsMarshal := codeUnits is VarRef ? "ushort*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\UCNV_FROM_U_CALLBACK_ESCAPE", _contextMarshal, _context, "ptr", fromUArgs, codeUnitsMarshal, codeUnits, "int", length, "int", codePoint, "int", reason, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\UCNV_FROM_U_CALLBACK_ESCAPE", _contextMarshal, _context, "ptr", fromUArgs, codeUnitsMarshal, codeUnits, "int", length, "int", codePoint, "int", reason, errMarshal, err, "CDecl")
     }
 
     /**
@@ -17601,7 +17605,7 @@ class Globalization {
         _contextMarshal := _context is VarRef ? "ptr" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\UCNV_TO_U_CALLBACK_SKIP", _contextMarshal, _context, "ptr", toUArgs, "ptr", codeUnits, "int", length, "int", reason, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\UCNV_TO_U_CALLBACK_SKIP", _contextMarshal, _context, "ptr", toUArgs, "ptr", codeUnits, "int", length, "int", reason, errMarshal, err, "CDecl")
     }
 
     /**
@@ -17620,7 +17624,7 @@ class Globalization {
         _contextMarshal := _context is VarRef ? "ptr" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\UCNV_TO_U_CALLBACK_SUBSTITUTE", _contextMarshal, _context, "ptr", toUArgs, "ptr", codeUnits, "int", length, "int", reason, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\UCNV_TO_U_CALLBACK_SUBSTITUTE", _contextMarshal, _context, "ptr", toUArgs, "ptr", codeUnits, "int", length, "int", reason, errMarshal, err, "CDecl")
     }
 
     /**
@@ -17639,7 +17643,7 @@ class Globalization {
         _contextMarshal := _context is VarRef ? "ptr" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\UCNV_TO_U_CALLBACK_ESCAPE", _contextMarshal, _context, "ptr", toUArgs, "ptr", codeUnits, "int", length, "int", reason, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\UCNV_TO_U_CALLBACK_ESCAPE", _contextMarshal, _context, "ptr", toUArgs, "ptr", codeUnits, "int", length, "int", reason, errMarshal, err, "CDecl")
     }
 
     /**
@@ -17756,7 +17760,7 @@ class Globalization {
     static ucnv_close(converter) {
         converterMarshal := converter is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_close", converterMarshal, converter, "CDecl ")
+        DllCall("icuuc.dll\ucnv_close", converterMarshal, converter, "CDecl")
     }
 
     /**
@@ -17774,7 +17778,7 @@ class Globalization {
         lenMarshal := len is VarRef ? "char*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_getSubstChars", converterMarshal, converter, "ptr", subChars, lenMarshal, len, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_getSubstChars", converterMarshal, converter, "ptr", subChars, lenMarshal, len, errMarshal, err, "CDecl")
     }
 
     /**
@@ -17791,7 +17795,7 @@ class Globalization {
         converterMarshal := converter is VarRef ? "ptr*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_setSubstChars", converterMarshal, converter, "ptr", subChars, "char", len, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_setSubstChars", converterMarshal, converter, "ptr", subChars, "char", len, errMarshal, err, "CDecl")
     }
 
     /**
@@ -17807,7 +17811,7 @@ class Globalization {
         sMarshal := s is VarRef ? "ushort*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_setSubstString", cnvMarshal, cnv, sMarshal, s, "int", length, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_setSubstString", cnvMarshal, cnv, sMarshal, s, "int", length, errMarshal, err, "CDecl")
     }
 
     /**
@@ -17825,7 +17829,7 @@ class Globalization {
         lenMarshal := len is VarRef ? "char*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_getInvalidChars", converterMarshal, converter, "ptr", errBytes, lenMarshal, len, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_getInvalidChars", converterMarshal, converter, "ptr", errBytes, lenMarshal, len, errMarshal, err, "CDecl")
     }
 
     /**
@@ -17842,7 +17846,7 @@ class Globalization {
         lenMarshal := len is VarRef ? "char*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_getInvalidUChars", converterMarshal, converter, errUCharsMarshal, errUChars, lenMarshal, len, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_getInvalidUChars", converterMarshal, converter, errUCharsMarshal, errUChars, lenMarshal, len, errMarshal, err, "CDecl")
     }
 
     /**
@@ -17853,7 +17857,7 @@ class Globalization {
     static ucnv_reset(converter) {
         converterMarshal := converter is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_reset", converterMarshal, converter, "CDecl ")
+        DllCall("icuuc.dll\ucnv_reset", converterMarshal, converter, "CDecl")
     }
 
     /**
@@ -17864,7 +17868,7 @@ class Globalization {
     static ucnv_resetToUnicode(converter) {
         converterMarshal := converter is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_resetToUnicode", converterMarshal, converter, "CDecl ")
+        DllCall("icuuc.dll\ucnv_resetToUnicode", converterMarshal, converter, "CDecl")
     }
 
     /**
@@ -17875,7 +17879,7 @@ class Globalization {
     static ucnv_resetFromUnicode(converter) {
         converterMarshal := converter is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_resetFromUnicode", converterMarshal, converter, "CDecl ")
+        DllCall("icuuc.dll\ucnv_resetFromUnicode", converterMarshal, converter, "CDecl")
     }
 
     /**
@@ -17988,7 +17992,7 @@ class Globalization {
         startersMarshal := starters is VarRef ? "char*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_getStarters", converterMarshal, converter, startersMarshal, starters, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_getStarters", converterMarshal, converter, startersMarshal, starters, errMarshal, err, "CDecl")
     }
 
     /**
@@ -18004,7 +18008,7 @@ class Globalization {
         setFillInMarshal := setFillIn is VarRef ? "ptr*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_getUnicodeSet", cnvMarshal, cnv, setFillInMarshal, setFillIn, "int", whichSet, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\ucnv_getUnicodeSet", cnvMarshal, cnv, setFillInMarshal, setFillIn, "int", whichSet, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -18019,7 +18023,7 @@ class Globalization {
         actionMarshal := action is VarRef ? "ptr*" : "ptr"
         _contextMarshal := _context is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_getToUCallBack", converterMarshal, converter, actionMarshal, action, _contextMarshal, _context, "CDecl ")
+        DllCall("icuuc.dll\ucnv_getToUCallBack", converterMarshal, converter, actionMarshal, action, _contextMarshal, _context, "CDecl")
     }
 
     /**
@@ -18034,7 +18038,7 @@ class Globalization {
         actionMarshal := action is VarRef ? "ptr*" : "ptr"
         _contextMarshal := _context is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_getFromUCallBack", converterMarshal, converter, actionMarshal, action, _contextMarshal, _context, "CDecl ")
+        DllCall("icuuc.dll\ucnv_getFromUCallBack", converterMarshal, converter, actionMarshal, action, _contextMarshal, _context, "CDecl")
     }
 
     /**
@@ -18054,7 +18058,7 @@ class Globalization {
         oldContextMarshal := oldContext is VarRef ? "ptr*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_setToUCallBack", converterMarshal, converter, "ptr", newAction, newContextMarshal, newContext, oldActionMarshal, oldAction, oldContextMarshal, oldContext, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_setToUCallBack", converterMarshal, converter, "ptr", newAction, newContextMarshal, newContext, oldActionMarshal, oldAction, oldContextMarshal, oldContext, errMarshal, err, "CDecl")
     }
 
     /**
@@ -18074,7 +18078,7 @@ class Globalization {
         oldContextMarshal := oldContext is VarRef ? "ptr*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_setFromUCallBack", converterMarshal, converter, "ptr", newAction, newContextMarshal, newContext, oldActionMarshal, oldAction, oldContextMarshal, oldContext, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_setFromUCallBack", converterMarshal, converter, "ptr", newAction, newContextMarshal, newContext, oldActionMarshal, oldAction, oldContextMarshal, oldContext, errMarshal, err, "CDecl")
     }
 
     /**
@@ -18099,7 +18103,7 @@ class Globalization {
         offsetsMarshal := offsets is VarRef ? "int*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_fromUnicode", converterMarshal, converter, targetMarshal, target, "ptr", targetLimit, sourceMarshal, source, sourceLimitMarshal, sourceLimit, offsetsMarshal, offsets, "char", flush, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_fromUnicode", converterMarshal, converter, targetMarshal, target, "ptr", targetLimit, sourceMarshal, source, sourceLimitMarshal, sourceLimit, offsetsMarshal, offsets, "char", flush, errMarshal, err, "CDecl")
     }
 
     /**
@@ -18124,7 +18128,7 @@ class Globalization {
         offsetsMarshal := offsets is VarRef ? "int*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_toUnicode", converterMarshal, converter, targetMarshal, target, targetLimitMarshal, targetLimit, sourceMarshal, source, "ptr", sourceLimit, offsetsMarshal, offsets, "char", flush, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_toUnicode", converterMarshal, converter, targetMarshal, target, targetLimitMarshal, targetLimit, sourceMarshal, source, "ptr", sourceLimit, offsetsMarshal, offsets, "char", flush, errMarshal, err, "CDecl")
     }
 
     /**
@@ -18219,7 +18223,7 @@ class Globalization {
         pivotLimitMarshal := pivotLimit is VarRef ? "ushort*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_convertEx", targetCnvMarshal, targetCnv, sourceCnvMarshal, sourceCnv, targetMarshal, target, "ptr", targetLimit, sourceMarshal, source, "ptr", sourceLimit, pivotStartMarshal, pivotStart, pivotSourceMarshal, pivotSource, pivotTargetMarshal, pivotTarget, pivotLimitMarshal, pivotLimit, "char", reset, "char", flush, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\ucnv_convertEx", targetCnvMarshal, targetCnv, sourceCnvMarshal, sourceCnv, targetMarshal, target, "ptr", targetLimit, sourceMarshal, source, "ptr", sourceLimit, pivotStartMarshal, pivotStart, pivotSourceMarshal, pivotSource, pivotTargetMarshal, pivotTarget, pivotLimitMarshal, pivotLimit, "char", reset, "char", flush, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -18373,7 +18377,7 @@ class Globalization {
         aliasesMarshal := aliases is VarRef ? "ptr*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_getAliases", "ptr", alias, aliasesMarshal, aliases, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\ucnv_getAliases", "ptr", alias, aliasesMarshal, aliases, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -18466,7 +18470,7 @@ class Globalization {
     static ucnv_setDefaultName(name) {
         name := name is String ? StrPtr(name) : name
 
-        DllCall("icuuc.dll\ucnv_setDefaultName", "ptr", name, "CDecl ")
+        DllCall("icuuc.dll\ucnv_setDefaultName", "ptr", name, "CDecl")
     }
 
     /**
@@ -18480,7 +18484,7 @@ class Globalization {
         cnvMarshal := cnv is VarRef ? "ptr*" : "ptr"
         sourceMarshal := source is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_fixFileSeparator", cnvMarshal, cnv, sourceMarshal, source, "int", sourceLen, "CDecl ")
+        DllCall("icuuc.dll\ucnv_fixFileSeparator", cnvMarshal, cnv, sourceMarshal, source, "int", sourceLen, "CDecl")
     }
 
     /**
@@ -18504,7 +18508,7 @@ class Globalization {
     static ucnv_setFallback(cnv, usesFallback) {
         cnvMarshal := cnv is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_setFallback", cnvMarshal, cnv, "char", usesFallback, "CDecl ")
+        DllCall("icuuc.dll\ucnv_setFallback", cnvMarshal, cnv, "char", usesFallback, "CDecl")
     }
 
     /**
@@ -18593,7 +18597,7 @@ class Globalization {
 
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_cbFromUWriteBytes", "ptr", args, "ptr", source, "int", length, "int", offsetIndex, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_cbFromUWriteBytes", "ptr", args, "ptr", source, "int", length, "int", offsetIndex, errMarshal, err, "CDecl")
     }
 
     /**
@@ -18606,7 +18610,7 @@ class Globalization {
     static ucnv_cbFromUWriteSub(args, offsetIndex, err) {
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_cbFromUWriteSub", "ptr", args, "int", offsetIndex, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_cbFromUWriteSub", "ptr", args, "int", offsetIndex, errMarshal, err, "CDecl")
     }
 
     /**
@@ -18623,7 +18627,7 @@ class Globalization {
         sourceLimitMarshal := sourceLimit is VarRef ? "ushort*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_cbFromUWriteUChars", "ptr", args, sourceMarshal, source, sourceLimitMarshal, sourceLimit, "int", offsetIndex, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_cbFromUWriteUChars", "ptr", args, sourceMarshal, source, sourceLimitMarshal, sourceLimit, "int", offsetIndex, errMarshal, err, "CDecl")
     }
 
     /**
@@ -18639,7 +18643,7 @@ class Globalization {
         sourceMarshal := source is VarRef ? "ushort*" : "ptr"
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_cbToUWriteUChars", "ptr", args, sourceMarshal, source, "int", length, "int", offsetIndex, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_cbToUWriteUChars", "ptr", args, sourceMarshal, source, "int", length, "int", offsetIndex, errMarshal, err, "CDecl")
     }
 
     /**
@@ -18652,7 +18656,7 @@ class Globalization {
     static ucnv_cbToUWriteSub(args, offsetIndex, err) {
         errMarshal := err is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucnv_cbToUWriteSub", "ptr", args, "int", offsetIndex, errMarshal, err, "CDecl ")
+        DllCall("icuuc.dll\ucnv_cbToUWriteSub", "ptr", args, "int", offsetIndex, errMarshal, err, "CDecl")
     }
 
     /**
@@ -18663,7 +18667,7 @@ class Globalization {
     static u_init(_status) {
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\u_init", _statusMarshal, _status, "CDecl ")
+        DllCall("icuuc.dll\u_init", _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -18671,7 +18675,7 @@ class Globalization {
      * @returns {String} Nothing - always returns an empty string
      */
     static u_cleanup() {
-        DllCall("icuuc.dll\u_cleanup", "CDecl ")
+        DllCall("icuuc.dll\u_cleanup", "CDecl")
     }
 
     /**
@@ -18690,7 +18694,7 @@ class Globalization {
         fMarshal := f is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\u_setMemoryFunctions", _contextMarshal, _context, aMarshal, a, rMarshal, r, fMarshal, f, _statusMarshal, _status, "CDecl ")
+        DllCall("icuuc.dll\u_setMemoryFunctions", _contextMarshal, _context, aMarshal, a, rMarshal, r, fMarshal, f, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -18718,7 +18722,7 @@ class Globalization {
     static u_catclose(catd) {
         catdMarshal := catd is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\u_catclose", catdMarshal, catd, "CDecl ")
+        DllCall("icuuc.dll\u_catclose", catdMarshal, catd, "CDecl")
     }
 
     /**
@@ -19113,7 +19117,7 @@ class Globalization {
         enumRangeMarshal := enumRange is VarRef ? "ptr*" : "ptr"
         _contextMarshal := _context is VarRef ? "ptr" : "ptr"
 
-        DllCall("icuuc.dll\u_enumCharTypes", enumRangeMarshal, enumRange, _contextMarshal, _context, "CDecl ")
+        DllCall("icuuc.dll\u_enumCharTypes", enumRangeMarshal, enumRange, _contextMarshal, _context, "CDecl")
     }
 
     /**
@@ -19195,7 +19199,7 @@ class Globalization {
         _contextMarshal := _context is VarRef ? "ptr" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\u_enumCharNames", "int", start, "int", limit, fnMarshal, fn, _contextMarshal, _context, "int", nameChoice, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\u_enumCharNames", "int", start, "int", limit, fnMarshal, fn, _contextMarshal, _context, "int", nameChoice, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -19368,7 +19372,7 @@ class Globalization {
     static u_charAge(c, versionArray) {
         versionArrayMarshal := versionArray is VarRef ? "char*" : "ptr"
 
-        DllCall("icuuc.dll\u_charAge", "int", c, versionArrayMarshal, versionArray, "CDecl ")
+        DllCall("icuuc.dll\u_charAge", "int", c, versionArrayMarshal, versionArray, "CDecl")
     }
 
     /**
@@ -19379,7 +19383,7 @@ class Globalization {
     static u_getUnicodeVersion(versionArray) {
         versionArrayMarshal := versionArray is VarRef ? "char*" : "ptr"
 
-        DllCall("icuuc.dll\u_getUnicodeVersion", versionArrayMarshal, versionArray, "CDecl ")
+        DllCall("icuuc.dll\u_getUnicodeVersion", versionArrayMarshal, versionArray, "CDecl")
     }
 
     /**
@@ -19429,7 +19433,7 @@ class Globalization {
     static ubidi_close(pBiDi) {
         pBiDiMarshal := pBiDi is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_close", pBiDiMarshal, pBiDi, "CDecl ")
+        DllCall("icuuc.dll\ubidi_close", pBiDiMarshal, pBiDi, "CDecl")
     }
 
     /**
@@ -19441,7 +19445,7 @@ class Globalization {
     static ubidi_setInverse(pBiDi, isInverse) {
         pBiDiMarshal := pBiDi is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_setInverse", pBiDiMarshal, pBiDi, "char", isInverse, "CDecl ")
+        DllCall("icuuc.dll\ubidi_setInverse", pBiDiMarshal, pBiDi, "char", isInverse, "CDecl")
     }
 
     /**
@@ -19465,7 +19469,7 @@ class Globalization {
     static ubidi_orderParagraphsLTR(pBiDi, orderParagraphsLTR) {
         pBiDiMarshal := pBiDi is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_orderParagraphsLTR", pBiDiMarshal, pBiDi, "char", orderParagraphsLTR, "CDecl ")
+        DllCall("icuuc.dll\ubidi_orderParagraphsLTR", pBiDiMarshal, pBiDi, "char", orderParagraphsLTR, "CDecl")
     }
 
     /**
@@ -19489,7 +19493,7 @@ class Globalization {
     static ubidi_setReorderingMode(pBiDi, reorderingMode) {
         pBiDiMarshal := pBiDi is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_setReorderingMode", pBiDiMarshal, pBiDi, "int", reorderingMode, "CDecl ")
+        DllCall("icuuc.dll\ubidi_setReorderingMode", pBiDiMarshal, pBiDi, "int", reorderingMode, "CDecl")
     }
 
     /**
@@ -19513,7 +19517,7 @@ class Globalization {
     static ubidi_setReorderingOptions(pBiDi, reorderingOptions) {
         pBiDiMarshal := pBiDi is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_setReorderingOptions", pBiDiMarshal, pBiDi, "uint", reorderingOptions, "CDecl ")
+        DllCall("icuuc.dll\ubidi_setReorderingOptions", pBiDiMarshal, pBiDi, "uint", reorderingOptions, "CDecl")
     }
 
     /**
@@ -19544,7 +19548,7 @@ class Globalization {
         epilogueMarshal := epilogue is VarRef ? "ushort*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_setContext", pBiDiMarshal, pBiDi, prologueMarshal, prologue, "int", proLength, epilogueMarshal, epilogue, "int", epiLength, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\ubidi_setContext", pBiDiMarshal, pBiDi, prologueMarshal, prologue, "int", proLength, epilogueMarshal, epilogue, "int", epiLength, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -19563,7 +19567,7 @@ class Globalization {
         embeddingLevelsMarshal := embeddingLevels is VarRef ? "char*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_setPara", pBiDiMarshal, pBiDi, textMarshal, text, "int", length, "char", paraLevel, embeddingLevelsMarshal, embeddingLevels, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\ubidi_setPara", pBiDiMarshal, pBiDi, textMarshal, text, "int", length, "char", paraLevel, embeddingLevelsMarshal, embeddingLevels, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -19580,7 +19584,7 @@ class Globalization {
         pLineBiDiMarshal := pLineBiDi is VarRef ? "ptr*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_setLine", pParaBiDiMarshal, pParaBiDi, "int", start, "int", limit, pLineBiDiMarshal, pLineBiDi, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\ubidi_setLine", pParaBiDiMarshal, pParaBiDi, "int", start, "int", limit, pLineBiDiMarshal, pLineBiDi, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -19694,7 +19698,7 @@ class Globalization {
         pParaLevelMarshal := pParaLevel is VarRef ? "char*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_getParagraphByIndex", pBiDiMarshal, pBiDi, "int", paraIndex, pParaStartMarshal, pParaStart, pParaLimitMarshal, pParaLimit, pParaLevelMarshal, pParaLevel, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\ubidi_getParagraphByIndex", pBiDiMarshal, pBiDi, "int", paraIndex, pParaStartMarshal, pParaStart, pParaLimitMarshal, pParaLimit, pParaLevelMarshal, pParaLevel, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -19737,7 +19741,7 @@ class Globalization {
         pLogicalLimitMarshal := pLogicalLimit is VarRef ? "int*" : "ptr"
         pLevelMarshal := pLevel is VarRef ? "char*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_getLogicalRun", pBiDiMarshal, pBiDi, "int", logicalPosition, pLogicalLimitMarshal, pLogicalLimit, pLevelMarshal, pLevel, "CDecl ")
+        DllCall("icuuc.dll\ubidi_getLogicalRun", pBiDiMarshal, pBiDi, "int", logicalPosition, pLogicalLimitMarshal, pLogicalLimit, pLevelMarshal, pLevel, "CDecl")
     }
 
     /**
@@ -19813,7 +19817,7 @@ class Globalization {
         indexMapMarshal := indexMap is VarRef ? "int*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_getLogicalMap", pBiDiMarshal, pBiDi, indexMapMarshal, indexMap, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\ubidi_getLogicalMap", pBiDiMarshal, pBiDi, indexMapMarshal, indexMap, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -19828,7 +19832,7 @@ class Globalization {
         indexMapMarshal := indexMap is VarRef ? "int*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_getVisualMap", pBiDiMarshal, pBiDi, indexMapMarshal, indexMap, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\ubidi_getVisualMap", pBiDiMarshal, pBiDi, indexMapMarshal, indexMap, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -19842,7 +19846,7 @@ class Globalization {
         _levelsMarshal := _levels is VarRef ? "char*" : "ptr"
         indexMapMarshal := indexMap is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_reorderLogical", _levelsMarshal, _levels, "int", length, indexMapMarshal, indexMap, "CDecl ")
+        DllCall("icuuc.dll\ubidi_reorderLogical", _levelsMarshal, _levels, "int", length, indexMapMarshal, indexMap, "CDecl")
     }
 
     /**
@@ -19856,7 +19860,7 @@ class Globalization {
         _levelsMarshal := _levels is VarRef ? "char*" : "ptr"
         indexMapMarshal := indexMap is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_reorderVisual", _levelsMarshal, _levels, "int", length, indexMapMarshal, indexMap, "CDecl ")
+        DllCall("icuuc.dll\ubidi_reorderVisual", _levelsMarshal, _levels, "int", length, indexMapMarshal, indexMap, "CDecl")
     }
 
     /**
@@ -19870,7 +19874,7 @@ class Globalization {
         srcMapMarshal := srcMap is VarRef ? "int*" : "ptr"
         destMapMarshal := destMap is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_invertMap", srcMapMarshal, srcMap, destMapMarshal, destMap, "int", length, "CDecl ")
+        DllCall("icuuc.dll\ubidi_invertMap", srcMapMarshal, srcMap, destMapMarshal, destMap, "int", length, "CDecl")
     }
 
     /**
@@ -19927,7 +19931,7 @@ class Globalization {
         oldContextMarshal := oldContext is VarRef ? "ptr*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_setClassCallback", pBiDiMarshal, pBiDi, "ptr", newFn, newContextMarshal, newContext, oldFnMarshal, oldFn, oldContextMarshal, oldContext, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\ubidi_setClassCallback", pBiDiMarshal, pBiDi, "ptr", newFn, newContextMarshal, newContext, oldFnMarshal, oldFn, oldContextMarshal, oldContext, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -19942,7 +19946,7 @@ class Globalization {
         fnMarshal := fn is VarRef ? "ptr*" : "ptr"
         _contextMarshal := _context is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ubidi_getClassCallback", pBiDiMarshal, pBiDi, fnMarshal, fn, _contextMarshal, _context, "CDecl ")
+        DllCall("icuuc.dll\ubidi_getClassCallback", pBiDiMarshal, pBiDi, fnMarshal, fn, _contextMarshal, _context, "CDecl")
     }
 
     /**
@@ -20028,7 +20032,7 @@ class Globalization {
     static ubiditransform_close(pBidiTransform) {
         pBidiTransformMarshal := pBidiTransform is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ubiditransform_close", pBidiTransformMarshal, pBidiTransform, "CDecl ")
+        DllCall("icuuc.dll\ubiditransform_close", pBidiTransformMarshal, pBidiTransform, "CDecl")
     }
 
     /**
@@ -20201,7 +20205,7 @@ class Globalization {
      * @returns {String} Nothing - always returns an empty string
      */
     static utext_setNativeIndex(ut, nativeIndex) {
-        DllCall("icuuc.dll\utext_setNativeIndex", "ptr", ut, "int64", nativeIndex, "CDecl ")
+        DllCall("icuuc.dll\utext_setNativeIndex", "ptr", ut, "int64", nativeIndex, "CDecl")
     }
 
     /**
@@ -20294,7 +20298,7 @@ class Globalization {
     static utext_copy(ut, nativeStart, nativeLimit, destIndex, move, _status) {
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\utext_copy", "ptr", ut, "int64", nativeStart, "int64", nativeLimit, "int64", destIndex, "char", move, _statusMarshal, _status, "CDecl ")
+        DllCall("icuuc.dll\utext_copy", "ptr", ut, "int64", nativeStart, "int64", nativeLimit, "int64", destIndex, "char", move, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -20303,7 +20307,7 @@ class Globalization {
      * @returns {String} Nothing - always returns an empty string
      */
     static utext_freeze(ut) {
-        DllCall("icuuc.dll\utext_freeze", "ptr", ut, "CDecl ")
+        DllCall("icuuc.dll\utext_freeze", "ptr", ut, "CDecl")
     }
 
     /**
@@ -20379,7 +20383,7 @@ class Globalization {
     static uset_close(set) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_close", setMarshal, set, "CDecl ")
+        DllCall("icuuc.dll\uset_close", setMarshal, set, "CDecl")
     }
 
     /**
@@ -20414,7 +20418,7 @@ class Globalization {
     static uset_freeze(set) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_freeze", setMarshal, set, "CDecl ")
+        DllCall("icuuc.dll\uset_freeze", setMarshal, set, "CDecl")
     }
 
     /**
@@ -20439,7 +20443,7 @@ class Globalization {
     static uset_set(set, start, end) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_set", setMarshal, set, "int", start, "int", end, "CDecl ")
+        DllCall("icuuc.dll\uset_set", setMarshal, set, "int", start, "int", end, "CDecl")
     }
 
     /**
@@ -20472,7 +20476,7 @@ class Globalization {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\uset_applyIntPropertyValue", setMarshal, set, "int", prop, "int", value, ecMarshal, ec, "CDecl ")
+        DllCall("icuuc.dll\uset_applyIntPropertyValue", setMarshal, set, "int", prop, "int", value, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -20491,7 +20495,7 @@ class Globalization {
         valueMarshal := value is VarRef ? "ushort*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\uset_applyPropertyAlias", setMarshal, set, propMarshal, prop, "int", propLength, valueMarshal, value, "int", valueLength, ecMarshal, ec, "CDecl ")
+        DllCall("icuuc.dll\uset_applyPropertyAlias", setMarshal, set, propMarshal, prop, "int", propLength, valueMarshal, value, "int", valueLength, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -20535,7 +20539,7 @@ class Globalization {
     static uset_add(set, c) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_add", setMarshal, set, "int", c, "CDecl ")
+        DllCall("icuuc.dll\uset_add", setMarshal, set, "int", c, "CDecl")
     }
 
     /**
@@ -20548,7 +20552,7 @@ class Globalization {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
         additionalSetMarshal := additionalSet is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_addAll", setMarshal, set, additionalSetMarshal, additionalSet, "CDecl ")
+        DllCall("icuuc.dll\uset_addAll", setMarshal, set, additionalSetMarshal, additionalSet, "CDecl")
     }
 
     /**
@@ -20561,7 +20565,7 @@ class Globalization {
     static uset_addRange(set, start, end) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_addRange", setMarshal, set, "int", start, "int", end, "CDecl ")
+        DllCall("icuuc.dll\uset_addRange", setMarshal, set, "int", start, "int", end, "CDecl")
     }
 
     /**
@@ -20575,7 +20579,7 @@ class Globalization {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
         strMarshal := str is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuuc.dll\uset_addString", setMarshal, set, strMarshal, str, "int", strLen, "CDecl ")
+        DllCall("icuuc.dll\uset_addString", setMarshal, set, strMarshal, str, "int", strLen, "CDecl")
     }
 
     /**
@@ -20589,7 +20593,7 @@ class Globalization {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
         strMarshal := str is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuuc.dll\uset_addAllCodePoints", setMarshal, set, strMarshal, str, "int", strLen, "CDecl ")
+        DllCall("icuuc.dll\uset_addAllCodePoints", setMarshal, set, strMarshal, str, "int", strLen, "CDecl")
     }
 
     /**
@@ -20601,7 +20605,7 @@ class Globalization {
     static uset_remove(set, c) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_remove", setMarshal, set, "int", c, "CDecl ")
+        DllCall("icuuc.dll\uset_remove", setMarshal, set, "int", c, "CDecl")
     }
 
     /**
@@ -20614,7 +20618,7 @@ class Globalization {
     static uset_removeRange(set, start, end) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_removeRange", setMarshal, set, "int", start, "int", end, "CDecl ")
+        DllCall("icuuc.dll\uset_removeRange", setMarshal, set, "int", start, "int", end, "CDecl")
     }
 
     /**
@@ -20628,7 +20632,7 @@ class Globalization {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
         strMarshal := str is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuuc.dll\uset_removeString", setMarshal, set, strMarshal, str, "int", strLen, "CDecl ")
+        DllCall("icuuc.dll\uset_removeString", setMarshal, set, strMarshal, str, "int", strLen, "CDecl")
     }
 
     /**
@@ -20642,7 +20646,7 @@ class Globalization {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
         strMarshal := str is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icu.dll\uset_removeAllCodePoints", setMarshal, set, strMarshal, str, "int", length, "CDecl ")
+        DllCall("icu.dll\uset_removeAllCodePoints", setMarshal, set, strMarshal, str, "int", length, "CDecl")
     }
 
     /**
@@ -20655,7 +20659,7 @@ class Globalization {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
         removeSetMarshal := removeSet is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_removeAll", setMarshal, set, removeSetMarshal, removeSet, "CDecl ")
+        DllCall("icuuc.dll\uset_removeAll", setMarshal, set, removeSetMarshal, removeSet, "CDecl")
     }
 
     /**
@@ -20668,7 +20672,7 @@ class Globalization {
     static uset_retain(set, start, end) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_retain", setMarshal, set, "int", start, "int", end, "CDecl ")
+        DllCall("icuuc.dll\uset_retain", setMarshal, set, "int", start, "int", end, "CDecl")
     }
 
     /**
@@ -20682,7 +20686,7 @@ class Globalization {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
         strMarshal := str is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icu.dll\uset_retainString", setMarshal, set, strMarshal, str, "int", length, "CDecl ")
+        DllCall("icu.dll\uset_retainString", setMarshal, set, strMarshal, str, "int", length, "CDecl")
     }
 
     /**
@@ -20696,7 +20700,7 @@ class Globalization {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
         strMarshal := str is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icu.dll\uset_retainAllCodePoints", setMarshal, set, strMarshal, str, "int", length, "CDecl ")
+        DllCall("icu.dll\uset_retainAllCodePoints", setMarshal, set, strMarshal, str, "int", length, "CDecl")
     }
 
     /**
@@ -20709,7 +20713,7 @@ class Globalization {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
         retainMarshal := retain is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_retainAll", setMarshal, set, retainMarshal, retain, "CDecl ")
+        DllCall("icuuc.dll\uset_retainAll", setMarshal, set, retainMarshal, retain, "CDecl")
     }
 
     /**
@@ -20720,7 +20724,7 @@ class Globalization {
     static uset_compact(set) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_compact", setMarshal, set, "CDecl ")
+        DllCall("icuuc.dll\uset_compact", setMarshal, set, "CDecl")
     }
 
     /**
@@ -20731,7 +20735,7 @@ class Globalization {
     static uset_complement(set) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_complement", setMarshal, set, "CDecl ")
+        DllCall("icuuc.dll\uset_complement", setMarshal, set, "CDecl")
     }
 
     /**
@@ -20744,7 +20748,7 @@ class Globalization {
     static uset_complementRange(set, start, end) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icu.dll\uset_complementRange", setMarshal, set, "int", start, "int", end, "CDecl ")
+        DllCall("icu.dll\uset_complementRange", setMarshal, set, "int", start, "int", end, "CDecl")
     }
 
     /**
@@ -20758,7 +20762,7 @@ class Globalization {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
         strMarshal := str is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icu.dll\uset_complementString", setMarshal, set, strMarshal, str, "int", length, "CDecl ")
+        DllCall("icu.dll\uset_complementString", setMarshal, set, strMarshal, str, "int", length, "CDecl")
     }
 
     /**
@@ -20772,7 +20776,7 @@ class Globalization {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
         strMarshal := str is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icu.dll\uset_complementAllCodePoints", setMarshal, set, strMarshal, str, "int", length, "CDecl ")
+        DllCall("icu.dll\uset_complementAllCodePoints", setMarshal, set, strMarshal, str, "int", length, "CDecl")
     }
 
     /**
@@ -20785,7 +20789,7 @@ class Globalization {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
         complementMarshal := complement is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_complementAll", setMarshal, set, complementMarshal, complement, "CDecl ")
+        DllCall("icuuc.dll\uset_complementAll", setMarshal, set, complementMarshal, complement, "CDecl")
     }
 
     /**
@@ -20796,7 +20800,7 @@ class Globalization {
     static uset_clear(set) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_clear", setMarshal, set, "CDecl ")
+        DllCall("icuuc.dll\uset_clear", setMarshal, set, "CDecl")
     }
 
     /**
@@ -20808,7 +20812,7 @@ class Globalization {
     static uset_closeOver(set, attributes) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_closeOver", setMarshal, set, "int", attributes, "CDecl ")
+        DllCall("icuuc.dll\uset_closeOver", setMarshal, set, "int", attributes, "CDecl")
     }
 
     /**
@@ -20819,7 +20823,7 @@ class Globalization {
     static uset_removeAllStrings(set) {
         setMarshal := set is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uset_removeAllStrings", setMarshal, set, "CDecl ")
+        DllCall("icuuc.dll\uset_removeAllStrings", setMarshal, set, "CDecl")
     }
 
     /**
@@ -21147,7 +21151,7 @@ class Globalization {
      * @returns {String} Nothing - always returns an empty string
      */
     static uset_setSerializedToOne(fillSet, c) {
-        DllCall("icuuc.dll\uset_setSerializedToOne", "ptr", fillSet, "int", c, "CDecl ")
+        DllCall("icuuc.dll\uset_setSerializedToOne", "ptr", fillSet, "int", c, "CDecl")
     }
 
     /**
@@ -21289,7 +21293,7 @@ class Globalization {
     static unorm2_close(norm2) {
         norm2Marshal := norm2 is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\unorm2_close", norm2Marshal, norm2, "CDecl ")
+        DllCall("icuuc.dll\unorm2_close", norm2Marshal, norm2, "CDecl")
     }
 
     /**
@@ -21552,7 +21556,7 @@ class Globalization {
     static ucnvsel_close(sel) {
         selMarshal := sel is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ucnvsel_close", selMarshal, sel, "CDecl ")
+        DllCall("icuuc.dll\ucnvsel_close", selMarshal, sel, "CDecl")
     }
 
     /**
@@ -21634,7 +21638,7 @@ class Globalization {
 
         usMarshal := us is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuuc.dll\u_charsToUChars", "ptr", cs, usMarshal, us, "int", length, "CDecl ")
+        DllCall("icuuc.dll\u_charsToUChars", "ptr", cs, usMarshal, us, "int", length, "CDecl")
     }
 
     /**
@@ -21649,7 +21653,7 @@ class Globalization {
 
         usMarshal := us is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuuc.dll\u_UCharsToChars", usMarshal, us, "ptr", cs, "int", length, "CDecl ")
+        DllCall("icuuc.dll\u_UCharsToChars", usMarshal, us, "ptr", cs, "int", length, "CDecl")
     }
 
     /**
@@ -22688,7 +22692,7 @@ class Globalization {
     static ucasemap_close(csm) {
         csmMarshal := csm is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ucasemap_close", csmMarshal, csm, "CDecl ")
+        DllCall("icuuc.dll\ucasemap_close", csmMarshal, csm, "CDecl")
     }
 
     /**
@@ -22728,7 +22732,7 @@ class Globalization {
         csmMarshal := csm is VarRef ? "ptr*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucasemap_setLocale", csmMarshal, csm, "ptr", locale, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\ucasemap_setLocale", csmMarshal, csm, "ptr", locale, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -22742,7 +22746,7 @@ class Globalization {
         csmMarshal := csm is VarRef ? "ptr*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucasemap_setOptions", csmMarshal, csm, "uint", options, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\ucasemap_setOptions", csmMarshal, csm, "uint", options, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -22769,7 +22773,7 @@ class Globalization {
         iterToAdoptMarshal := iterToAdopt is VarRef ? "ptr*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ucasemap_setBreakIterator", csmMarshal, csm, iterToAdoptMarshal, iterToAdopt, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuuc.dll\ucasemap_setBreakIterator", csmMarshal, csm, iterToAdoptMarshal, iterToAdopt, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -22914,7 +22918,7 @@ class Globalization {
     static usprep_close(_profile) {
         _profileMarshal := _profile is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\usprep_close", _profileMarshal, _profile, "CDecl ")
+        DllCall("icuuc.dll\usprep_close", _profileMarshal, _profile, "CDecl")
     }
 
     /**
@@ -22960,7 +22964,7 @@ class Globalization {
     static uidna_close(idna) {
         idnaMarshal := idna is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\uidna_close", idnaMarshal, idna, "CDecl ")
+        DllCall("icuuc.dll\uidna_close", idnaMarshal, idna, "CDecl")
     }
 
     /**
@@ -23231,7 +23235,7 @@ class Globalization {
     static ubrk_close(bi) {
         biMarshal := bi is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ubrk_close", biMarshal, bi, "CDecl ")
+        DllCall("icuuc.dll\ubrk_close", biMarshal, bi, "CDecl")
     }
 
     /**
@@ -23247,7 +23251,7 @@ class Globalization {
         textMarshal := text is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ubrk_setText", biMarshal, bi, textMarshal, text, "int", textLength, _statusMarshal, _status, "CDecl ")
+        DllCall("icuuc.dll\ubrk_setText", biMarshal, bi, textMarshal, text, "int", textLength, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -23261,7 +23265,7 @@ class Globalization {
         biMarshal := bi is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ubrk_setUText", biMarshal, bi, "ptr", text, _statusMarshal, _status, "CDecl ")
+        DllCall("icuuc.dll\ubrk_setUText", biMarshal, bi, "ptr", text, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -23437,7 +23441,7 @@ class Globalization {
         biMarshal := bi is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\ubrk_refreshUText", biMarshal, bi, "ptr", text, _statusMarshal, _status, "CDecl ")
+        DllCall("icuuc.dll\ubrk_refreshUText", biMarshal, bi, "ptr", text, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -23467,7 +23471,7 @@ class Globalization {
         dataVersionFillinMarshal := dataVersionFillin is VarRef ? "char*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuuc.dll\u_getDataVersion", dataVersionFillinMarshal, dataVersionFillin, _statusMarshal, _status, "CDecl ")
+        DllCall("icuuc.dll\u_getDataVersion", dataVersionFillinMarshal, dataVersionFillin, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -23540,7 +23544,7 @@ class Globalization {
         zoneIDMarshal := zoneID is VarRef ? "ushort*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucal_setDefaultTimeZone", zoneIDMarshal, zoneID, ecMarshal, ec, "CDecl ")
+        DllCall("icuin.dll\ucal_setDefaultTimeZone", zoneIDMarshal, zoneID, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -23608,7 +23612,7 @@ class Globalization {
     static ucal_close(_cal) {
         _calMarshal := _cal is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ucal_close", _calMarshal, _cal, "CDecl ")
+        DllCall("icuin.dll\ucal_close", _calMarshal, _cal, "CDecl")
     }
 
     /**
@@ -23638,7 +23642,7 @@ class Globalization {
         zoneIDMarshal := zoneID is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucal_setTimeZone", _calMarshal, _cal, zoneIDMarshal, zoneID, "int", len, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ucal_setTimeZone", _calMarshal, _cal, zoneIDMarshal, zoneID, "int", len, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -23704,7 +23708,7 @@ class Globalization {
         _calMarshal := _cal is VarRef ? "ptr*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucal_setGregorianChange", _calMarshal, _cal, "double", date, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuin.dll\ucal_setGregorianChange", _calMarshal, _cal, "double", date, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -23744,7 +23748,7 @@ class Globalization {
     static ucal_setAttribute(_cal, attr, newValue) {
         _calMarshal := _cal is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ucal_setAttribute", _calMarshal, _cal, "int", attr, "int", newValue, "CDecl ")
+        DllCall("icuin.dll\ucal_setAttribute", _calMarshal, _cal, "int", attr, "int", newValue, "CDecl")
     }
 
     /**
@@ -23791,7 +23795,7 @@ class Globalization {
         _calMarshal := _cal is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucal_setMillis", _calMarshal, _cal, "double", _dateTime, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ucal_setMillis", _calMarshal, _cal, "double", _dateTime, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -23807,7 +23811,7 @@ class Globalization {
         _calMarshal := _cal is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucal_setDate", _calMarshal, _cal, "int", year, "int", month, "int", date, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ucal_setDate", _calMarshal, _cal, "int", year, "int", month, "int", date, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -23826,7 +23830,7 @@ class Globalization {
         _calMarshal := _cal is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucal_setDateTime", _calMarshal, _cal, "int", year, "int", month, "int", date, "int", hour, "int", minute, "int", second, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ucal_setDateTime", _calMarshal, _cal, "int", year, "int", month, "int", date, "int", hour, "int", minute, "int", second, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -23855,7 +23859,7 @@ class Globalization {
         _calMarshal := _cal is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucal_add", _calMarshal, _cal, "int", field, "int", amount, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ucal_add", _calMarshal, _cal, "int", field, "int", amount, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -23870,7 +23874,7 @@ class Globalization {
         _calMarshal := _cal is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucal_roll", _calMarshal, _cal, "int", field, "int", amount, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ucal_roll", _calMarshal, _cal, "int", field, "int", amount, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -23898,7 +23902,7 @@ class Globalization {
     static ucal_set(_cal, field, value) {
         _calMarshal := _cal is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ucal_set", _calMarshal, _cal, "int", field, "int", value, "CDecl ")
+        DllCall("icuin.dll\ucal_set", _calMarshal, _cal, "int", field, "int", value, "CDecl")
     }
 
     /**
@@ -23923,7 +23927,7 @@ class Globalization {
     static ucal_clearField(_cal, field) {
         _calMarshal := _cal is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ucal_clearField", _calMarshal, _cal, "int", field, "CDecl ")
+        DllCall("icuin.dll\ucal_clearField", _calMarshal, _cal, "int", field, "CDecl")
     }
 
     /**
@@ -23934,7 +23938,7 @@ class Globalization {
     static ucal_clear(calendar) {
         calendarMarshal := calendar is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ucal_clear", calendarMarshal, calendar, "CDecl ")
+        DllCall("icuin.dll\ucal_clear", calendarMarshal, calendar, "CDecl")
     }
 
     /**
@@ -24165,7 +24169,7 @@ class Globalization {
         dstOffsetMarshal := dstOffset is VarRef ? "int*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\ucal_getTimeZoneOffsetFromLocal", _calMarshal, _cal, "int", nonExistingTimeOpt, "int", duplicatedTimeOpt, rawOffsetMarshal, rawOffset, dstOffsetMarshal, dstOffset, _statusMarshal, _status, "CDecl ")
+        DllCall("icu.dll\ucal_getTimeZoneOffsetFromLocal", _calMarshal, _cal, "int", nonExistingTimeOpt, "int", duplicatedTimeOpt, rawOffsetMarshal, rawOffset, dstOffsetMarshal, dstOffset, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -24216,7 +24220,7 @@ class Globalization {
         expansionsMarshal := expansions is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucol_getContractionsAndExpansions", collMarshal, coll, contractionsMarshal, contractions, expansionsMarshal, expansions, "char", addPrefixes, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ucol_getContractionsAndExpansions", collMarshal, coll, contractionsMarshal, contractions, expansionsMarshal, expansions, "char", addPrefixes, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -24227,7 +24231,7 @@ class Globalization {
     static ucol_close(coll) {
         collMarshal := coll is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ucol_close", collMarshal, coll, "CDecl ")
+        DllCall("icuin.dll\ucol_close", collMarshal, coll, "CDecl")
     }
 
     /**
@@ -24360,7 +24364,7 @@ class Globalization {
     static ucol_setStrength(coll, strength) {
         collMarshal := coll is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ucol_setStrength", collMarshal, coll, "int", strength, "CDecl ")
+        DllCall("icuin.dll\ucol_setStrength", collMarshal, coll, "int", strength, "CDecl")
     }
 
     /**
@@ -24393,7 +24397,7 @@ class Globalization {
         reorderCodesMarshal := reorderCodes is VarRef ? "int*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucol_setReorderCodes", collMarshal, coll, reorderCodesMarshal, reorderCodes, "int", reorderCodesLength, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuin.dll\ucol_setReorderCodes", collMarshal, coll, reorderCodesMarshal, reorderCodes, "int", reorderCodesLength, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -24612,7 +24616,7 @@ class Globalization {
         collMarshal := coll is VarRef ? "ptr*" : "ptr"
         infoMarshal := info is VarRef ? "char*" : "ptr"
 
-        DllCall("icuin.dll\ucol_getVersion", collMarshal, coll, infoMarshal, info, "CDecl ")
+        DllCall("icuin.dll\ucol_getVersion", collMarshal, coll, infoMarshal, info, "CDecl")
     }
 
     /**
@@ -24625,7 +24629,7 @@ class Globalization {
         collMarshal := coll is VarRef ? "ptr*" : "ptr"
         infoMarshal := info is VarRef ? "char*" : "ptr"
 
-        DllCall("icuin.dll\ucol_getUCAVersion", collMarshal, coll, infoMarshal, info, "CDecl ")
+        DllCall("icuin.dll\ucol_getUCAVersion", collMarshal, coll, infoMarshal, info, "CDecl")
     }
 
     /**
@@ -24659,7 +24663,7 @@ class Globalization {
         collMarshal := coll is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucol_setAttribute", collMarshal, coll, "int", attr, "int", value, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ucol_setAttribute", collMarshal, coll, "int", attr, "int", value, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -24688,7 +24692,7 @@ class Globalization {
         collMarshal := coll is VarRef ? "ptr*" : "ptr"
         pErrorCodeMarshal := pErrorCode is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucol_setMaxVariable", collMarshal, coll, "int", group, pErrorCodeMarshal, pErrorCode, "CDecl ")
+        DllCall("icuin.dll\ucol_setMaxVariable", collMarshal, coll, "int", group, pErrorCodeMarshal, pErrorCode, "CDecl")
     }
 
     /**
@@ -24866,7 +24870,7 @@ class Globalization {
     static ucol_closeElements(elems) {
         elemsMarshal := elems is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ucol_closeElements", elemsMarshal, elems, "CDecl ")
+        DllCall("icuin.dll\ucol_closeElements", elemsMarshal, elems, "CDecl")
     }
 
     /**
@@ -24877,7 +24881,7 @@ class Globalization {
     static ucol_reset(elems) {
         elemsMarshal := elems is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ucol_reset", elemsMarshal, elems, "CDecl ")
+        DllCall("icuin.dll\ucol_reset", elemsMarshal, elems, "CDecl")
     }
 
     /**
@@ -24934,7 +24938,7 @@ class Globalization {
         textMarshal := text is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucol_setText", elemsMarshal, elems, textMarshal, text, "int", textLength, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ucol_setText", elemsMarshal, elems, textMarshal, text, "int", textLength, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -24960,7 +24964,7 @@ class Globalization {
         elemsMarshal := elems is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucol_setOffset", elemsMarshal, elems, "int", offset, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ucol_setOffset", elemsMarshal, elems, "int", offset, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -25013,7 +25017,7 @@ class Globalization {
     static ucsdet_close(ucsd) {
         ucsdMarshal := ucsd is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ucsdet_close", ucsdMarshal, ucsd, "CDecl ")
+        DllCall("icuin.dll\ucsdet_close", ucsdMarshal, ucsd, "CDecl")
     }
 
     /**
@@ -25030,7 +25034,7 @@ class Globalization {
         ucsdMarshal := ucsd is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucsdet_setText", ucsdMarshal, ucsd, "ptr", textIn, "int", len, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ucsdet_setText", ucsdMarshal, ucsd, "ptr", textIn, "int", len, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -25047,7 +25051,7 @@ class Globalization {
         ucsdMarshal := ucsd is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ucsdet_setDeclaredEncoding", ucsdMarshal, ucsd, "ptr", encoding, "int", length, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ucsdet_setDeclaredEncoding", ucsdMarshal, ucsd, "ptr", encoding, "int", length, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -25198,7 +25202,7 @@ class Globalization {
     static ufieldpositer_close(fpositer) {
         fpositerMarshal := fpositer is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ufieldpositer_close", fpositerMarshal, fpositer, "CDecl ")
+        DllCall("icuin.dll\ufieldpositer_close", fpositerMarshal, fpositer, "CDecl")
     }
 
     /**
@@ -25237,7 +25241,7 @@ class Globalization {
     static ufmt_close(fmt) {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ufmt_close", fmtMarshal, fmt, "CDecl ")
+        DllCall("icuin.dll\ufmt_close", fmtMarshal, fmt, "CDecl")
     }
 
     /**
@@ -25419,7 +25423,7 @@ class Globalization {
         ucfposMarshal := ucfpos is VarRef ? "ptr*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\ucfpos_reset", ucfposMarshal, ucfpos, ecMarshal, ec, "CDecl ")
+        DllCall("icu.dll\ucfpos_reset", ucfposMarshal, ucfpos, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -25430,7 +25434,7 @@ class Globalization {
     static ucfpos_close(ucfpos) {
         ucfposMarshal := ucfpos is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icu.dll\ucfpos_close", ucfposMarshal, ucfpos, "CDecl ")
+        DllCall("icu.dll\ucfpos_close", ucfposMarshal, ucfpos, "CDecl")
     }
 
     /**
@@ -25444,7 +25448,7 @@ class Globalization {
         ucfposMarshal := ucfpos is VarRef ? "ptr*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\ucfpos_constrainCategory", ucfposMarshal, ucfpos, "int", category, ecMarshal, ec, "CDecl ")
+        DllCall("icu.dll\ucfpos_constrainCategory", ucfposMarshal, ucfpos, "int", category, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -25459,7 +25463,7 @@ class Globalization {
         ucfposMarshal := ucfpos is VarRef ? "ptr*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\ucfpos_constrainField", ucfposMarshal, ucfpos, "int", category, "int", field, ecMarshal, ec, "CDecl ")
+        DllCall("icu.dll\ucfpos_constrainField", ucfposMarshal, ucfpos, "int", category, "int", field, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -25504,7 +25508,7 @@ class Globalization {
         pLimitMarshal := pLimit is VarRef ? "int*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\ucfpos_getIndexes", ucfposMarshal, ucfpos, pStartMarshal, pStart, pLimitMarshal, pLimit, ecMarshal, ec, "CDecl ")
+        DllCall("icu.dll\ucfpos_getIndexes", ucfposMarshal, ucfpos, pStartMarshal, pStart, pLimitMarshal, pLimit, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -25532,7 +25536,7 @@ class Globalization {
         ucfposMarshal := ucfpos is VarRef ? "ptr*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\ucfpos_setInt64IterationContext", ucfposMarshal, ucfpos, "int64", _context, ecMarshal, ec, "CDecl ")
+        DllCall("icu.dll\ucfpos_setInt64IterationContext", ucfposMarshal, ucfpos, "int64", _context, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -25565,7 +25569,7 @@ class Globalization {
         ucfposMarshal := ucfpos is VarRef ? "ptr*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\ucfpos_setState", ucfposMarshal, ucfpos, "int", category, "int", field, "int", start, "int", limit, ecMarshal, ec, "CDecl ")
+        DllCall("icu.dll\ucfpos_setState", ucfposMarshal, ucfpos, "int", category, "int", field, "int", start, "int", limit, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -25629,7 +25633,7 @@ class Globalization {
     static udtitvfmt_close(formatter) {
         formatterMarshal := formatter is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\udtitvfmt_close", formatterMarshal, formatter, "CDecl ")
+        DllCall("icuin.dll\udtitvfmt_close", formatterMarshal, formatter, "CDecl")
     }
 
     /**
@@ -25666,7 +25670,7 @@ class Globalization {
     static udtitvfmt_closeResult(uresult) {
         uresultMarshal := uresult is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icu.dll\udtitvfmt_closeResult", uresultMarshal, uresult, "CDecl ")
+        DllCall("icu.dll\udtitvfmt_closeResult", uresultMarshal, uresult, "CDecl")
     }
 
     /**
@@ -25703,7 +25707,7 @@ class Globalization {
         resultMarshal := result is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\udtitvfmt_formatToResult", formatterMarshal, formatter, "double", fromDate, "double", toDate, resultMarshal, result, _statusMarshal, _status, "CDecl ")
+        DllCall("icu.dll\udtitvfmt_formatToResult", formatterMarshal, formatter, "double", fromDate, "double", toDate, resultMarshal, result, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -25717,7 +25721,7 @@ class Globalization {
         formatterMarshal := formatter is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\udtitvfmt_setContext", formatterMarshal, formatter, "int", value, _statusMarshal, _status, "CDecl ")
+        DllCall("icu.dll\udtitvfmt_setContext", formatterMarshal, formatter, "int", value, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -25807,7 +25811,7 @@ class Globalization {
     static ulistfmt_close(listfmt) {
         listfmtMarshal := listfmt is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuuc.dll\ulistfmt_close", listfmtMarshal, listfmt, "CDecl ")
+        DllCall("icuuc.dll\ulistfmt_close", listfmtMarshal, listfmt, "CDecl")
     }
 
     /**
@@ -25844,7 +25848,7 @@ class Globalization {
     static ulistfmt_closeResult(uresult) {
         uresultMarshal := uresult is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icu.dll\ulistfmt_closeResult", uresultMarshal, uresult, "CDecl ")
+        DllCall("icu.dll\ulistfmt_closeResult", uresultMarshal, uresult, "CDecl")
     }
 
     /**
@@ -25886,7 +25890,7 @@ class Globalization {
         uresultMarshal := uresult is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\ulistfmt_formatStringsToResult", listfmtMarshal, listfmt, stringsMarshal, strings, stringLengthsMarshal, stringLengths, "int", stringCount, uresultMarshal, uresult, _statusMarshal, _status, "CDecl ")
+        DllCall("icu.dll\ulistfmt_formatStringsToResult", listfmtMarshal, listfmt, stringsMarshal, strings, stringLengthsMarshal, stringLengths, "int", stringCount, uresultMarshal, uresult, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -25912,7 +25916,7 @@ class Globalization {
     static ulocdata_close(uld) {
         uldMarshal := uld is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ulocdata_close", uldMarshal, uld, "CDecl ")
+        DllCall("icuin.dll\ulocdata_close", uldMarshal, uld, "CDecl")
     }
 
     /**
@@ -25924,7 +25928,7 @@ class Globalization {
     static ulocdata_setNoSubstitute(uld, setting) {
         uldMarshal := uld is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ulocdata_setNoSubstitute", uldMarshal, uld, "char", setting, "CDecl ")
+        DllCall("icuin.dll\ulocdata_setNoSubstitute", uldMarshal, uld, "char", setting, "CDecl")
     }
 
     /**
@@ -26005,7 +26009,7 @@ class Globalization {
         widthMarshal := width is VarRef ? "int*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ulocdata_getPaperSize", "ptr", localeID, heightMarshal, height, widthMarshal, width, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ulocdata_getPaperSize", "ptr", localeID, heightMarshal, height, widthMarshal, width, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -26018,7 +26022,7 @@ class Globalization {
         versionArrayMarshal := versionArray is VarRef ? "char*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\ulocdata_getCLDRVersion", versionArrayMarshal, versionArray, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\ulocdata_getCLDRVersion", versionArrayMarshal, versionArray, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -26063,16 +26067,20 @@ class Globalization {
      * @param {Pointer<Integer>} result 
      * @param {Integer} resultLength 
      * @param {Pointer<UErrorCode>} _status 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} 
      */
-    static u_formatMessage(locale, pattern, patternLength, result, resultLength, _status) {
+    static u_formatMessage(locale, pattern, patternLength, result, resultLength, _status, args*) {
         locale := locale is String ? StrPtr(locale) : locale
 
         patternMarshal := pattern is VarRef ? "ushort*" : "ptr"
         resultMarshal := result is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        result := DllCall("icuin.dll\u_formatMessage", "ptr", locale, patternMarshal, pattern, "int", patternLength, resultMarshal, result, "int", resultLength, _statusMarshal, _status, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("icuin.dll\u_formatMessage", "ptr", locale, patternMarshal, pattern, "int", patternLength, resultMarshal, result, "int", resultLength, _statusMarshal, _status, varArgs*)
         return result
     }
 
@@ -26107,16 +26115,20 @@ class Globalization {
      * @param {Pointer<Integer>} source 
      * @param {Integer} sourceLength 
      * @param {Pointer<UErrorCode>} _status 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {String} Nothing - always returns an empty string
      */
-    static u_parseMessage(locale, pattern, patternLength, source, sourceLength, _status) {
+    static u_parseMessage(locale, pattern, patternLength, source, sourceLength, _status, args*) {
         locale := locale is String ? StrPtr(locale) : locale
 
         patternMarshal := pattern is VarRef ? "ushort*" : "ptr"
         sourceMarshal := source is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\u_parseMessage", "ptr", locale, patternMarshal, pattern, "int", patternLength, sourceMarshal, source, "int", sourceLength, _statusMarshal, _status, "CDecl ")
+        varArgs := [args*]
+        varArgs.Push("CDecl")
+
+        DllCall("icuin.dll\u_parseMessage", "ptr", locale, patternMarshal, pattern, "int", patternLength, sourceMarshal, source, "int", sourceLength, _statusMarshal, _status, varArgs*)
     }
 
     /**
@@ -26138,7 +26150,7 @@ class Globalization {
         apMarshal := ap is VarRef ? "char*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\u_vparseMessage", "ptr", locale, patternMarshal, pattern, "int", patternLength, sourceMarshal, source, "int", sourceLength, apMarshal, ap, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\u_vparseMessage", "ptr", locale, patternMarshal, pattern, "int", patternLength, sourceMarshal, source, "int", sourceLength, apMarshal, ap, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -26150,16 +26162,20 @@ class Globalization {
      * @param {Integer} resultLength 
      * @param {Pointer<UParseError>} parseError 
      * @param {Pointer<UErrorCode>} _status 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} 
      */
-    static u_formatMessageWithError(locale, pattern, patternLength, result, resultLength, parseError, _status) {
+    static u_formatMessageWithError(locale, pattern, patternLength, result, resultLength, parseError, _status, args*) {
         locale := locale is String ? StrPtr(locale) : locale
 
         patternMarshal := pattern is VarRef ? "ushort*" : "ptr"
         resultMarshal := result is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        result := DllCall("icuin.dll\u_formatMessageWithError", "ptr", locale, patternMarshal, pattern, "int", patternLength, resultMarshal, result, "int", resultLength, "ptr", parseError, _statusMarshal, _status, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("icuin.dll\u_formatMessageWithError", "ptr", locale, patternMarshal, pattern, "int", patternLength, resultMarshal, result, "int", resultLength, "ptr", parseError, _statusMarshal, _status, varArgs*)
         return result
     }
 
@@ -26196,16 +26212,20 @@ class Globalization {
      * @param {Integer} sourceLength 
      * @param {Pointer<UParseError>} parseError 
      * @param {Pointer<UErrorCode>} _status 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {String} Nothing - always returns an empty string
      */
-    static u_parseMessageWithError(locale, pattern, patternLength, source, sourceLength, parseError, _status) {
+    static u_parseMessageWithError(locale, pattern, patternLength, source, sourceLength, parseError, _status, args*) {
         locale := locale is String ? StrPtr(locale) : locale
 
         patternMarshal := pattern is VarRef ? "ushort*" : "ptr"
         sourceMarshal := source is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\u_parseMessageWithError", "ptr", locale, patternMarshal, pattern, "int", patternLength, sourceMarshal, source, "int", sourceLength, "ptr", parseError, _statusMarshal, _status, "CDecl ")
+        varArgs := [args*]
+        varArgs.Push("CDecl")
+
+        DllCall("icuin.dll\u_parseMessageWithError", "ptr", locale, patternMarshal, pattern, "int", patternLength, sourceMarshal, source, "int", sourceLength, "ptr", parseError, _statusMarshal, _status, varArgs*)
     }
 
     /**
@@ -26228,7 +26248,7 @@ class Globalization {
         apMarshal := ap is VarRef ? "char*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\u_vparseMessageWithError", "ptr", locale, patternMarshal, pattern, "int", patternLength, sourceMarshal, source, "int", sourceLength, apMarshal, ap, "ptr", parseError, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\u_vparseMessageWithError", "ptr", locale, patternMarshal, pattern, "int", patternLength, sourceMarshal, source, "int", sourceLength, apMarshal, ap, "ptr", parseError, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -26258,7 +26278,7 @@ class Globalization {
     static umsg_close(format) {
         formatMarshal := format is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\umsg_close", formatMarshal, format, "CDecl ")
+        DllCall("icuin.dll\umsg_close", formatMarshal, format, "CDecl")
     }
 
     /**
@@ -26286,7 +26306,7 @@ class Globalization {
 
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\umsg_setLocale", fmtMarshal, fmt, "ptr", locale, "CDecl ")
+        DllCall("icuin.dll\umsg_setLocale", fmtMarshal, fmt, "ptr", locale, "CDecl")
     }
 
     /**
@@ -26315,7 +26335,7 @@ class Globalization {
         patternMarshal := pattern is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\umsg_applyPattern", fmtMarshal, fmt, patternMarshal, pattern, "int", patternLength, "ptr", parseError, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\umsg_applyPattern", fmtMarshal, fmt, patternMarshal, pattern, "int", patternLength, "ptr", parseError, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -26341,14 +26361,18 @@ class Globalization {
      * @param {Pointer<Integer>} result 
      * @param {Integer} resultLength 
      * @param {Pointer<UErrorCode>} _status 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} 
      */
-    static umsg_format(fmt, result, resultLength, _status) {
+    static umsg_format(fmt, result, resultLength, _status, args*) {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
         resultMarshal := result is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        result := DllCall("icuin.dll\umsg_format", fmtMarshal, fmt, resultMarshal, result, "int", resultLength, _statusMarshal, _status, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("icuin.dll\umsg_format", fmtMarshal, fmt, resultMarshal, result, "int", resultLength, _statusMarshal, _status, varArgs*)
         return result
     }
 
@@ -26378,15 +26402,19 @@ class Globalization {
      * @param {Integer} sourceLength 
      * @param {Pointer<Integer>} count 
      * @param {Pointer<UErrorCode>} _status 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {String} Nothing - always returns an empty string
      */
-    static umsg_parse(fmt, source, sourceLength, count, _status) {
+    static umsg_parse(fmt, source, sourceLength, count, _status, args*) {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
         sourceMarshal := source is VarRef ? "ushort*" : "ptr"
         countMarshal := count is VarRef ? "int*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\umsg_parse", fmtMarshal, fmt, sourceMarshal, source, "int", sourceLength, countMarshal, count, _statusMarshal, _status, "CDecl ")
+        varArgs := [args*]
+        varArgs.Push("CDecl")
+
+        DllCall("icuin.dll\umsg_parse", fmtMarshal, fmt, sourceMarshal, source, "int", sourceLength, countMarshal, count, _statusMarshal, _status, varArgs*)
     }
 
     /**
@@ -26406,7 +26434,7 @@ class Globalization {
         apMarshal := ap is VarRef ? "char*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\umsg_vparse", fmtMarshal, fmt, sourceMarshal, source, "int", sourceLength, countMarshal, count, apMarshal, ap, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\umsg_vparse", fmtMarshal, fmt, sourceMarshal, source, "int", sourceLength, countMarshal, count, apMarshal, ap, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -26455,7 +26483,7 @@ class Globalization {
     static unum_close(fmt) {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\unum_close", fmtMarshal, fmt, "CDecl ")
+        DllCall("icuin.dll\unum_close", fmtMarshal, fmt, "CDecl")
     }
 
     /**
@@ -26749,7 +26777,7 @@ class Globalization {
         patternMarshal := pattern is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\unum_applyPattern", formatMarshal, format, "char", localized, patternMarshal, pattern, "int", patternLength, "ptr", parseError, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\unum_applyPattern", formatMarshal, format, "char", localized, patternMarshal, pattern, "int", patternLength, "ptr", parseError, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -26794,7 +26822,7 @@ class Globalization {
     static unum_setAttribute(fmt, attr, newValue) {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\unum_setAttribute", fmtMarshal, fmt, "int", attr, "int", newValue, "CDecl ")
+        DllCall("icuin.dll\unum_setAttribute", fmtMarshal, fmt, "int", attr, "int", newValue, "CDecl")
     }
 
     /**
@@ -26820,7 +26848,7 @@ class Globalization {
     static unum_setDoubleAttribute(fmt, attr, newValue) {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\unum_setDoubleAttribute", fmtMarshal, fmt, "int", attr, "double", newValue, "CDecl ")
+        DllCall("icuin.dll\unum_setDoubleAttribute", fmtMarshal, fmt, "int", attr, "double", newValue, "CDecl")
     }
 
     /**
@@ -26855,7 +26883,7 @@ class Globalization {
         newValueMarshal := newValue is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\unum_setTextAttribute", fmtMarshal, fmt, "int", tag, newValueMarshal, newValue, "int", newValueLength, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\unum_setTextAttribute", fmtMarshal, fmt, "int", tag, newValueMarshal, newValue, "int", newValueLength, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -26908,7 +26936,7 @@ class Globalization {
         valueMarshal := value is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\unum_setSymbol", fmtMarshal, fmt, "int", symbol, valueMarshal, value, "int", length, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\unum_setSymbol", fmtMarshal, fmt, "int", symbol, valueMarshal, value, "int", length, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -26937,7 +26965,7 @@ class Globalization {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\unum_setContext", fmtMarshal, fmt, "int", value, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\unum_setContext", fmtMarshal, fmt, "int", value, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -26996,7 +27024,7 @@ class Globalization {
     static udat_close(format) {
         formatMarshal := format is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\udat_close", formatMarshal, format, "CDecl ")
+        DllCall("icuin.dll\udat_close", formatMarshal, format, "CDecl")
     }
 
     /**
@@ -27026,7 +27054,7 @@ class Globalization {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\udat_setBooleanAttribute", fmtMarshal, fmt, "int", attr, "char", newValue, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\udat_setBooleanAttribute", fmtMarshal, fmt, "int", attr, "char", newValue, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -27159,7 +27187,7 @@ class Globalization {
         parsePosMarshal := parsePos is VarRef ? "int*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\udat_parseCalendar", formatMarshal, format, calendarMarshal, calendar, textMarshal, text, "int", textLength, parsePosMarshal, parsePos, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\udat_parseCalendar", formatMarshal, format, calendarMarshal, calendar, textMarshal, text, "int", textLength, parsePosMarshal, parsePos, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -27183,7 +27211,7 @@ class Globalization {
     static udat_setLenient(fmt, isLenient) {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\udat_setLenient", fmtMarshal, fmt, "char", isLenient, "CDecl ")
+        DllCall("icuin.dll\udat_setLenient", fmtMarshal, fmt, "char", isLenient, "CDecl")
     }
 
     /**
@@ -27208,7 +27236,7 @@ class Globalization {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
         calendarToSetMarshal := calendarToSet is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\udat_setCalendar", fmtMarshal, fmt, calendarToSetMarshal, calendarToSet, "CDecl ")
+        DllCall("icuin.dll\udat_setCalendar", fmtMarshal, fmt, calendarToSetMarshal, calendarToSet, "CDecl")
     }
 
     /**
@@ -27250,7 +27278,7 @@ class Globalization {
         numberFormatToSetMarshal := numberFormatToSet is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\udat_adoptNumberFormatForFields", fmtMarshal, fmt, fieldsMarshal, fields, numberFormatToSetMarshal, numberFormatToSet, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\udat_adoptNumberFormatForFields", fmtMarshal, fmt, fieldsMarshal, fields, numberFormatToSetMarshal, numberFormatToSet, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -27263,7 +27291,7 @@ class Globalization {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
         numberFormatToSetMarshal := numberFormatToSet is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\udat_setNumberFormat", fmtMarshal, fmt, numberFormatToSetMarshal, numberFormatToSet, "CDecl ")
+        DllCall("icuin.dll\udat_setNumberFormat", fmtMarshal, fmt, numberFormatToSetMarshal, numberFormatToSet, "CDecl")
     }
 
     /**
@@ -27276,7 +27304,7 @@ class Globalization {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
         numberFormatToAdoptMarshal := numberFormatToAdopt is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\udat_adoptNumberFormat", fmtMarshal, fmt, numberFormatToAdoptMarshal, numberFormatToAdopt, "CDecl ")
+        DllCall("icuin.dll\udat_adoptNumberFormat", fmtMarshal, fmt, numberFormatToAdoptMarshal, numberFormatToAdopt, "CDecl")
     }
 
     /**
@@ -27323,7 +27351,7 @@ class Globalization {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\udat_set2DigitYearStart", fmtMarshal, fmt, "double", d, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\udat_set2DigitYearStart", fmtMarshal, fmt, "double", d, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -27356,7 +27384,7 @@ class Globalization {
         formatMarshal := format is VarRef ? "ptr*" : "ptr"
         patternMarshal := pattern is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuin.dll\udat_applyPattern", formatMarshal, format, "char", localized, patternMarshal, pattern, "int", patternLength, "CDecl ")
+        DllCall("icuin.dll\udat_applyPattern", formatMarshal, format, "char", localized, patternMarshal, pattern, "int", patternLength, "CDecl")
     }
 
     /**
@@ -27406,7 +27434,7 @@ class Globalization {
         valueMarshal := value is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\udat_setSymbols", formatMarshal, format, "int", type, "int", symbolIndex, valueMarshal, value, "int", valueLength, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\udat_setSymbols", formatMarshal, format, "int", type, "int", symbolIndex, valueMarshal, value, "int", valueLength, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -27435,7 +27463,7 @@ class Globalization {
         fmtMarshal := fmt is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\udat_setContext", fmtMarshal, fmt, "int", value, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\udat_setContext", fmtMarshal, fmt, "int", value, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -27488,7 +27516,7 @@ class Globalization {
     static udatpg_close(dtpg) {
         dtpgMarshal := dtpg is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\udatpg_close", dtpgMarshal, dtpg, "CDecl ")
+        DllCall("icuin.dll\udatpg_close", dtpgMarshal, dtpg, "CDecl")
     }
 
     /**
@@ -27621,7 +27649,7 @@ class Globalization {
         dtpgMarshal := dtpg is VarRef ? "ptr*" : "ptr"
         valueMarshal := value is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuin.dll\udatpg_setAppendItemFormat", dtpgMarshal, dtpg, "int", field, valueMarshal, value, "int", length, "CDecl ")
+        DllCall("icuin.dll\udatpg_setAppendItemFormat", dtpgMarshal, dtpg, "int", field, valueMarshal, value, "int", length, "CDecl")
     }
 
     /**
@@ -27651,7 +27679,7 @@ class Globalization {
         dtpgMarshal := dtpg is VarRef ? "ptr*" : "ptr"
         valueMarshal := value is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuin.dll\udatpg_setAppendItemName", dtpgMarshal, dtpg, "int", field, valueMarshal, value, "int", length, "CDecl ")
+        DllCall("icuin.dll\udatpg_setAppendItemName", dtpgMarshal, dtpg, "int", field, valueMarshal, value, "int", length, "CDecl")
     }
 
     /**
@@ -27699,7 +27727,7 @@ class Globalization {
         dtpgMarshal := dtpg is VarRef ? "ptr*" : "ptr"
         dtFormatMarshal := dtFormat is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuin.dll\udatpg_setDateTimeFormat", dtpgMarshal, dtpg, dtFormatMarshal, dtFormat, "int", length, "CDecl ")
+        DllCall("icuin.dll\udatpg_setDateTimeFormat", dtpgMarshal, dtpg, dtFormatMarshal, dtFormat, "int", length, "CDecl")
     }
 
     /**
@@ -27727,7 +27755,7 @@ class Globalization {
         dtpgMarshal := dtpg is VarRef ? "ptr*" : "ptr"
         _decimalMarshal := _decimal is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuin.dll\udatpg_setDecimal", dtpgMarshal, dtpg, _decimalMarshal, _decimal, "int", length, "CDecl ")
+        DllCall("icuin.dll\udatpg_setDecimal", dtpgMarshal, dtpg, _decimalMarshal, _decimal, "int", length, "CDecl")
     }
 
     /**
@@ -27912,7 +27940,7 @@ class Globalization {
         uresultMarshal := uresult is VarRef ? "ptr*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\unumf_formatInt", uformatterMarshal, uformatter, "int64", value, uresultMarshal, uresult, ecMarshal, ec, "CDecl ")
+        DllCall("icu.dll\unumf_formatInt", uformatterMarshal, uformatter, "int64", value, uresultMarshal, uresult, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -27928,7 +27956,7 @@ class Globalization {
         uresultMarshal := uresult is VarRef ? "ptr*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\unumf_formatDouble", uformatterMarshal, uformatter, "double", value, uresultMarshal, uresult, ecMarshal, ec, "CDecl ")
+        DllCall("icu.dll\unumf_formatDouble", uformatterMarshal, uformatter, "double", value, uresultMarshal, uresult, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -27947,7 +27975,7 @@ class Globalization {
         uresultMarshal := uresult is VarRef ? "ptr*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\unumf_formatDecimal", uformatterMarshal, uformatter, "ptr", value, "int", valueLen, uresultMarshal, uresult, ecMarshal, ec, "CDecl ")
+        DllCall("icu.dll\unumf_formatDecimal", uformatterMarshal, uformatter, "ptr", value, "int", valueLen, uresultMarshal, uresult, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -28008,7 +28036,7 @@ class Globalization {
         ufpositerMarshal := ufpositer is VarRef ? "ptr*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\unumf_resultGetAllFieldPositions", uresultMarshal, uresult, ufpositerMarshal, ufpositer, ecMarshal, ec, "CDecl ")
+        DllCall("icu.dll\unumf_resultGetAllFieldPositions", uresultMarshal, uresult, ufpositerMarshal, ufpositer, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -28037,7 +28065,7 @@ class Globalization {
     static unumf_close(uformatter) {
         uformatterMarshal := uformatter is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icu.dll\unumf_close", uformatterMarshal, uformatter, "CDecl ")
+        DllCall("icu.dll\unumf_close", uformatterMarshal, uformatter, "CDecl")
     }
 
     /**
@@ -28048,7 +28076,7 @@ class Globalization {
     static unumf_closeResult(uresult) {
         uresultMarshal := uresult is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icu.dll\unumf_closeResult", uresultMarshal, uresult, "CDecl ")
+        DllCall("icu.dll\unumf_closeResult", uresultMarshal, uresult, "CDecl")
     }
 
     /**
@@ -28098,7 +28126,7 @@ class Globalization {
         uresultMarshal := uresult is VarRef ? "ptr*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\unumrf_formatDoubleRange", uformatterMarshal, uformatter, "double", first, "double", second, uresultMarshal, uresult, ecMarshal, ec, "CDecl ")
+        DllCall("icu.dll\unumrf_formatDoubleRange", uformatterMarshal, uformatter, "double", first, "double", second, uresultMarshal, uresult, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -28120,7 +28148,7 @@ class Globalization {
         uresultMarshal := uresult is VarRef ? "ptr*" : "ptr"
         ecMarshal := ec is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\unumrf_formatDecimalRange", uformatterMarshal, uformatter, "ptr", first, "int", firstLen, "ptr", second, "int", secondLen, uresultMarshal, uresult, ecMarshal, ec, "CDecl ")
+        DllCall("icu.dll\unumrf_formatDecimalRange", uformatterMarshal, uformatter, "ptr", first, "int", firstLen, "ptr", second, "int", secondLen, uresultMarshal, uresult, ecMarshal, ec, "CDecl")
     }
 
     /**
@@ -28195,7 +28223,7 @@ class Globalization {
     static unumrf_close(uformatter) {
         uformatterMarshal := uformatter is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icu.dll\unumrf_close", uformatterMarshal, uformatter, "CDecl ")
+        DllCall("icu.dll\unumrf_close", uformatterMarshal, uformatter, "CDecl")
     }
 
     /**
@@ -28206,7 +28234,7 @@ class Globalization {
     static unumrf_closeResult(uresult) {
         uresultMarshal := uresult is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icu.dll\unumrf_closeResult", uresultMarshal, uresult, "CDecl ")
+        DllCall("icu.dll\unumrf_closeResult", uresultMarshal, uresult, "CDecl")
     }
 
     /**
@@ -28247,7 +28275,7 @@ class Globalization {
     static unumsys_close(unumsys) {
         unumsysMarshal := unumsys is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\unumsys_close", unumsysMarshal, unumsys, "CDecl ")
+        DllCall("icuin.dll\unumsys_close", unumsysMarshal, unumsys, "CDecl")
     }
 
     /**
@@ -28354,7 +28382,7 @@ class Globalization {
     static uplrules_close(uplrules) {
         uplrulesMarshal := uplrules is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\uplrules_close", uplrulesMarshal, uplrules, "CDecl ")
+        DllCall("icuin.dll\uplrules_close", uplrulesMarshal, uplrules, "CDecl")
     }
 
     /**
@@ -28465,7 +28493,7 @@ class Globalization {
     static uregex_close(regexp) {
         regexpMarshal := regexp is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\uregex_close", regexpMarshal, regexp, "CDecl ")
+        DllCall("icuin.dll\uregex_close", regexpMarshal, regexp, "CDecl")
     }
 
     /**
@@ -28539,7 +28567,7 @@ class Globalization {
         textMarshal := text is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_setText", regexpMarshal, regexp, textMarshal, text, "int", textLength, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_setText", regexpMarshal, regexp, textMarshal, text, "int", textLength, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -28553,7 +28581,7 @@ class Globalization {
         regexpMarshal := regexp is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_setUText", regexpMarshal, regexp, "ptr", text, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_setUText", regexpMarshal, regexp, "ptr", text, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -28598,7 +28626,7 @@ class Globalization {
         regexpMarshal := regexp is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_refreshUText", regexpMarshal, regexp, "ptr", text, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_refreshUText", regexpMarshal, regexp, "ptr", text, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -28861,7 +28889,7 @@ class Globalization {
         regexpMarshal := regexp is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_reset", regexpMarshal, regexp, "int", index, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_reset", regexpMarshal, regexp, "int", index, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -28875,7 +28903,7 @@ class Globalization {
         regexpMarshal := regexp is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_reset64", regexpMarshal, regexp, "int64", index, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_reset64", regexpMarshal, regexp, "int64", index, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -28890,7 +28918,7 @@ class Globalization {
         regexpMarshal := regexp is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_setRegion", regexpMarshal, regexp, "int", regionStart, "int", regionLimit, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_setRegion", regexpMarshal, regexp, "int", regionStart, "int", regionLimit, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -28905,7 +28933,7 @@ class Globalization {
         regexpMarshal := regexp is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_setRegion64", regexpMarshal, regexp, "int64", regionStart, "int64", regionLimit, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_setRegion64", regexpMarshal, regexp, "int64", regionStart, "int64", regionLimit, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -28921,7 +28949,7 @@ class Globalization {
         regexpMarshal := regexp is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_setRegionAndStart", regexpMarshal, regexp, "int64", regionStart, "int64", regionLimit, "int64", startIndex, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_setRegionAndStart", regexpMarshal, regexp, "int64", regionStart, "int64", regionLimit, "int64", startIndex, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29005,7 +29033,7 @@ class Globalization {
         regexpMarshal := regexp is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_useTransparentBounds", regexpMarshal, regexp, "char", b, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_useTransparentBounds", regexpMarshal, regexp, "char", b, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29033,7 +29061,7 @@ class Globalization {
         regexpMarshal := regexp is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_useAnchoringBounds", regexpMarshal, regexp, "char", b, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_useAnchoringBounds", regexpMarshal, regexp, "char", b, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29169,7 +29197,7 @@ class Globalization {
         regexpMarshal := regexp is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_appendReplacementUText", regexpMarshal, regexp, "ptr", replacementText, "ptr", dest, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_appendReplacementUText", regexpMarshal, regexp, "ptr", replacementText, "ptr", dest, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29255,7 +29283,7 @@ class Globalization {
         regexpMarshal := regexp is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_setTimeLimit", regexpMarshal, regexp, "int", limit, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_setTimeLimit", regexpMarshal, regexp, "int", limit, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29283,7 +29311,7 @@ class Globalization {
         regexpMarshal := regexp is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_setStackLimit", regexpMarshal, regexp, "int", limit, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_setStackLimit", regexpMarshal, regexp, "int", limit, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29313,7 +29341,7 @@ class Globalization {
         _contextMarshal := _context is VarRef ? "ptr" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_setMatchCallback", regexpMarshal, regexp, "ptr", callback, _contextMarshal, _context, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_setMatchCallback", regexpMarshal, regexp, "ptr", callback, _contextMarshal, _context, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29330,7 +29358,7 @@ class Globalization {
         _contextMarshal := _context is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_getMatchCallback", regexpMarshal, regexp, callbackMarshal, callback, _contextMarshal, _context, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_getMatchCallback", regexpMarshal, regexp, callbackMarshal, callback, _contextMarshal, _context, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29346,7 +29374,7 @@ class Globalization {
         _contextMarshal := _context is VarRef ? "ptr" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_setFindProgressCallback", regexpMarshal, regexp, "ptr", callback, _contextMarshal, _context, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_setFindProgressCallback", regexpMarshal, regexp, "ptr", callback, _contextMarshal, _context, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29363,7 +29391,7 @@ class Globalization {
         _contextMarshal := _context is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uregex_getFindProgressCallback", regexpMarshal, regexp, callbackMarshal, callback, _contextMarshal, _context, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uregex_getFindProgressCallback", regexpMarshal, regexp, callbackMarshal, callback, _contextMarshal, _context, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29566,7 +29594,7 @@ class Globalization {
     static ureldatefmt_close(reldatefmt) {
         reldatefmtMarshal := reldatefmt is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\ureldatefmt_close", reldatefmtMarshal, reldatefmt, "CDecl ")
+        DllCall("icuin.dll\ureldatefmt_close", reldatefmtMarshal, reldatefmt, "CDecl")
     }
 
     /**
@@ -29603,7 +29631,7 @@ class Globalization {
     static ureldatefmt_closeResult(ufrdt) {
         ufrdtMarshal := ufrdt is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icu.dll\ureldatefmt_closeResult", ufrdtMarshal, ufrdt, "CDecl ")
+        DllCall("icu.dll\ureldatefmt_closeResult", ufrdtMarshal, ufrdt, "CDecl")
     }
 
     /**
@@ -29639,7 +29667,7 @@ class Globalization {
         resultMarshal := result is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\ureldatefmt_formatNumericToResult", reldatefmtMarshal, reldatefmt, "double", offset, "int", _unit, resultMarshal, result, _statusMarshal, _status, "CDecl ")
+        DllCall("icu.dll\ureldatefmt_formatNumericToResult", reldatefmtMarshal, reldatefmt, "double", offset, "int", _unit, resultMarshal, result, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29675,7 +29703,7 @@ class Globalization {
         resultMarshal := result is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icu.dll\ureldatefmt_formatToResult", reldatefmtMarshal, reldatefmt, "double", offset, "int", _unit, resultMarshal, result, _statusMarshal, _status, "CDecl ")
+        DllCall("icu.dll\ureldatefmt_formatToResult", reldatefmtMarshal, reldatefmt, "double", offset, "int", _unit, resultMarshal, result, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29754,7 +29782,7 @@ class Globalization {
     static usearch_close(searchiter) {
         searchiterMarshal := searchiter is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\usearch_close", searchiterMarshal, searchiter, "CDecl ")
+        DllCall("icuin.dll\usearch_close", searchiterMarshal, searchiter, "CDecl")
     }
 
     /**
@@ -29768,7 +29796,7 @@ class Globalization {
         strsrchMarshal := strsrch is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\usearch_setOffset", strsrchMarshal, strsrch, "int", position, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\usearch_setOffset", strsrchMarshal, strsrch, "int", position, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29795,7 +29823,7 @@ class Globalization {
         strsrchMarshal := strsrch is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\usearch_setAttribute", strsrchMarshal, strsrch, "int", attribute, "int", value, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\usearch_setAttribute", strsrchMarshal, strsrch, "int", attribute, "int", value, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29864,7 +29892,7 @@ class Globalization {
         breakiterMarshal := breakiter is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\usearch_setBreakIterator", strsrchMarshal, strsrch, breakiterMarshal, breakiter, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\usearch_setBreakIterator", strsrchMarshal, strsrch, breakiterMarshal, breakiter, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29892,7 +29920,7 @@ class Globalization {
         textMarshal := text is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\usearch_setText", strsrchMarshal, strsrch, textMarshal, text, "int", textlength, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\usearch_setText", strsrchMarshal, strsrch, textMarshal, text, "int", textlength, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29933,7 +29961,7 @@ class Globalization {
         collatorMarshal := collator is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\usearch_setCollator", strsrchMarshal, strsrch, collatorMarshal, collator, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\usearch_setCollator", strsrchMarshal, strsrch, collatorMarshal, collator, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -29949,7 +29977,7 @@ class Globalization {
         patternMarshal := pattern is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\usearch_setPattern", strsrchMarshal, strsrch, patternMarshal, pattern, "int", patternlength, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\usearch_setPattern", strsrchMarshal, strsrch, patternMarshal, pattern, "int", patternlength, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -30060,7 +30088,7 @@ class Globalization {
     static usearch_reset(strsrch) {
         strsrchMarshal := strsrch is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\usearch_reset", strsrchMarshal, strsrch, "CDecl ")
+        DllCall("icuin.dll\usearch_reset", strsrchMarshal, strsrch, "CDecl")
     }
 
     /**
@@ -30122,7 +30150,7 @@ class Globalization {
     static uspoof_close(sc) {
         scMarshal := sc is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\uspoof_close", scMarshal, sc, "CDecl ")
+        DllCall("icuin.dll\uspoof_close", scMarshal, sc, "CDecl")
     }
 
     /**
@@ -30150,7 +30178,7 @@ class Globalization {
         scMarshal := sc is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uspoof_setChecks", scMarshal, sc, "int", checks, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uspoof_setChecks", scMarshal, sc, "int", checks, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -30176,7 +30204,7 @@ class Globalization {
     static uspoof_setRestrictionLevel(sc, restrictionLevel) {
         scMarshal := sc is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\uspoof_setRestrictionLevel", scMarshal, sc, "int", restrictionLevel, "CDecl ")
+        DllCall("icuin.dll\uspoof_setRestrictionLevel", scMarshal, sc, "int", restrictionLevel, "CDecl")
     }
 
     /**
@@ -30204,7 +30232,7 @@ class Globalization {
         scMarshal := sc is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uspoof_setAllowedLocales", scMarshal, sc, "ptr", localesList, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uspoof_setAllowedLocales", scMarshal, sc, "ptr", localesList, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -30233,7 +30261,7 @@ class Globalization {
         charsMarshal := chars is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\uspoof_setAllowedChars", scMarshal, sc, charsMarshal, chars, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\uspoof_setAllowedChars", scMarshal, sc, charsMarshal, chars, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -30348,7 +30376,7 @@ class Globalization {
     static uspoof_closeCheckResult(checkResult) {
         checkResultMarshal := checkResult is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\uspoof_closeCheckResult", checkResultMarshal, checkResult, "CDecl ")
+        DllCall("icuin.dll\uspoof_closeCheckResult", checkResultMarshal, checkResult, "CDecl")
     }
 
     /**
@@ -30616,7 +30644,7 @@ class Globalization {
     static utrans_close(trans) {
         transMarshal := trans is VarRef ? "ptr*" : "ptr"
 
-        DllCall("icuin.dll\utrans_close", transMarshal, trans, "CDecl ")
+        DllCall("icuin.dll\utrans_close", transMarshal, trans, "CDecl")
     }
 
     /**
@@ -30643,7 +30671,7 @@ class Globalization {
         adoptedTransMarshal := adoptedTrans is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\utrans_register", adoptedTransMarshal, adoptedTrans, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\utrans_register", adoptedTransMarshal, adoptedTrans, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -30655,7 +30683,7 @@ class Globalization {
     static utrans_unregisterID(id, idLength) {
         idMarshal := id is VarRef ? "ushort*" : "ptr"
 
-        DllCall("icuin.dll\utrans_unregisterID", idMarshal, id, "int", idLength, "CDecl ")
+        DllCall("icuin.dll\utrans_unregisterID", idMarshal, id, "int", idLength, "CDecl")
     }
 
     /**
@@ -30671,7 +30699,7 @@ class Globalization {
         filterPatternMarshal := filterPattern is VarRef ? "ushort*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\utrans_setFilter", transMarshal, trans, filterPatternMarshal, filterPattern, "int", filterPatternLen, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\utrans_setFilter", transMarshal, trans, filterPatternMarshal, filterPattern, "int", filterPatternLen, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -30711,7 +30739,7 @@ class Globalization {
         limitMarshal := limit is VarRef ? "int*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\utrans_trans", transMarshal, trans, repMarshal, rep, "ptr", repFunc, "int", start, limitMarshal, limit, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\utrans_trans", transMarshal, trans, repMarshal, rep, "ptr", repFunc, "int", start, limitMarshal, limit, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -30728,7 +30756,7 @@ class Globalization {
         repMarshal := rep is VarRef ? "ptr*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\utrans_transIncremental", transMarshal, trans, repMarshal, rep, "ptr", repFunc, "ptr", pos, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\utrans_transIncremental", transMarshal, trans, repMarshal, rep, "ptr", repFunc, "ptr", pos, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -30749,7 +30777,7 @@ class Globalization {
         limitMarshal := limit is VarRef ? "int*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\utrans_transUChars", transMarshal, trans, textMarshal, text, textLengthMarshal, textLength, "int", textCapacity, "int", start, limitMarshal, limit, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\utrans_transUChars", transMarshal, trans, textMarshal, text, textLengthMarshal, textLength, "int", textCapacity, "int", start, limitMarshal, limit, _statusMarshal, _status, "CDecl")
     }
 
     /**
@@ -30768,7 +30796,7 @@ class Globalization {
         textLengthMarshal := textLength is VarRef ? "int*" : "ptr"
         _statusMarshal := _status is VarRef ? "int*" : "ptr"
 
-        DllCall("icuin.dll\utrans_transIncrementalUChars", transMarshal, trans, textMarshal, text, textLengthMarshal, textLength, "int", textCapacity, "ptr", pos, _statusMarshal, _status, "CDecl ")
+        DllCall("icuin.dll\utrans_transIncrementalUChars", transMarshal, trans, textMarshal, text, textLengthMarshal, textLength, "int", textCapacity, "ptr", pos, _statusMarshal, _status, "CDecl")
     }
 
     /**

--- a/Windows/Win32/Media/Multimedia/Apis.ahk
+++ b/Windows/Win32/Media/Multimedia/Apis.ahk
@@ -27411,14 +27411,18 @@ class Multimedia {
      * @param {Integer} nStreams Number of streams saved in the file.
      * @param {IAVIStream} pfile Pointer to an AVI stream. This parameter is paired with <i>lpOptions</i>. The parameter pair can be repeated as a variable number of arguments.
      * @param {Pointer<AVICOMPRESSOPTIONS>} lpOptions Pointer to an application-defined <a href="https://docs.microsoft.com/windows/desktop/api/vfw/ns-vfw-avicompressoptions">AVICOMPRESSOPTIONS</a> structure containing the compression options for the stream referenced by <i>pavi</i>. This parameter is paired with pavi. The parameter pair can be repeated as a variable number of arguments.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {HRESULT} Returns AVIERR_OK if successful or an error otherwise.
      * @see https://learn.microsoft.com/windows/win32/api/vfw/nf-vfw-avisavea
      * @since windows5.0
      */
-    static AVISaveA(szFile, pclsidHandler, lpfnCallback, nStreams, pfile, lpOptions) {
+    static AVISaveA(szFile, pclsidHandler, lpfnCallback, nStreams, pfile, lpOptions, args*) {
         szFile := szFile is String ? StrPtr(szFile) : szFile
 
-        result := DllCall("AVIFIL32.dll\AVISaveA", "ptr", szFile, "ptr", pclsidHandler, "ptr", lpfnCallback, "int", nStreams, "ptr", pfile, "ptr", lpOptions, "CDecl HRESULT")
+        varArgs := [args*]
+        varArgs.Push("CDecl HRESULT")
+
+        result := DllCall("AVIFIL32.dll\AVISaveA", "ptr", szFile, "ptr", pclsidHandler, "ptr", lpfnCallback, "int", nStreams, "ptr", pfile, "ptr", lpOptions, varArgs*)
         return result
     }
 
@@ -27491,14 +27495,18 @@ class Multimedia {
      * @param {Integer} nStreams Number of streams saved in the file.
      * @param {IAVIStream} pfile Pointer to an AVI stream. This parameter is paired with <i>lpOptions</i>. The parameter pair can be repeated as a variable number of arguments.
      * @param {Pointer<AVICOMPRESSOPTIONS>} lpOptions Pointer to an application-defined <a href="https://docs.microsoft.com/windows/desktop/api/vfw/ns-vfw-avicompressoptions">AVICOMPRESSOPTIONS</a> structure containing the compression options for the stream referenced by <i>pavi</i>. This parameter is paired with pavi. The parameter pair can be repeated as a variable number of arguments.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {HRESULT} Returns AVIERR_OK if successful or an error otherwise.
      * @see https://learn.microsoft.com/windows/win32/api/vfw/nf-vfw-avisavew
      * @since windows5.0
      */
-    static AVISaveW(szFile, pclsidHandler, lpfnCallback, nStreams, pfile, lpOptions) {
+    static AVISaveW(szFile, pclsidHandler, lpfnCallback, nStreams, pfile, lpOptions, args*) {
         szFile := szFile is String ? StrPtr(szFile) : szFile
 
-        result := DllCall("AVIFIL32.dll\AVISaveW", "ptr", szFile, "ptr", pclsidHandler, "ptr", lpfnCallback, "int", nStreams, "ptr", pfile, "ptr", lpOptions, "CDecl HRESULT")
+        varArgs := [args*]
+        varArgs.Push("CDecl HRESULT")
+
+        result := DllCall("AVIFIL32.dll\AVISaveW", "ptr", szFile, "ptr", pclsidHandler, "ptr", lpfnCallback, "int", nStreams, "ptr", pfile, "ptr", lpOptions, varArgs*)
         return result
     }
 

--- a/Windows/Win32/NetworkManagement/NetManagement/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/NetManagement/Apis.ahk
@@ -21451,12 +21451,16 @@ class NetManagement {
      * 
      * @param {Integer} dwTraceID 
      * @param {PSTR} lpszFormat 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} 
      */
-    static TracePrintfA(dwTraceID, lpszFormat) {
+    static TracePrintfA(dwTraceID, lpszFormat, args*) {
         lpszFormat := lpszFormat is String ? StrPtr(lpszFormat) : lpszFormat
 
-        result := DllCall("rtutils.dll\TracePrintfA", "uint", dwTraceID, "ptr", lpszFormat, "CDecl uint")
+        varArgs := [args*]
+        varArgs.Push("CDecl uint")
+
+        result := DllCall("rtutils.dll\TracePrintfA", "uint", dwTraceID, "ptr", lpszFormat, varArgs*)
         return result
     }
 
@@ -21465,12 +21469,16 @@ class NetManagement {
      * @param {Integer} dwTraceID 
      * @param {Integer} dwFlags 
      * @param {PSTR} lpszFormat 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} 
      */
-    static TracePrintfExA(dwTraceID, dwFlags, lpszFormat) {
+    static TracePrintfExA(dwTraceID, dwFlags, lpszFormat, args*) {
         lpszFormat := lpszFormat is String ? StrPtr(lpszFormat) : lpszFormat
 
-        result := DllCall("rtutils.dll\TracePrintfExA", "uint", dwTraceID, "uint", dwFlags, "ptr", lpszFormat, "CDecl uint")
+        varArgs := [args*]
+        varArgs.Push("CDecl uint")
+
+        result := DllCall("rtutils.dll\TracePrintfExA", "uint", dwTraceID, "uint", dwFlags, "ptr", lpszFormat, varArgs*)
         return result
     }
 
@@ -21574,12 +21582,16 @@ class NetManagement {
      * 
      * @param {Integer} dwTraceID 
      * @param {PWSTR} lpszFormat 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} 
      */
-    static TracePrintfW(dwTraceID, lpszFormat) {
+    static TracePrintfW(dwTraceID, lpszFormat, args*) {
         lpszFormat := lpszFormat is String ? StrPtr(lpszFormat) : lpszFormat
 
-        result := DllCall("rtutils.dll\TracePrintfW", "uint", dwTraceID, "ptr", lpszFormat, "CDecl uint")
+        varArgs := [args*]
+        varArgs.Push("CDecl uint")
+
+        result := DllCall("rtutils.dll\TracePrintfW", "uint", dwTraceID, "ptr", lpszFormat, varArgs*)
         return result
     }
 
@@ -21588,12 +21600,16 @@ class NetManagement {
      * @param {Integer} dwTraceID 
      * @param {Integer} dwFlags 
      * @param {PWSTR} lpszFormat 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} 
      */
-    static TracePrintfExW(dwTraceID, dwFlags, lpszFormat) {
+    static TracePrintfExW(dwTraceID, dwFlags, lpszFormat, args*) {
         lpszFormat := lpszFormat is String ? StrPtr(lpszFormat) : lpszFormat
 
-        result := DllCall("rtutils.dll\TracePrintfExW", "uint", dwTraceID, "uint", dwFlags, "ptr", lpszFormat, "CDecl uint")
+        varArgs := [args*]
+        varArgs.Push("CDecl uint")
+
+        result := DllCall("rtutils.dll\TracePrintfExW", "uint", dwTraceID, "uint", dwFlags, "ptr", lpszFormat, varArgs*)
         return result
     }
 
@@ -21792,13 +21808,17 @@ class NetManagement {
      * @param {Integer} dwErrorCode 
      * @param {Integer} dwMessageId 
      * @param {PSTR} ptszFormat 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {String} Nothing - always returns an empty string
      */
-    static RouterLogEventExA(hLogHandle, dwEventType, dwErrorCode, dwMessageId, ptszFormat) {
+    static RouterLogEventExA(hLogHandle, dwEventType, dwErrorCode, dwMessageId, ptszFormat, args*) {
         hLogHandle := hLogHandle is Win32Handle ? NumGet(hLogHandle, "ptr") : hLogHandle
         ptszFormat := ptszFormat is String ? StrPtr(ptszFormat) : ptszFormat
 
-        DllCall("rtutils.dll\RouterLogEventExA", "ptr", hLogHandle, "uint", dwEventType, "uint", dwErrorCode, "uint", dwMessageId, "ptr", ptszFormat, "CDecl ")
+        varArgs := [args*]
+        varArgs.Push("CDecl")
+
+        DllCall("rtutils.dll\RouterLogEventExA", "ptr", hLogHandle, "uint", dwEventType, "uint", dwErrorCode, "uint", dwMessageId, "ptr", ptszFormat, varArgs*)
     }
 
     /**
@@ -21921,13 +21941,17 @@ class NetManagement {
      * @param {Integer} dwErrorCode 
      * @param {Integer} dwMessageId 
      * @param {PWSTR} ptszFormat 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {String} Nothing - always returns an empty string
      */
-    static RouterLogEventExW(hLogHandle, dwEventType, dwErrorCode, dwMessageId, ptszFormat) {
+    static RouterLogEventExW(hLogHandle, dwEventType, dwErrorCode, dwMessageId, ptszFormat, args*) {
         hLogHandle := hLogHandle is Win32Handle ? NumGet(hLogHandle, "ptr") : hLogHandle
         ptszFormat := ptszFormat is String ? StrPtr(ptszFormat) : ptszFormat
 
-        DllCall("rtutils.dll\RouterLogEventExW", "ptr", hLogHandle, "uint", dwEventType, "uint", dwErrorCode, "uint", dwMessageId, "ptr", ptszFormat, "CDecl ")
+        varArgs := [args*]
+        varArgs.Push("CDecl")
+
+        DllCall("rtutils.dll\RouterLogEventExW", "ptr", hLogHandle, "uint", dwEventType, "uint", dwErrorCode, "uint", dwMessageId, "ptr", ptszFormat, varArgs*)
     }
 
     /**

--- a/Windows/Win32/NetworkManagement/NetShell/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/NetShell/Apis.ahk
@@ -326,14 +326,18 @@ class NetShell {
      * Displays a system or application error message to the NetShell console.
      * @param {HANDLE} _hModule A handle to the module from which the string should be loaded, or null for system error messages.
      * @param {Integer} dwErrId The identifier of the message to print.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} Returns the number of characters printed. Returns zero upon failure.
      * @see https://learn.microsoft.com/windows/win32/api/netsh/nf-netsh-printerror
      * @since windows5.1.2600
      */
-    static PrintError(_hModule, dwErrId) {
+    static PrintError(_hModule, dwErrId, args*) {
         _hModule := _hModule is Win32Handle ? NumGet(_hModule, "ptr") : _hModule
 
-        result := DllCall("NETSH.dll\PrintError", "ptr", _hModule, "uint", dwErrId, "CDecl uint")
+        varArgs := [args*]
+        varArgs.Push("CDecl uint")
+
+        result := DllCall("NETSH.dll\PrintError", "ptr", _hModule, "uint", dwErrId, varArgs*)
         return result
     }
 
@@ -343,14 +347,18 @@ class NetShell {
      * Use this function when the format string, identified by the <i>dwMsgId</i> parameter, must be localized.
      * @param {HANDLE} _hModule A handle to the module from which the string should be loaded.
      * @param {Integer} dwMsgId The identifier  of the message to print.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} Returns the number of characters printed. Returns zero upon failure.
      * @see https://learn.microsoft.com/windows/win32/api/netsh/nf-netsh-printmessagefrommodule
      * @since windows5.1.2600
      */
-    static PrintMessageFromModule(_hModule, dwMsgId) {
+    static PrintMessageFromModule(_hModule, dwMsgId, args*) {
         _hModule := _hModule is Win32Handle ? NumGet(_hModule, "ptr") : _hModule
 
-        result := DllCall("NETSH.dll\PrintMessageFromModule", "ptr", _hModule, "uint", dwMsgId, "CDecl uint")
+        varArgs := [args*]
+        varArgs.Push("CDecl uint")
+
+        result := DllCall("NETSH.dll\PrintMessageFromModule", "ptr", _hModule, "uint", dwMsgId, varArgs*)
         return result
     }
 
@@ -360,14 +368,18 @@ class NetShell {
      * Use the 
      * <b>PrintMessage</b> function when the message to be output is not required to be localized.
      * @param {PWSTR} pwszFormat A string to be output to the NetShell console.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} Returns the number of characters printed. Returns zero upon failure.
      * @see https://learn.microsoft.com/windows/win32/api/netsh/nf-netsh-printmessage
      * @since windows5.1.2600
      */
-    static PrintMessage(pwszFormat) {
+    static PrintMessage(pwszFormat, args*) {
         pwszFormat := pwszFormat is String ? StrPtr(pwszFormat) : pwszFormat
 
-        result := DllCall("NETSH.dll\PrintMessage", "ptr", pwszFormat, "CDecl uint")
+        varArgs := [args*]
+        varArgs.Push("CDecl uint")
+
+        result := DllCall("NETSH.dll\PrintMessage", "ptr", pwszFormat, varArgs*)
         return result
     }
 

--- a/Windows/Win32/NetworkManagement/Snmp/Apis.ahk
+++ b/Windows/Win32/NetworkManagement/Snmp/Apis.ahk
@@ -986,14 +986,18 @@ class Snmp {
      * <a href="https://docs.microsoft.com/windows/desktop/api/snmp/nf-snmp-snmpsvcsetlogtype">SnmpSvcSetLogType</a> function to specify the destination for the debug output.
      * @param {SNMP_LOG} nLogLevel 
      * @param {PSTR} szFormat Pointer to a null-terminated format string that is similar to the standard C library function <b>printf</b> style.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {String} Nothing - always returns an empty string
      * @see https://learn.microsoft.com/windows/win32/api/snmp/nf-snmp-snmputildbgprint
      * @since windows5.0
      */
-    static SnmpUtilDbgPrint(nLogLevel, szFormat) {
+    static SnmpUtilDbgPrint(nLogLevel, szFormat, args*) {
         szFormat := szFormat is String ? StrPtr(szFormat) : szFormat
 
-        DllCall("snmpapi.dll\SnmpUtilDbgPrint", "int", nLogLevel, "ptr", szFormat, "CDecl ")
+        varArgs := [args*]
+        varArgs.Push("CDecl")
+
+        DllCall("snmpapi.dll\SnmpUtilDbgPrint", "int", nLogLevel, "ptr", szFormat, varArgs*)
     }
 
     /**

--- a/Windows/Win32/Networking/Ldap/Apis.ahk
+++ b/Windows/Win32/Networking/Ldap/Apis.ahk
@@ -7644,7 +7644,7 @@ class Ldap {
     static ldap_perror(ld, _msg) {
         _msg := _msg is String ? StrPtr(_msg) : _msg
 
-        DllCall("WLDAP32.dll\ldap_perror", "ptr", ld, "ptr", _msg, "CDecl ")
+        DllCall("WLDAP32.dll\ldap_perror", "ptr", ld, "ptr", _msg, "CDecl")
     }
 
     /**
@@ -8544,7 +8544,7 @@ class Ldap {
     static ldap_memfreeW(Block) {
         Block := Block is String ? StrPtr(Block) : Block
 
-        DllCall("WLDAP32.dll\ldap_memfreeW", "ptr", Block, "CDecl ")
+        DllCall("WLDAP32.dll\ldap_memfreeW", "ptr", Block, "CDecl")
     }
 
     /**
@@ -8562,7 +8562,7 @@ class Ldap {
     static ldap_memfreeA(Block) {
         Block := Block is String ? StrPtr(Block) : Block
 
-        DllCall("WLDAP32.dll\ldap_memfreeA", "ptr", Block, "CDecl ")
+        DllCall("WLDAP32.dll\ldap_memfreeA", "ptr", Block, "CDecl")
     }
 
     /**
@@ -8575,7 +8575,7 @@ class Ldap {
      * @since windows6.0.6000
      */
     static ber_bvfree(bv) {
-        DllCall("WLDAP32.dll\ber_bvfree", "ptr", bv, "CDecl ")
+        DllCall("WLDAP32.dll\ber_bvfree", "ptr", bv, "CDecl")
     }
 
     /**
@@ -8593,7 +8593,7 @@ class Ldap {
     static ldap_memfree(Block) {
         Block := Block is String ? StrPtr(Block) : Block
 
-        DllCall("WLDAP32.dll\ldap_memfree", "ptr", Block, "CDecl ")
+        DllCall("WLDAP32.dll\ldap_memfree", "ptr", Block, "CDecl")
     }
 
     /**
@@ -8807,7 +8807,7 @@ class Ldap {
      * @returns {String} Nothing - always returns an empty string
      */
     static ldap_set_dbg_routine(DebugPrintRoutine) {
-        DllCall("WLDAP32.dll\ldap_set_dbg_routine", "ptr", DebugPrintRoutine, "CDecl ")
+        DllCall("WLDAP32.dll\ldap_set_dbg_routine", "ptr", DebugPrintRoutine, "CDecl")
     }
 
     /**
@@ -10292,7 +10292,7 @@ class Ldap {
      * @since windows6.0.6000
      */
     static ber_free(pBerElement, fbuf) {
-        DllCall("WLDAP32.dll\ber_free", "ptr", pBerElement, "int", fbuf, "CDecl ")
+        DllCall("WLDAP32.dll\ber_free", "ptr", pBerElement, "int", fbuf, "CDecl")
     }
 
     /**
@@ -10310,7 +10310,7 @@ class Ldap {
     static ber_bvecfree(pBerVal) {
         pBerValMarshal := pBerVal is VarRef ? "ptr*" : "ptr"
 
-        DllCall("WLDAP32.dll\ber_bvecfree", pBerValMarshal, pBerVal, "CDecl ")
+        DllCall("WLDAP32.dll\ber_bvecfree", pBerValMarshal, pBerVal, "CDecl")
     }
 
     /**
@@ -10516,14 +10516,18 @@ class Ldap {
      * Each left brace (<b>{</b>) character must be paired with a right brace (<b>}</b>) character later in the format string, or in the format string of a subsequent call to <b>ber_printf</b> for that specific <a href="https://docs.microsoft.com/previous-versions/windows/desktop/api/winldap/ns-winldap-berelement">BerElement</a>. The same applies to the left bracket ([) character and right bracket (]) characters.
      * @param {Pointer<BerElement>} pBerElement A pointer to the encoded <a href="https://docs.microsoft.com/previous-versions/windows/desktop/api/winldap/ns-winldap-berelement">BerElement</a> structure.
      * @param {PSTR} fmt An encoding format string. For more information, see Remarks.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} If the function succeeds, a non-negative number is returned. If the function fails,  -1 is returned.
      * @see https://learn.microsoft.com/windows/win32/api/winber/nf-winber-ber_printf
      * @since windows6.0.6000
      */
-    static ber_printf(pBerElement, fmt) {
+    static ber_printf(pBerElement, fmt, args*) {
         fmt := fmt is String ? StrPtr(fmt) : fmt
 
-        result := DllCall("WLDAP32.dll\ber_printf", "ptr", pBerElement, "ptr", fmt, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("WLDAP32.dll\ber_printf", "ptr", pBerElement, "ptr", fmt, varArgs*)
         return result
     }
 
@@ -10605,14 +10609,18 @@ class Ldap {
      * </table>
      * @param {Pointer<BerElement>} pBerElement Pointer to the decoded <a href="https://docs.microsoft.com/previous-versions/windows/desktop/api/winldap/ns-winldap-berelement">BerElement</a> structure.
      * @param {PSTR} fmt Encoding format string. For more information, see Remarks section.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} On error, the function returns LBER_ERROR.
      * @see https://learn.microsoft.com/windows/win32/api/winber/nf-winber-ber_scanf
      * @since windows6.0.6000
      */
-    static ber_scanf(pBerElement, fmt) {
+    static ber_scanf(pBerElement, fmt, args*) {
         fmt := fmt is String ? StrPtr(fmt) : fmt
 
-        result := DllCall("WLDAP32.dll\ber_scanf", "ptr", pBerElement, "ptr", fmt, "CDecl uint")
+        varArgs := [args*]
+        varArgs.Push("CDecl uint")
+
+        result := DllCall("WLDAP32.dll\ber_scanf", "ptr", pBerElement, "ptr", fmt, varArgs*)
         return result
     }
 

--- a/Windows/Win32/Security/Authorization/Apis.ahk
+++ b/Windows/Win32/Security/Authorization/Apis.ahk
@@ -2209,13 +2209,14 @@ class Authorization {
      * @param {PWSTR} szAdditionalInfo String, defined by the Resource Manager, for additional audit information.
      * @param {Pointer<AUTHZ_AUDIT_EVENT_HANDLE>} phAuditEvent Pointer that receives an <b>AUTHZ_AUDIT_EVENT_HANDLE</b> structure.
      * @param {Integer} dwAdditionalParameterCount Must be set to zero.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {BOOL} If the function succeeds, it returns <b>TRUE</b>.
      * 
      * If the function fails, it returns <b>FALSE</b>. For extended error information, call <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
      * @see https://learn.microsoft.com/windows/win32/api/authz/nf-authz-authzinitializeobjectaccessauditevent
      * @since windows5.1.2600
      */
-    static AuthzInitializeObjectAccessAuditEvent(Flags, hAuditEventType, szOperationType, szObjectType, szObjectName, szAdditionalInfo, phAuditEvent, dwAdditionalParameterCount) {
+    static AuthzInitializeObjectAccessAuditEvent(Flags, hAuditEventType, szOperationType, szObjectType, szObjectName, szAdditionalInfo, phAuditEvent, dwAdditionalParameterCount, args*) {
         hAuditEventType := hAuditEventType is Win32Handle ? NumGet(hAuditEventType, "ptr") : hAuditEventType
         szOperationType := szOperationType is String ? StrPtr(szOperationType) : szOperationType
         szObjectType := szObjectType is String ? StrPtr(szObjectType) : szObjectType
@@ -2224,7 +2225,10 @@ class Authorization {
 
         A_LastError := 0
 
-        result := DllCall("AUTHZ.dll\AuthzInitializeObjectAccessAuditEvent", "uint", Flags, "ptr", hAuditEventType, "ptr", szOperationType, "ptr", szObjectType, "ptr", szObjectName, "ptr", szAdditionalInfo, "ptr", phAuditEvent, "uint", dwAdditionalParameterCount, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("AUTHZ.dll\AuthzInitializeObjectAccessAuditEvent", "uint", Flags, "ptr", hAuditEventType, "ptr", szOperationType, "ptr", szObjectType, "ptr", szObjectName, "ptr", szAdditionalInfo, "ptr", phAuditEvent, "uint", dwAdditionalParameterCount, varArgs*)
         if(!result && A_LastError) {
             throw OSError(A_LastError)
         }
@@ -2280,13 +2284,14 @@ class Authorization {
      * @param {PWSTR} szAdditionalInfo2 Pointer to a string defined by the Resource Manager that contains additional audit information.
      * @param {Pointer<AUTHZ_AUDIT_EVENT_HANDLE>} phAuditEvent A pointer to the returned <b>AUTHZ_AUDIT_EVENT_HANDLE</b> handle.
      * @param {Integer} dwAdditionalParameterCount Must be set to zero.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {BOOL} If the function succeeds, it returns <b>TRUE</b>.
      * 
      * If the function fails, it returns <b>FALSE</b>. For extended error information, call <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
      * @see https://learn.microsoft.com/windows/win32/api/authz/nf-authz-authzinitializeobjectaccessauditevent2
      * @since windowsserver2003
      */
-    static AuthzInitializeObjectAccessAuditEvent2(Flags, hAuditEventType, szOperationType, szObjectType, szObjectName, szAdditionalInfo, szAdditionalInfo2, phAuditEvent, dwAdditionalParameterCount) {
+    static AuthzInitializeObjectAccessAuditEvent2(Flags, hAuditEventType, szOperationType, szObjectType, szObjectName, szAdditionalInfo, szAdditionalInfo2, phAuditEvent, dwAdditionalParameterCount, args*) {
         hAuditEventType := hAuditEventType is Win32Handle ? NumGet(hAuditEventType, "ptr") : hAuditEventType
         szOperationType := szOperationType is String ? StrPtr(szOperationType) : szOperationType
         szObjectType := szObjectType is String ? StrPtr(szObjectType) : szObjectType
@@ -2296,7 +2301,10 @@ class Authorization {
 
         A_LastError := 0
 
-        result := DllCall("AUTHZ.dll\AuthzInitializeObjectAccessAuditEvent2", "uint", Flags, "ptr", hAuditEventType, "ptr", szOperationType, "ptr", szObjectType, "ptr", szObjectName, "ptr", szAdditionalInfo, "ptr", szAdditionalInfo2, "ptr", phAuditEvent, "uint", dwAdditionalParameterCount, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("AUTHZ.dll\AuthzInitializeObjectAccessAuditEvent2", "uint", Flags, "ptr", hAuditEventType, "ptr", szOperationType, "ptr", szObjectType, "ptr", szObjectName, "ptr", szAdditionalInfo, "ptr", szAdditionalInfo2, "ptr", phAuditEvent, "uint", dwAdditionalParameterCount, varArgs*)
         if(!result && A_LastError) {
             throw OSError(A_LastError)
         }
@@ -2531,18 +2539,22 @@ class Authorization {
      * @param {Integer} dwAuditId The identifier of the audit.
      * @param {PSID} pUserSid A pointer to the <a href="https://docs.microsoft.com/windows/desktop/SecGloss/s-gly">security identifier</a> (SID) that will be listed as the source of the audit in the event log.
      * @param {Integer} dwCount The number of AuditParamFlag  type/value pairs that appear in the variable arguments section that follows this parameter.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {BOOL} If the function succeeds, the function returns <b>TRUE</b>.
      * 
      * If the function fails, it returns <b>FALSE</b>. For extended error information, call <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
      * @see https://learn.microsoft.com/windows/win32/api/authz/nf-authz-authzreportsecurityevent
      * @since windowsserver2003
      */
-    static AuthzReportSecurityEvent(dwFlags, hEventProvider, dwAuditId, pUserSid, dwCount) {
+    static AuthzReportSecurityEvent(dwFlags, hEventProvider, dwAuditId, pUserSid, dwCount, args*) {
         hEventProvider := hEventProvider is Win32Handle ? NumGet(hEventProvider, "ptr") : hEventProvider
 
         A_LastError := 0
 
-        result := DllCall("AUTHZ.dll\AuthzReportSecurityEvent", "uint", dwFlags, "ptr", hEventProvider, "uint", dwAuditId, "ptr", pUserSid, "uint", dwCount, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("AUTHZ.dll\AuthzReportSecurityEvent", "uint", dwFlags, "ptr", hEventProvider, "uint", dwAuditId, "ptr", pUserSid, "uint", dwCount, varArgs*)
         if(!result && A_LastError) {
             throw OSError(A_LastError)
         }

--- a/Windows/Win32/System/DeploymentServices/Apis.ahk
+++ b/Windows/Win32/System/DeploymentServices/Apis.ahk
@@ -1328,14 +1328,18 @@ class DeploymentServices {
      * </td>
      * </tr>
      * </table>
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {HRESULT} If the function succeeds, the return is <b>S_OK</b>.
      * @see https://learn.microsoft.com/windows/win32/api/wdsclientapi/nf-wdsclientapi-wdsclilog
      * @since windows6.0.6000
      */
-    static WdsCliLog(hSession, ulLogLevel, ulMessageCode) {
+    static WdsCliLog(hSession, ulLogLevel, ulMessageCode, args*) {
         hSession := hSession is Win32Handle ? NumGet(hSession, "ptr") : hSession
 
-        result := DllCall("WDSCLIENTAPI.dll\WdsCliLog", "ptr", hSession, "uint", ulLogLevel, "uint", ulMessageCode, "CDecl HRESULT")
+        varArgs := [args*]
+        varArgs.Push("CDecl HRESULT")
+
+        result := DllCall("WDSCLIENTAPI.dll\WdsCliLog", "ptr", hSession, "uint", ulLogLevel, "uint", ulMessageCode, varArgs*)
         return result
     }
 
@@ -2270,15 +2274,19 @@ class DeploymentServices {
      * </tr>
      * </table>
      * @param {PWSTR} pszFormat Address of a buffer that contains a printf-style format string.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} If the function succeeds, the return value is <b>ERROR_SUCCESS</b>.
      * @see https://learn.microsoft.com/windows/win32/api/wdspxe/nf-wdspxe-pxetrace
      * @since windowsserver2008
      */
-    static PxeTrace(_hProvider, Severity, pszFormat) {
+    static PxeTrace(_hProvider, Severity, pszFormat, args*) {
         _hProvider := _hProvider is Win32Handle ? NumGet(_hProvider, "ptr") : _hProvider
         pszFormat := pszFormat is String ? StrPtr(pszFormat) : pszFormat
 
-        result := DllCall("WDSPXE.dll\PxeTrace", "ptr", _hProvider, "uint", Severity, "ptr", pszFormat, "CDecl uint")
+        varArgs := [args*]
+        varArgs.Push("CDecl uint")
+
+        result := DllCall("WDSPXE.dll\PxeTrace", "ptr", _hProvider, "uint", Severity, "ptr", pszFormat, varArgs*)
         return result
     }
 
@@ -3185,15 +3193,19 @@ class DeploymentServices {
      * @param {HANDLE} _hProvider Handle to the provider. This handle was given to the provider in the <a href="https://docs.microsoft.com/windows/desktop/api/wdstpdi/nf-wdstpdi-wdstransportproviderinitialize">WdsTransportProviderInitialize</a> function.
      * @param {Integer} Severity Severity level of the message.
      * @param {PWSTR} pwszFormat A pointer to a null-terminated string value that contains a formatted string.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {HRESULT} If the function succeeds, the return is <b>S_OK</b>.
      * @see https://learn.microsoft.com/windows/win32/api/wdstpdi/nf-wdstpdi-wdstransportservertrace
      * @since windowsserver2008
      */
-    static WdsTransportServerTrace(_hProvider, Severity, pwszFormat) {
+    static WdsTransportServerTrace(_hProvider, Severity, pwszFormat, args*) {
         _hProvider := _hProvider is Win32Handle ? NumGet(_hProvider, "ptr") : _hProvider
         pwszFormat := pwszFormat is String ? StrPtr(pwszFormat) : pwszFormat
 
-        result := DllCall("WDSMC.dll\WdsTransportServerTrace", "ptr", _hProvider, "uint", Severity, "ptr", pwszFormat, "CDecl HRESULT")
+        varArgs := [args*]
+        varArgs.Push("CDecl HRESULT")
+
+        result := DllCall("WDSMC.dll\WdsTransportServerTrace", "ptr", _hProvider, "uint", Severity, "ptr", pwszFormat, varArgs*)
         return result
     }
 

--- a/Windows/Win32/System/Diagnostics/Debug/Apis.ahk
+++ b/Windows/Win32/System/Diagnostics/Debug/Apis.ahk
@@ -2470,7 +2470,7 @@ class Debug {
      * @see https://learn.microsoft.com/windows/win32/api/winnt/nf-winnt-rtlrestorecontext
      */
     static RtlRestoreContext(ContextRecord, ExceptionRecord) {
-        DllCall("KERNEL32.dll\RtlRestoreContext", "ptr", ContextRecord, "ptr", ExceptionRecord, "CDecl ")
+        DllCall("KERNEL32.dll\RtlRestoreContext", "ptr", ContextRecord, "ptr", ExceptionRecord, "CDecl")
     }
 
     /**

--- a/Windows/Win32/System/Diagnostics/Etw/Apis.ahk
+++ b/Windows/Win32/System/Diagnostics/Etw/Apis.ahk
@@ -6294,6 +6294,7 @@ class Etw {
      * @param {Integer} MessageNumber Number that uniquely identifies each occurrence of the message. You must define
      * the value specified for this parameter; the value should be meaningful to the
      * application.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {WIN32_ERROR} If the function succeeds, the return value is ERROR_SUCCESS.
      * 
      * If the function fails, the return value is one of the
@@ -6332,8 +6333,11 @@ class Etw {
      * @see https://learn.microsoft.com/windows/win32/api/evntrace/nf-evntrace-tracemessage
      * @since windows5.1.2600
      */
-    static TraceMessage(LoggerHandle, MessageFlags, MessageGuid, MessageNumber) {
-        result := DllCall("ADVAPI32.dll\TraceMessage", "uint", LoggerHandle, "uint", MessageFlags, "ptr", MessageGuid, "ushort", MessageNumber, "CDecl uint")
+    static TraceMessage(LoggerHandle, MessageFlags, MessageGuid, MessageNumber, args*) {
+        varArgs := [args*]
+        varArgs.Push("CDecl uint")
+
+        result := DllCall("ADVAPI32.dll\TraceMessage", "uint", LoggerHandle, "uint", MessageFlags, "ptr", MessageGuid, "ushort", MessageNumber, varArgs*)
         return result
     }
 

--- a/Windows/Win32/System/Ole/Apis.ahk
+++ b/Windows/Win32/System/Ole/Apis.ahk
@@ -24157,6 +24157,7 @@ class Ole {
      * > The oledlg.h header defines OleUIPromptUser as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
      * @param {Integer} nTemplate The resource number of the dialog box to be displayed. See Remarks.
      * @param {HWND} hwndParent The handle to the parent window of the dialog box.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} Standard Success/Error Definitions
      * 
      * 
@@ -24451,10 +24452,13 @@ class Ole {
      * @see https://learn.microsoft.com/windows/win32/api/oledlg/nf-oledlg-oleuipromptuserw
      * @since windows5.0
      */
-    static OleUIPromptUserW(nTemplate, hwndParent) {
+    static OleUIPromptUserW(nTemplate, hwndParent, args*) {
         hwndParent := hwndParent is Win32Handle ? NumGet(hwndParent, "ptr") : hwndParent
 
-        result := DllCall("oledlg.dll\OleUIPromptUserW", "int", nTemplate, "ptr", hwndParent, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("oledlg.dll\OleUIPromptUserW", "int", nTemplate, "ptr", hwndParent, varArgs*)
         return result
     }
 
@@ -24479,6 +24483,7 @@ class Ole {
      * > The oledlg.h header defines OleUIPromptUser as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
      * @param {Integer} nTemplate The resource number of the dialog box to be displayed. See Remarks.
      * @param {HWND} hwndParent The handle to the parent window of the dialog box.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} Standard Success/Error Definitions
      * 
      * 
@@ -24773,10 +24778,13 @@ class Ole {
      * @see https://learn.microsoft.com/windows/win32/api/oledlg/nf-oledlg-oleuipromptusera
      * @since windows5.0
      */
-    static OleUIPromptUserA(nTemplate, hwndParent) {
+    static OleUIPromptUserA(nTemplate, hwndParent, args*) {
         hwndParent := hwndParent is Win32Handle ? NumGet(hwndParent, "ptr") : hwndParent
 
-        result := DllCall("oledlg.dll\OleUIPromptUserA", "int", nTemplate, "ptr", hwndParent, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("oledlg.dll\OleUIPromptUserA", "int", nTemplate, "ptr", hwndParent, varArgs*)
         return result
     }
 

--- a/Windows/Win32/System/Rpc/Apis.ahk
+++ b/Windows/Win32/System/Rpc/Apis.ahk
@@ -23903,16 +23903,20 @@ class Rpc {
      * The <b>NdrClientCall2</b> function is used by all <a href="https://docs.microsoft.com/windows/desktop/Midl/-oi">/Oicf</a> mode client-side stubs. The <b>NdrClientCall2</b> function transmits all [in] data to the remote server, and upon receipt of the response packet, returns the [out] value to the client-side application.
      * @param {Pointer<MIDL_STUB_DESC>} pStubDescriptor Pointer to the MIDL-generated <a href="https://docs.microsoft.com/windows/desktop/api/rpcndr/ns-rpcndr-midl_stub_desc">MIDL_STUB_DESC</a> structure that contains information about the description of the remote interface.
      * @param {Pointer<Integer>} pFormat Pointer to the MIDL-generated procedure format string that describes the method and parameters.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {CLIENT_CALL_RETURN} Return value of the remote call. The maximum size of a return value is equivalent to the register size of the system. MIDL switches to the <a href="https://docs.microsoft.com/windows/desktop/Midl/-os">/Os</a> mode stub if the return value size is larger than the register size.
      * 
      * Depending on the method definition, this function can throw an exception if there is a network or server failure.
      * @see https://learn.microsoft.com/windows/win32/api/rpcndr/nf-rpcndr-ndrclientcall2
      * @since windows5.0
      */
-    static NdrClientCall2(pStubDescriptor, pFormat) {
+    static NdrClientCall2(pStubDescriptor, pFormat, args*) {
         pFormatMarshal := pFormat is VarRef ? "char*" : "ptr"
 
-        result := DllCall("RPCRT4.dll\NdrClientCall2", "ptr", pStubDescriptor, pFormatMarshal, pFormat, "CDecl ptr")
+        varArgs := [args*]
+        varArgs.Push("CDecl ptr")
+
+        result := DllCall("RPCRT4.dll\NdrClientCall2", "ptr", pStubDescriptor, pFormatMarshal, pFormat, varArgs*)
         return result
     }
 
@@ -23920,16 +23924,20 @@ class Rpc {
      * The NdrAsyncClientCall function is the asynchronous client-side entry point for the /Oi and /Oic mode stub.
      * @param {Pointer<MIDL_STUB_DESC>} pStubDescriptor Pointer to the MIDL-generated <a href="https://docs.microsoft.com/windows/desktop/api/rpcndr/ns-rpcndr-midl_stub_desc">MIDL_STUB_DESC</a> structure that contains information about the description of the remote interface.
      * @param {Pointer<Integer>} pFormat Pointer to the MIDL-generated procedure format string that describes the method and parameters.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {CLIENT_CALL_RETURN} Return value of the remote call. The maximum size of a return value is equivalent to the register size of the system. MIDL switches to the <a href="https://docs.microsoft.com/windows/desktop/Midl/-os">/Os</a> mode stub if the return value size is larger than the register size.
      * 
      * Depending on the method definition, this function can throw an exception if there is a network or server failure.
      * @see https://learn.microsoft.com/windows/win32/api/rpcndr/nf-rpcndr-ndrasyncclientcall
      * @since windows5.0
      */
-    static NdrAsyncClientCall(pStubDescriptor, pFormat) {
+    static NdrAsyncClientCall(pStubDescriptor, pFormat, args*) {
         pFormatMarshal := pFormat is VarRef ? "char*" : "ptr"
 
-        result := DllCall("RPCRT4.dll\NdrAsyncClientCall", "ptr", pStubDescriptor, pFormatMarshal, pFormat, "CDecl ptr")
+        varArgs := [args*]
+        varArgs.Push("CDecl ptr")
+
+        result := DllCall("RPCRT4.dll\NdrAsyncClientCall", "ptr", pStubDescriptor, pFormatMarshal, pFormat, varArgs*)
         return result
     }
 
@@ -23937,14 +23945,18 @@ class Rpc {
      * NdrDcomAsyncClientCall may be altered or unavailable.
      * @param {Pointer<MIDL_STUB_DESC>} pStubDescriptor Reserved.
      * @param {Pointer<Integer>} pFormat Reserved.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {CLIENT_CALL_RETURN} Reserved.
      * @see https://learn.microsoft.com/windows/win32/api/rpcndr/nf-rpcndr-ndrdcomasyncclientcall
      * @since windows5.0
      */
-    static NdrDcomAsyncClientCall(pStubDescriptor, pFormat) {
+    static NdrDcomAsyncClientCall(pStubDescriptor, pFormat, args*) {
         pFormatMarshal := pFormat is VarRef ? "char*" : "ptr"
 
-        result := DllCall("RPCRT4.dll\NdrDcomAsyncClientCall", "ptr", pStubDescriptor, pFormatMarshal, pFormat, "CDecl ptr")
+        varArgs := [args*]
+        varArgs.Push("CDecl ptr")
+
+        result := DllCall("RPCRT4.dll\NdrDcomAsyncClientCall", "ptr", pStubDescriptor, pFormatMarshal, pFormat, varArgs*)
         return result
     }
 
@@ -25079,14 +25091,18 @@ class Rpc {
      * @param {Pointer<MIDL_STUBLESS_PROXY_INFO>} pProxyInfo Reserved.
      * @param {Integer} nProcNum Reserved.
      * @param {Pointer<Void>} pReturnValue Reserved.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {CLIENT_CALL_RETURN} Reserved.
      * @see https://learn.microsoft.com/windows/win32/api/rpcndr/nf-rpcndr-ndrclientcall3
      * @since windows5.0
      */
-    static NdrClientCall3(pProxyInfo, nProcNum, pReturnValue) {
+    static NdrClientCall3(pProxyInfo, nProcNum, pReturnValue, args*) {
         pReturnValueMarshal := pReturnValue is VarRef ? "ptr" : "ptr"
 
-        result := DllCall("RPCRT4.dll\NdrClientCall3", "ptr", pProxyInfo, "uint", nProcNum, pReturnValueMarshal, pReturnValue, "CDecl ptr")
+        varArgs := [args*]
+        varArgs.Push("CDecl ptr")
+
+        result := DllCall("RPCRT4.dll\NdrClientCall3", "ptr", pProxyInfo, "uint", nProcNum, pReturnValueMarshal, pReturnValue, varArgs*)
         return result
     }
 
@@ -25095,14 +25111,18 @@ class Rpc {
      * @param {Pointer<MIDL_STUBLESS_PROXY_INFO>} pProxyInfo Reserved.
      * @param {Integer} nProcNum Reserved.
      * @param {Pointer<Void>} pReturnValue Reserved.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {CLIENT_CALL_RETURN} Reserved.
      * @see https://learn.microsoft.com/windows/win32/api/rpcndr/nf-rpcndr-ndr64asyncclientcall
      * @since windows5.1.2600
      */
-    static Ndr64AsyncClientCall(pProxyInfo, nProcNum, pReturnValue) {
+    static Ndr64AsyncClientCall(pProxyInfo, nProcNum, pReturnValue, args*) {
         pReturnValueMarshal := pReturnValue is VarRef ? "ptr" : "ptr"
 
-        result := DllCall("RPCRT4.dll\Ndr64AsyncClientCall", "ptr", pProxyInfo, "uint", nProcNum, pReturnValueMarshal, pReturnValue, "CDecl ptr")
+        varArgs := [args*]
+        varArgs.Push("CDecl ptr")
+
+        result := DllCall("RPCRT4.dll\Ndr64AsyncClientCall", "ptr", pProxyInfo, "uint", nProcNum, pReturnValueMarshal, pReturnValue, varArgs*)
         return result
     }
 
@@ -25111,12 +25131,16 @@ class Rpc {
      * @param {Pointer<MIDL_STUBLESS_PROXY_INFO>} pProxyInfo 
      * @param {Integer} nProcNum 
      * @param {Pointer<Void>} pReturnValue 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {CLIENT_CALL_RETURN} 
      */
-    static Ndr64DcomAsyncClientCall(pProxyInfo, nProcNum, pReturnValue) {
+    static Ndr64DcomAsyncClientCall(pProxyInfo, nProcNum, pReturnValue, args*) {
         pReturnValueMarshal := pReturnValue is VarRef ? "ptr" : "ptr"
 
-        result := DllCall("RPCRT4.dll\Ndr64DcomAsyncClientCall", "ptr", pProxyInfo, "uint", nProcNum, pReturnValueMarshal, pReturnValue, "CDecl ptr")
+        varArgs := [args*]
+        varArgs.Push("CDecl ptr")
+
+        result := DllCall("RPCRT4.dll\Ndr64DcomAsyncClientCall", "ptr", pProxyInfo, "uint", nProcNum, pReturnValueMarshal, pReturnValue, varArgs*)
         return result
     }
 
@@ -26056,14 +26080,18 @@ class Rpc {
      * @param {Pointer<Void>} _Handle Reserved.
      * @param {Pointer<MIDL_STUB_DESC>} pStubDesc Reserved.
      * @param {Pointer<Integer>} pFormatString Reserved.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {String} Nothing - always returns an empty string
      * @see https://learn.microsoft.com/windows/win32/api/midles/nf-midles-ndrmesprocencodedecode2
      */
-    static NdrMesProcEncodeDecode(_Handle, pStubDesc, pFormatString) {
+    static NdrMesProcEncodeDecode(_Handle, pStubDesc, pFormatString, args*) {
         _HandleMarshal := _Handle is VarRef ? "ptr" : "ptr"
         pFormatStringMarshal := pFormatString is VarRef ? "char*" : "ptr"
 
-        DllCall("RPCRT4.dll\NdrMesProcEncodeDecode", _HandleMarshal, _Handle, "ptr", pStubDesc, pFormatStringMarshal, pFormatString, "CDecl ")
+        varArgs := [args*]
+        varArgs.Push("CDecl")
+
+        DllCall("RPCRT4.dll\NdrMesProcEncodeDecode", _HandleMarshal, _Handle, "ptr", pStubDesc, pFormatStringMarshal, pFormatString, varArgs*)
     }
 
     /**
@@ -26071,15 +26099,19 @@ class Rpc {
      * @param {Pointer<Void>} _Handle Reserved.
      * @param {Pointer<MIDL_STUB_DESC>} pStubDesc Reserved.
      * @param {Pointer<Integer>} pFormatString Reserved.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {CLIENT_CALL_RETURN} Reserved.
      * @see https://learn.microsoft.com/windows/win32/api/midles/nf-midles-ndrmesprocencodedecode2
      * @since windows5.0
      */
-    static NdrMesProcEncodeDecode2(_Handle, pStubDesc, pFormatString) {
+    static NdrMesProcEncodeDecode2(_Handle, pStubDesc, pFormatString, args*) {
         _HandleMarshal := _Handle is VarRef ? "ptr" : "ptr"
         pFormatStringMarshal := pFormatString is VarRef ? "char*" : "ptr"
 
-        result := DllCall("RPCRT4.dll\NdrMesProcEncodeDecode2", _HandleMarshal, _Handle, "ptr", pStubDesc, pFormatStringMarshal, pFormatString, "CDecl ptr")
+        varArgs := [args*]
+        varArgs.Push("CDecl ptr")
+
+        result := DllCall("RPCRT4.dll\NdrMesProcEncodeDecode2", _HandleMarshal, _Handle, "ptr", pStubDesc, pFormatStringMarshal, pFormatString, varArgs*)
         return result
     }
 
@@ -26162,13 +26194,17 @@ class Rpc {
      * @param {Pointer<MIDL_STUBLESS_PROXY_INFO>} pProxyInfo 
      * @param {Integer} nProcNum 
      * @param {Pointer<Void>} pReturnValue 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {CLIENT_CALL_RETURN} 
      */
-    static NdrMesProcEncodeDecode3(_Handle, pProxyInfo, nProcNum, pReturnValue) {
+    static NdrMesProcEncodeDecode3(_Handle, pProxyInfo, nProcNum, pReturnValue, args*) {
         _HandleMarshal := _Handle is VarRef ? "ptr" : "ptr"
         pReturnValueMarshal := pReturnValue is VarRef ? "ptr" : "ptr"
 
-        result := DllCall("RPCRT4.dll\NdrMesProcEncodeDecode3", _HandleMarshal, _Handle, "ptr", pProxyInfo, "uint", nProcNum, pReturnValueMarshal, pReturnValue, "CDecl ptr")
+        varArgs := [args*]
+        varArgs.Push("CDecl ptr")
+
+        result := DllCall("RPCRT4.dll\NdrMesProcEncodeDecode3", _HandleMarshal, _Handle, "ptr", pProxyInfo, "uint", nProcNum, pReturnValueMarshal, pReturnValue, varArgs*)
         return result
     }
 

--- a/Windows/Win32/UI/Shell/Apis.ahk
+++ b/Windows/Win32/UI/Shell/Apis.ahk
@@ -18814,6 +18814,7 @@ class Shell {
      * @param {MESSAGEBOX_STYLE} fuStyle Type: <b>UINT</b>
      * 
      * Specifies the contents and behavior of the dialog box. For possible values, see <a href="https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-messagebox">MessageBox</a>.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} Type: <b>int</b>
      * 
      * An integer value indicating a button that was pressed in the message box. For specific values, see <a href="https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-messagebox">MessageBox</a>.
@@ -18824,7 +18825,7 @@ class Shell {
      * @see https://learn.microsoft.com/windows/win32/api/shellapi/nf-shellapi-shellmessageboxa
      * @since windows5.1.2600
      */
-    static ShellMessageBoxA(hAppInst, _hWnd, lpcText, lpcTitle, fuStyle) {
+    static ShellMessageBoxA(hAppInst, _hWnd, lpcText, lpcTitle, fuStyle, args*) {
         hAppInst := hAppInst is Win32Handle ? NumGet(hAppInst, "ptr") : hAppInst
         _hWnd := _hWnd is Win32Handle ? NumGet(_hWnd, "ptr") : _hWnd
         lpcText := lpcText is String ? StrPtr(lpcText) : lpcText
@@ -18832,7 +18833,10 @@ class Shell {
 
         A_LastError := 0
 
-        result := DllCall("SHLWAPI.dll\ShellMessageBoxA", "ptr", hAppInst, "ptr", _hWnd, "ptr", lpcText, "ptr", lpcTitle, "uint", fuStyle, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("SHLWAPI.dll\ShellMessageBoxA", "ptr", hAppInst, "ptr", _hWnd, "ptr", lpcText, "ptr", lpcTitle, "uint", fuStyle, varArgs*)
         if(A_LastError) {
             throw OSError(A_LastError)
         }
@@ -18860,6 +18864,7 @@ class Shell {
      * @param {MESSAGEBOX_STYLE} fuStyle Type: <b>UINT</b>
      * 
      * Specifies the contents and behavior of the dialog box. For possible values, see <a href="https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-messagebox">MessageBox</a>.
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} Type: <b>int</b>
      * 
      * An integer value indicating a button that was pressed in the message box. For specific values, see <a href="https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-messagebox">MessageBox</a>.
@@ -18870,7 +18875,7 @@ class Shell {
      * @see https://learn.microsoft.com/windows/win32/api/shellapi/nf-shellapi-shellmessageboxw
      * @since windows5.1.2600
      */
-    static ShellMessageBoxW(hAppInst, _hWnd, lpcText, lpcTitle, fuStyle) {
+    static ShellMessageBoxW(hAppInst, _hWnd, lpcText, lpcTitle, fuStyle, args*) {
         hAppInst := hAppInst is Win32Handle ? NumGet(hAppInst, "ptr") : hAppInst
         _hWnd := _hWnd is Win32Handle ? NumGet(_hWnd, "ptr") : _hWnd
         lpcText := lpcText is String ? StrPtr(lpcText) : lpcText
@@ -18878,7 +18883,10 @@ class Shell {
 
         A_LastError := 0
 
-        result := DllCall("SHLWAPI.dll\ShellMessageBoxW", "ptr", hAppInst, "ptr", _hWnd, "ptr", lpcText, "ptr", lpcTitle, "uint", fuStyle, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("SHLWAPI.dll\ShellMessageBoxW", "ptr", hAppInst, "ptr", _hWnd, "ptr", lpcText, "ptr", lpcTitle, "uint", fuStyle, varArgs*)
         if(A_LastError) {
             throw OSError(A_LastError)
         }
@@ -21319,17 +21327,21 @@ class Shell {
      * @param {PSTR} pszFmt Type: <b>PCTSTR</b>
      * 
      * A <a href="https://docs.microsoft.com/windows/desktop/direct3dhlsl/printf">printf</a>-style format string. The %s format identifier should never be used in an unbounded form. To avoid potential buffer overruns, always specify a size; for instance "%32s".
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} Type: <b>int</b>
      * 
      * Returns the number of characters written to the buffer, excluding any terminating <b>NULL</b> characters. A negative value is returned if an error occurs.
      * @see https://learn.microsoft.com/windows/win32/api/shlwapi/nf-shlwapi-wnsprintfa
      * @since windows5.0
      */
-    static wnsprintfA(pszDest, cchDest, pszFmt) {
+    static wnsprintfA(pszDest, cchDest, pszFmt, args*) {
         pszDest := pszDest is String ? StrPtr(pszDest) : pszDest
         pszFmt := pszFmt is String ? StrPtr(pszFmt) : pszFmt
 
-        result := DllCall("SHLWAPI.dll\wnsprintfA", "ptr", pszDest, "int", cchDest, "ptr", pszFmt, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("SHLWAPI.dll\wnsprintfA", "ptr", pszDest, "int", cchDest, "ptr", pszFmt, varArgs*)
         return result
     }
 
@@ -21354,17 +21366,21 @@ class Shell {
      * @param {PWSTR} pszFmt Type: <b>PCTSTR</b>
      * 
      * A <a href="https://docs.microsoft.com/windows/desktop/direct3dhlsl/printf">printf</a>-style format string. The %s format identifier should never be used in an unbounded form. To avoid potential buffer overruns, always specify a size; for instance "%32s".
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} Type: <b>int</b>
      * 
      * Returns the number of characters written to the buffer, excluding any terminating <b>NULL</b> characters. A negative value is returned if an error occurs.
      * @see https://learn.microsoft.com/windows/win32/api/shlwapi/nf-shlwapi-wnsprintfw
      * @since windows5.0
      */
-    static wnsprintfW(pszDest, cchDest, pszFmt) {
+    static wnsprintfW(pszDest, cchDest, pszFmt, args*) {
         pszDest := pszDest is String ? StrPtr(pszDest) : pszDest
         pszFmt := pszFmt is String ? StrPtr(pszFmt) : pszFmt
 
-        result := DllCall("SHLWAPI.dll\wnsprintfW", "ptr", pszDest, "int", cchDest, "ptr", pszFmt, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("SHLWAPI.dll\wnsprintfW", "ptr", pszDest, "int", cchDest, "ptr", pszFmt, varArgs*)
         return result
     }
 

--- a/Windows/Win32/UI/WindowsAndMessaging/Apis.ahk
+++ b/Windows/Win32/UI/WindowsAndMessaging/Apis.ahk
@@ -7796,6 +7796,7 @@ class WindowsAndMessaging {
      * > The winuser.h header defines wsprintf as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
      * @param {PSTR} param0 
      * @param {PSTR} param1 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} Type: <b>int</b>
      * 
      * If the function succeeds, the return value is the number of characters stored in the output buffer, not counting the terminating null character.
@@ -7804,13 +7805,16 @@ class WindowsAndMessaging {
      * @see https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-wsprintfa
      * @since windows5.0
      */
-    static wsprintfA(param0, param1) {
+    static wsprintfA(param0, param1, args*) {
         param0 := param0 is String ? StrPtr(param0) : param0
         param1 := param1 is String ? StrPtr(param1) : param1
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\wsprintfA", "ptr", param0, "ptr", param1, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("USER32.dll\wsprintfA", "ptr", param0, "ptr", param1, varArgs*)
         if(A_LastError) {
             throw OSError(A_LastError)
         }
@@ -8001,6 +8005,7 @@ class WindowsAndMessaging {
      * > The winuser.h header defines wsprintf as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
      * @param {PWSTR} param0 
      * @param {PWSTR} param1 
+     * @param {Any} args* Additional arguments as alternating DllCall type/value pairs (e.g., "int", 42, "str", "hello")
      * @returns {Integer} Type: <b>int</b>
      * 
      * If the function succeeds, the return value is the number of characters stored in the output buffer, not counting the terminating null character.
@@ -8009,13 +8014,16 @@ class WindowsAndMessaging {
      * @see https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-wsprintfw
      * @since windows5.0
      */
-    static wsprintfW(param0, param1) {
+    static wsprintfW(param0, param1, args*) {
         param0 := param0 is String ? StrPtr(param0) : param0
         param1 := param1 is String ? StrPtr(param1) : param1
 
         A_LastError := 0
 
-        result := DllCall("USER32.dll\wsprintfW", "ptr", param0, "ptr", param1, "CDecl int")
+        varArgs := [args*]
+        varArgs.Push("CDecl int")
+
+        result := DllCall("USER32.dll\wsprintfW", "ptr", param0, "ptr", param1, varArgs*)
         if(A_LastError) {
             throw OSError(A_LastError)
         }


### PR DESCRIPTION
**Previously**, there was no specific support for variadic methods. The generator would generate them, but only include the known arguments, making them somewhat unhelpful.

Per the [metadata documentation](https://github.com/microsoft/win32metadata/blob/main/docs/projections.md):
> Variadic functions contain `__arglist` as the final parameter

**This was problematic because** variadic methods are a part of the APIs and were not covered

**Now**, variadic methods are fully supported.

The actual variadic arguments are, unfortunately, lists of DllCall type / value pairs. The metadata doesn't carry any type information for the variadic args and in many cases no such type information exists, as in the case of [`wsprintfW](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-wsprintfw) and most of the `AllJoyn` methods. So the variadic argument list is a `DllCall` style arg list again:

```autohotkey
nChars := WindowsAndMessaging.wsprintfW(buf, "%d World! %s", "int", 42, "ptr", StrPtr("hello"))
result := StrGet(buf, "UTF-16")

MsgBox(result) ; "Hello World! 42"
```

On the generator, see [`afad12878538e51b9994ab224b7103959e77aad7`](https://github.com/holy-tao/AhkWin32Structs-Generator/commit/afad12878538e51b9994ab224b7103959e77aad7) and [`c12c10188a8a224bd19ea4927b6360e49b635e52`](https://github.com/holy-tao/AhkWin32Structs-Generator/commit/c12c10188a8a224bd19ea4927b6360e49b635e52).

### Testing

Added smoke tests into `GeneratedApiSmoke.test.ahk`.

### Related Issues

Resolves #10 

---

#### Checklist

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] No breaking changes (or breaking changes documented)
