### PR TITLE
Fix array item enumeration

### DIFF
--- a/CStyleArray.ahk
+++ b/CStyleArray.ahk
@@ -167,41 +167,36 @@ class CStyleArrayList extends Win32Struct {
      *          in 2-variable mode, the first is the index
      * @see https://www.autohotkey.com/docs/v2/lib/Enumerator.htm
      */
-    __Enum(numberOfVars){
+    __Enum(numberOfVars := 1){
         if(numberOfVars != 1 && numberOfVars != 2)
             throw MethodError("Enumeration only supports 1 or 2 variables")
 
-        return numberOfVars == 1? _Enumerator1 : _Enumerator2
+        itemIndex := 0
+        Result := (numberOfVars == 1) ? _Enumerator1 : _Enumerator2
+        ObjSetBase(Result, Enumerator.Prototype)
+        return Result
         
         /**
          * 1-variable enumerator
          */
         _Enumerator1(&item){
-            static index := 1
-
-            if(index > this.length){
-                index := 1
-                return false
+            if (++itemIndex <= this.Length){
+                item := this[itemIndex]
+                return true
             }
-
-            item := this[index++]
-            return true
+            return false
         }
 
         /**
          * 2-variable enumerator.
          */
-        _Enumerator2(&index, &item){
-            static enumIndex := 1
-
-            if(enumIndex > this.length){
-                enumIndex := 1
-                return false
+        _Enumerator2(&outIndex, &item){
+            if (++itemIndex <= this.Length){
+                outIndex := itemIndex
+                item := this[itemIndex]
+                return true
             }
-            
-            index := enumIndex
-            item := this[enumIndex++]
-            return true
+            return false
         }
     }
 


### PR DESCRIPTION

**Previously**, each "instance" of the enumerator shared the same static variable to keep track of the array index.

The issue is that this only works if only one enumerator is ever used at once, **and** the entire array is being iterated through without `break`-ing, such that the index is reset back to `1`.

```autohotkey
Create() {
    Result := CStyleArrayList(Primitive, "int", 2)
    Result[1] := 1
    Result[2] := 2
    return Result.__Enum(1)
}

Enumer1 := Create()
Enumer2 := Create()

Enumer1(&Item1)
Enumer2(&Item2)
MsgBox(Item1) ; ==> 1 (Arr1[1])
MsgBox(Item2) ; ==> 2 (Arr2[2])
```

**Now**, multiple enumerators can be used safely at once. The trick is to capture a variable from the outside each time a new enumerator is made, instead of using a shared static variable.

```autohotkey
...
Enumer1(&Item1) ; ==> Arr1[1]
Enumer2(&Item2) ; ==> Arr2[1]
```

### Changes

#### Fixed Enumeration

- fixed tracking of array index for individual enumerator

#### Other

The next changes are minor details to improve consistency with built-in `Array` enumerator:

1. The argument passed to `.__Enum()` is *optional* and defaults to `1`.
2. No matter if there are elements left, the index advances.
3. Explicitly "upgrade" the return type of `.__Enum()` to `Enumerator`. This means `Type()` returns `"Enumerator"` instead of `"Func"`/`"Closure"`, and it also allows you to add methods to `Enumerator.Prototype` which the enumerator has access to.

Compared to regular array:

```autohotkey
; 1.
[].__Enum() ; o.k.

; 2.
Arr := []
Enumer := Arr.__Enum(1)
Enumer(&Value) ; (index 1, returns `false`, `Value` remains `unset`)
Arr.Push(1, 2)
Enumer(&Value) ; (index 2, returns `true`, `Value` becomes `2`)

; 3.
Type([].__Enum(1)) ; "Enumerator"
ObjGetBase([].__Enum(1)) ; Enumerator.Prototype
```

### Testing

A simple test:

```autohotkey
Create() {
    Result := CStyleArrayList(Primitive, "int", 2)
    Result[1] := 1
    Result[2] := 2
    return Result.__Enum(1)
}

Enumer1 := Create()
Enumer2 := Create()

Enumer1(&Item1)
Enumer2(&Item2)
MsgBox(Item1) ; ==> 1
MsgBox(Item2) ; ==> 1
```

### Related Issues

none
<!-- Link to any related issues, e.g., "Closes #123" or "Related to #456" -->

---

#### Checklist

- [ ] Reviewers assigned
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or breaking changes documented)
